### PR TITLE
fix artifactoryPublish task: use correct publication name

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -227,7 +227,7 @@ artifactory {
             password = System.env.ARTIFACTORY_API_KEY
         }
         defaults {
-            publications('maven')
+            publications('graphqlJava')
             publishIvy = false
             // This needs to be "false", otherwise, the artifactory plugin will try to publish
             // a build info file to Artifactory and fail because we don't have the permissions to do that.


### PR DESCRIPTION
we are using `./gradlew artifactoryPublish` to publish https://github.com/atlassian-labs/nadel/blob/master/.github/workflows/master.yml#L23
we had a wrong name for the publication so the publish wasn't happening. Fixing the name.

Before:
`./gradlew artifactoryPublish`

```
> Configure project :
created development version: 2021-04-06T10-42-41-58d189b

> Task :artifactoryPublish
> Task :extractModuleInfo UP-TO-DATE
> Task :artifactoryDeploy

Deprecated Gradle features were used in this build, making it incompatible with Gradle 7.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/6.8.3/userguide/command_line_interface.html#sec:command_line_warnings

BUILD SUCCESSFUL in 369ms
```

After
`./gradlew artifactoryPublish`


```
created development version: 2021-04-06T10-43-34-8f305d3

> Task :extractGraphqlGrammar UP-TO-DATE
> Task :generateAntrlToJavaSource
> Task :generateGrammarSource UP-TO-DATE
> Task :compileJava UP-TO-DATE
> Task :compileGroovy NO-SOURCE
> Task :processResources NO-SOURCE
> Task :classes UP-TO-DATE
> Task :jar
> Task :generateMetadataFileForGraphqlJavaPublication
> Task :generatePomFileForGraphqlJavaPublication
> Task :javadoc
> Task :javadocJar
> Task :sourcesJar
> Task :signGraphqlJavaPublication FAILED

Deprecated Gradle features were used in this build, making it incompatible with Gradle 7.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/6.8.3/userguide/command_line_interface.html#sec:command_line_warnings
11 actionable tasks: 8 executed, 3 up-to-date

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':signGraphqlJavaPublication'.
> Could not read PGP secret key
```