### PR TITLE
GQLGW-717 Null Pointer Exception when query hydration field does not exist

### DIFF
--- a/src/main/java/graphql/nadel/engine/HydrationInputResolver.java
+++ b/src/main/java/graphql/nadel/engine/HydrationInputResolver.java
@@ -214,6 +214,7 @@ public class HydrationInputResolver {
         } else {
             topLevelFieldDefinition = ((GraphQLObjectType) service.getUnderlyingSchema().getQueryType().getFieldDefinition(syntheticFieldName).getType()).getFieldDefinition(topLevelFieldName);
         }
+        assertNotNull(topLevelFieldDefinition, () -> String.format("field '%s' definition not found", topLevelFieldName));
 
         return isList(unwrapNonNull(topLevelFieldDefinition.getType()));
     }

--- a/src/main/java/graphql/nadel/engine/HydrationInputResolver.java
+++ b/src/main/java/graphql/nadel/engine/HydrationInputResolver.java
@@ -214,7 +214,7 @@ public class HydrationInputResolver {
         } else {
             topLevelFieldDefinition = ((GraphQLObjectType) service.getUnderlyingSchema().getQueryType().getFieldDefinition(syntheticFieldName).getType()).getFieldDefinition(topLevelFieldName);
         }
-        assertNotNull(topLevelFieldDefinition, () -> String.format("field '%s' definition not found", topLevelFieldName));
+        assertNotNull(topLevelFieldDefinition, () -> String.format("hydration field '%s' does not exist in underlying schema in service '%s'", topLevelFieldName, service.getName()));
 
         return isList(unwrapNonNull(topLevelFieldDefinition.getType()));
     }

--- a/src/test/groovy/graphql/nadel/e2e/NadelE2ETest.groovy
+++ b/src/test/groovy/graphql/nadel/e2e/NadelE2ETest.groovy
@@ -300,7 +300,6 @@ class NadelE2ETest extends Specification {
 
         when:
         def result = nadel.execute(nadelExecutionInput).get()
-        println(result)
 
         then:
         def e = thrown(Exception)

--- a/src/test/groovy/graphql/nadel/e2e/NadelE2ETest.groovy
+++ b/src/test/groovy/graphql/nadel/e2e/NadelE2ETest.groovy
@@ -285,26 +285,26 @@ class NadelE2ETest extends Specification {
         ServiceExecutionResult topLevelResult = new ServiceExecutionResult(topLevelData)
         ServiceExecutionResult hydrationResult1_1 = new ServiceExecutionResult(hydrationDataBatch1)
         ServiceExecutionResult hydrationResult1_2 = new ServiceExecutionResult(hydrationDataBatch2)
-        when:
-        def result = nadel.execute(nadelExecutionInput)
 
-        then:
-        1 * serviceExecution1.execute(_) >>
+        serviceExecution1.execute(_) >>
 
                 completedFuture(topLevelResult)
 
-        1 * serviceExecution2.execute(_) >>
+        serviceExecution2.execute(_) >>
 
                 completedFuture(hydrationResult1_1)
 
-        1 * serviceExecution2.execute(_) >>
+        serviceExecution2.execute(_) >>
 
                 completedFuture(hydrationResult1_2)
 
-//        TODO syntax - how to intercept the error during e2e test
-        def e = thrown CompletionException
-        e.cause instanceof AssertException
-        e.cause.message == "field 'doesNotExist' definition not found"
+        when:
+        def result = nadel.execute(nadelExecutionInput).get()
+        println(result)
+
+        then:
+        def e = thrown(Exception)
+        e.cause.message == "hydration field 'doesNotExist' does not exist in underlying schema in service 'Bar'"
     }
 
     def "query with three nested hydrations"() {

--- a/src/test/groovy/graphql/nadel/e2e/NadelE2ETest.groovy
+++ b/src/test/groovy/graphql/nadel/e2e/NadelE2ETest.groovy
@@ -212,6 +212,98 @@ class NadelE2ETest extends Specification {
         er.extensions.containsKey("resultComplexity")
     }
 
+    def "test batch hydration null pointer when hydrated query field does not exist"() {
+
+        def nsdl = [
+                Foo: '''
+         service Foo {
+            type Query{
+                foos: [Foo]  
+            } 
+            type Foo {
+                name: String
+                bar: Bar => hydrated from Bar.doesNotExist(id: $source.barId) object identified by barId, batch size 2
+            }
+         }
+         ''',
+                Bar: '''
+         service Bar {
+            type Query{
+                bar: Bar 
+            } 
+            type Bar {
+                barId: ID
+                name: String 
+            }
+         }
+        ''']
+        def underlyingSchema1 = typeDefinitions('''
+            type Query{
+                foos: [Foo]  
+            } 
+            type Foo {
+                name: String
+                barId: ID
+            }
+        ''')
+        def underlyingSchema2 = typeDefinitions('''
+            type Query{
+                bar: Bar 
+                barsById(id: [ID]): [Bar]
+            } 
+            type Bar {
+                barId: ID
+                name: String
+                nestedBarId: ID
+            }
+        ''')
+
+        def query = '''
+                { foos { bar { name } } }
+        '''
+        ServiceExecution serviceExecution1 = Mock(ServiceExecution)
+        ServiceExecution serviceExecution2 = Mock(ServiceExecution)
+
+        ServiceExecutionFactory serviceFactory = TestUtil.serviceFactory([
+                Foo: new Tuple2(serviceExecution1, underlyingSchema1),
+                Bar: new Tuple2(serviceExecution2, underlyingSchema2)]
+        )
+        given:
+        Nadel nadel = newNadel()
+                .dsl(nsdl)
+                .serviceExecutionFactory(serviceFactory)
+                .build()
+
+        NadelExecutionInput nadelExecutionInput = newNadelExecutionInput()
+                .query(query)
+                .artificialFieldsUUID("UUID")
+                .build()
+
+        def topLevelData = [foos: [[barId: "bar1"], [barId: "bar2"], [barId: "bar3"]]]
+        def hydrationDataBatch1 = [barsById: [[object_identifier__UUID: "bar1", name: "Bar 1"], [object_identifier__UUID: "bar2", name: "Bar 2"]]]
+        def hydrationDataBatch2 = [barsById: [[object_identifier__UUID: "bar3", name: "Bar 3"]]]
+        ServiceExecutionResult topLevelResult = new ServiceExecutionResult(topLevelData)
+        ServiceExecutionResult hydrationResult1_1 = new ServiceExecutionResult(hydrationDataBatch1)
+        ServiceExecutionResult hydrationResult1_2 = new ServiceExecutionResult(hydrationDataBatch2)
+        when:
+        def result = nadel.execute(nadelExecutionInput)
+
+        then:
+        1 * serviceExecution1.execute(_) >>
+
+                completedFuture(topLevelResult)
+
+        1 * serviceExecution2.execute(_) >>
+
+                completedFuture(hydrationResult1_1)
+
+        1 * serviceExecution2.execute(_) >>
+
+                completedFuture(hydrationResult1_2)
+
+        result.errors[0].message == "hydration field does not exist. Please check the hydration field in the .nadel schema"
+    }
+
     def "query with three nested hydrations"() {
 
         def nsdl = [

--- a/src/test/groovy/graphql/nadel/e2e/NadelE2ETest.groovy
+++ b/src/test/groovy/graphql/nadel/e2e/NadelE2ETest.groovy
@@ -301,7 +301,10 @@ class NadelE2ETest extends Specification {
 
                 completedFuture(hydrationResult1_2)
 
-        result.errors[0].message == "hydration field does not exist. Please check the hydration field in the .nadel schema"
+//        TODO syntax - how to intercept the error during e2e test
+        def e = thrown CompletionException
+        e.cause instanceof AssertException
+        e.cause.message == "field 'doesNotExist' definition not found"
     }
 
     def "query with three nested hydrations"() {


### PR DESCRIPTION
This null pointer exception is caused by a bad Nadel schema - specifically, when the query field to be hydrated does not exist.

### How to reproduce:

Bad `.nadel` schema
```
service Foo {
  type Query{
    foos: [Foo]  
  } 
     
  type Foo {
    name: String
    bar: Bar => hydrated from Bar.doesNotExist(id: $source.barId) object identified by barId, batch size 2
  }
}
```
#### Steps
* `Bar.doesNotExist` is not a field on type `Bar`
* `isBatchHydrationField()` executes
* `isBatchHydrationField()` attempts to find the `topLevelFieldDefinition` of `doesNotExist`. This is `null`, because the field does not exist
* The last line of `isBatchHydrationField()` returns a function with parameter `topLevelFieldDefinition.getType()`, which evaluates to `null.getType()`. This is the cause of the null pointer exception