### PR TITLE
Added the ability to edit the subselection of a merged field

### DIFF
--- a/api/src/main/java/graphql/nadel/util/MergedFieldUtil.java
+++ b/api/src/main/java/graphql/nadel/util/MergedFieldUtil.java
@@ -1,0 +1,83 @@
+package graphql.nadel.util;
+
+import graphql.Assert;
+import graphql.execution.ExecutionContext;
+import graphql.execution.ExecutionStepInfo;
+import graphql.execution.FieldCollector;
+import graphql.execution.FieldCollectorParameters;
+import graphql.execution.MergedField;
+import graphql.execution.MergedSelectionSet;
+import graphql.execution.ResultPath;
+import graphql.execution.nextgen.FieldSubSelection;
+import graphql.language.Field;
+import graphql.language.SelectionSet;
+import graphql.schema.GraphQLObjectType;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Predicate;
+
+import static graphql.execution.ExecutionStepInfo.newExecutionStepInfo;
+import static java.util.stream.Collectors.toList;
+
+public class MergedFieldUtil {
+
+    /**
+     * This helper method will take a parent merged field and edit its (merged) sub selection so that only child merged fields
+     * that meet the predicate will be included into that field
+     *
+     * @param parentField         the parent field to edit
+     * @param parentFieldTypeName the name of the object type of the parent field
+     * @param executionContext    the execution context (which may include fragments etc...)
+     * @param fieldPredicate      the predicate to decide if a field should be included
+     *
+     * @return a new MergedField with the edited child sub selection
+     */
+    public static MergedField includeSubSelection(MergedField parentField, String parentFieldTypeName, ExecutionContext executionContext, Predicate<MergedField> fieldPredicate) {
+
+        FieldSubSelection fieldSubSelection = getFieldSubSelection(parentField, parentFieldTypeName, executionContext);
+        MergedSelectionSet mergedSelectionSet = fieldSubSelection.getMergedSelectionSet();
+        List<MergedField> childFields = new ArrayList<>(mergedSelectionSet.getSubFieldsList());
+        childFields.removeIf(childMergedField -> !fieldPredicate.test(childMergedField));
+
+        List<Field> newFields = childFields.stream().map(MergedField::getSingleField).collect(toList());
+
+        Assert.assertFalse(newFields.isEmpty(), () -> "You have not included any child sub selections which is invalid");
+
+        SelectionSet selectionSet = SelectionSet.newSelectionSet(newFields).build();
+        Field newParentField = parentField.getSingleField().transform(bld -> bld.selectionSet(selectionSet));
+        return MergedField.newMergedField().addField(newParentField).build();
+    }
+
+    /**
+     * This will build out the field sub selection (of merged fields) for a given parent merged fields.
+     *
+     * @param parentField         the parent field
+     * @param parentFieldTypeName the name of the object type of the parent field
+     * @param executionContext    the execution context (which may include fragments etc...)
+     *
+     * @return a field sub selection where the sub selection is in fact merged fields one level deep
+     */
+    public static FieldSubSelection getFieldSubSelection(MergedField parentField, String parentFieldTypeName, ExecutionContext executionContext) {
+        FieldCollector fieldCollector = new FieldCollector();
+        GraphQLObjectType parentFieldObjectType = executionContext.getGraphQLSchema().getObjectType(parentFieldTypeName);
+
+        FieldCollectorParameters collectorParameters = FieldCollectorParameters.newParameters()
+                .schema(executionContext.getGraphQLSchema())
+                .objectType(parentFieldObjectType)
+                .fragments(executionContext.getFragmentsByName())
+                .variables(executionContext.getVariables())
+                .build();
+
+        MergedSelectionSet mergedSelectionSet = fieldCollector.collectFields(collectorParameters, parentField.getSingleField().getSelectionSet());
+        ExecutionStepInfo executionInfo = newExecutionStepInfo().type(parentFieldObjectType).path(ResultPath.rootPath()).build();
+
+        return FieldSubSelection.newFieldSubSelection()
+                .source(executionContext.getRoot())
+                .localContext(executionContext.getLocalContext())
+                .mergedSelectionSet(mergedSelectionSet)
+                .executionInfo(executionInfo)
+                .build();
+
+    }
+}

--- a/api/src/test/groovy/graphql/nadel/util/MergedFieldUtilTest.groovy
+++ b/api/src/test/groovy/graphql/nadel/util/MergedFieldUtilTest.groovy
@@ -1,0 +1,130 @@
+package graphql.nadel.util
+
+import graphql.AssertException
+import graphql.execution.ExecutionContext
+import graphql.execution.ExecutionContextBuilder
+import graphql.execution.ExecutionId
+import graphql.execution.MergedField
+import graphql.language.AstPrinter
+import graphql.language.Field
+import graphql.language.FragmentDefinition
+import graphql.language.NodeUtil
+import graphql.language.OperationDefinition
+import graphql.nadel.testutils.TestUtil
+import spock.lang.Specification
+
+import java.util.function.Predicate
+
+class MergedFieldUtilTest extends Specification {
+
+    def sdl = '''
+        type Query {
+            jira : JiraQuery
+        }
+        
+        type JiraQuery {
+            someIssues : [IssueDetails]
+            allIssues : [IssueDetails]
+            projects : [ProjectDetails]
+        }
+        
+        type IssueDetails {
+            id : ID
+            key : String
+        }
+        
+        type ProjectDetails {
+            name : String
+        }
+    '''
+
+    def schema = TestUtil.schema(sdl)
+
+
+    class TestFieldAndContext {
+        MergedField mergedField
+        ExecutionContext executionContext
+
+        TestFieldAndContext(String query, Map<String, Object> variables) {
+            def document = TestUtil.parseQuery(query)
+            NodeUtil.GetOperationResult getOperationResult = NodeUtil.getOperation(document, null)
+            Map<String, FragmentDefinition> fragmentsByName = getOperationResult.fragmentsByName
+            OperationDefinition operationDefinition = getOperationResult.operationDefinition
+
+            def topField = operationDefinition.getSelectionSet().getSelectionsOfType(Field.class)[0] as Field
+            this.mergedField = MergedField.newMergedField(topField).build()
+            this.executionContext = ExecutionContextBuilder.newExecutionContextBuilder()
+                    .graphQLSchema(schema)
+                    .fragmentsByName(fragmentsByName)
+                    .variables(variables).executionId(ExecutionId.from("id"))
+                    .build()
+
+        }
+    }
+
+    def complicatedQuery = '''
+            query {
+                jira {
+                    ... JiraQueryFrag
+                    ... on JiraQuery {
+                        allIssues { key }
+                    }
+                    specific: someIssues { id, key }
+                    projects { name }
+                    aliasedProject : projects { name }
+                }
+            }
+            
+            fragment IssueDetailsFrag on IssueDetails {
+                id
+                key
+            }
+
+            fragment JiraQueryFrag on JiraQuery {
+                someIssues {
+                    ... IssueDetailsFrag
+                }
+            }
+                
+        '''
+
+
+    def "'can edit to include only certain fields'"() {
+
+        def testFieldAndContext = new TestFieldAndContext(complicatedQuery, [:])
+        Predicate<MergedField> onlyIssueFields = { fld -> fld.name.toLowerCase().contains("issue") }
+
+        when:
+        def actualMergedField = MergedFieldUtil.includeSubSelection(
+                testFieldAndContext.mergedField, "JiraQuery", testFieldAndContext.executionContext, onlyIssueFields)
+
+        then:
+        actualMergedField.getFields().size() == 1
+        def actualField = actualMergedField.getSingleField()
+
+        actualField.getName() == "jira"
+        actualField.getSelectionSet().getSelections().size() == 3
+
+        def subSelectedFields = actualField.getSelectionSet().getSelectionsOfType(Field.class)
+        subSelectedFields.size() == 3
+
+        subSelectedFields.collect { (it.alias == null ? "" : it.alias + ":") + it.name } ==
+                ["someIssues", "allIssues", "specific:someIssues"]
+
+        def printedAst = AstPrinter.printAstCompact(actualField)
+        printedAst == 'jira {someIssues {...IssueDetailsFrag} allIssues {key} specific:someIssues {id key}}'
+    }
+
+    def "cant edit away all fields"() {
+        def testFieldAndContext = new TestFieldAndContext(complicatedQuery, [:])
+        Predicate<MergedField> noFieldsAlways = { fld -> false }
+
+        when:
+        MergedFieldUtil.includeSubSelection(
+                testFieldAndContext.mergedField, "JiraQuery", testFieldAndContext.executionContext, noFieldsAlways)
+
+        then:
+        thrown(AssertException.class)
+
+    }
+}


### PR DESCRIPTION
This uses Field Collector to create "merged" fields of a give parent merged field.  It then edits the parent and creates a new parent field that has only fields that match the predicate