### PR TITLE
add support for subscription requests

### DIFF
--- a/src/main/java/graphql/nadel/DefinitionRegistry.java
+++ b/src/main/java/graphql/nadel/DefinitionRegistry.java
@@ -56,6 +56,10 @@ public class DefinitionRegistry {
         return getOpsDefinitions(Operation.MUTATION);
     }
 
+    public List<ObjectTypeDefinition> getSubscriptionType() {
+        return getOpsDefinitions(Operation.SUBSCRIPTION);
+    }
+
     private List<ObjectTypeDefinition> getOpsDefinitions(Operation operation) {
         String type = getOperationTypeName(operation);
         return getDefinition(type, ObjectTypeDefinition.class);

--- a/src/main/java/graphql/nadel/Operation.java
+++ b/src/main/java/graphql/nadel/Operation.java
@@ -58,6 +58,8 @@ public enum Operation {
                 return assertNotNull(schema.getQueryType());
             case MUTATION:
                 return assertNotNull(schema.getMutationType());
+            case SUBSCRIPTION:
+                return assertNotNull(schema.getSubscriptionType());
             default:
                 return assertShouldNeverHappen();
         }

--- a/src/main/java/graphql/nadel/engine/Execution.java
+++ b/src/main/java/graphql/nadel/engine/Execution.java
@@ -164,6 +164,18 @@ public class Execution {
                     }
                 }
             }
+
+            List<ObjectTypeDefinition> subscriptionTypeDefinitions = service.getDefinitionRegistry().getSubscriptionType();
+            if (subscriptionTypeDefinitions != null) {
+                for (ObjectTypeDefinition subscriptionTypeDefinition : subscriptionTypeDefinitions) {
+                    GraphQLObjectType schemaSubscriptionType = overallSchema.getSubscriptionType();
+                    for (FieldDefinition fieldDefinition : subscriptionTypeDefinition.getFieldDefinitions()) {
+                        GraphQLFieldDefinition graphQLFieldDefinition = schemaSubscriptionType.getFieldDefinition(fieldDefinition.getName());
+                        FieldInfo fieldInfo = new FieldInfo(FieldInfo.FieldKind.TOPLEVEL, service, graphQLFieldDefinition);
+                        fieldInfoByDefinition.put(graphQLFieldDefinition, fieldInfo);
+                    }
+                }
+            }
         }
         return new FieldInfos(fieldInfoByDefinition);
     }


### PR DESCRIPTION
Adding some missing paths for subscription requests to work, adding the operation name, and the field definitions