### PR TITLE
Dynamic Service Resolution

### DIFF
--- a/api/src/main/java/graphql/nadel/hooks/ServiceExecutionHooks.java
+++ b/api/src/main/java/graphql/nadel/hooks/ServiceExecutionHooks.java
@@ -55,9 +55,9 @@ public interface ServiceExecutionHooks {
      * @param services a list of all services registered on Nadel
      * @param fieldName the name of the field
      * @param arguments GraphQL arguments that were passed when querying the field
-     * @return the Service that should be used to fetch data for that field
+     * @return the Service that should be used to fetch data for that field or an error that was raised when trying to resolve the service.
      */
-    default Service resolveServiceForField(List<Service> services, String fieldName, Map<String, Object> arguments) {
+    default ServiceOrError resolveServiceForField(List<Service> services, String fieldName, Map<String, Object> arguments) {
         return null;
     }
 }

--- a/api/src/main/java/graphql/nadel/hooks/ServiceExecutionHooks.java
+++ b/api/src/main/java/graphql/nadel/hooks/ServiceExecutionHooks.java
@@ -2,8 +2,10 @@ package graphql.nadel.hooks;
 
 import graphql.GraphQLError;
 import graphql.PublicSpi;
+import graphql.nadel.Service;
 import graphql.nadel.normalized.NormalizedQueryField;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -45,5 +47,17 @@ public interface ServiceExecutionHooks {
             Object userSuppliedContext
     ) {
         return CompletableFuture.completedFuture(Optional.empty());
+    }
+
+    /***
+     * Called to resolve the service that should be used to fetch data for a field that uses dynamic service resolution.
+     *
+     * @param services a list of all services registered on Nadel
+     * @param fieldName the name of the field
+     * @param arguments GraphQL arguments that were passed when querying the field
+     * @return the Service that should be used to fetch data for that field
+     */
+    default Service getServiceForDynamicField(List<Service> services, String fieldName, Map<String, Object> arguments) {
+        return null;
     }
 }

--- a/api/src/main/java/graphql/nadel/hooks/ServiceExecutionHooks.java
+++ b/api/src/main/java/graphql/nadel/hooks/ServiceExecutionHooks.java
@@ -57,7 +57,7 @@ public interface ServiceExecutionHooks {
      * @param arguments GraphQL arguments that were passed when querying the field
      * @return the Service that should be used to fetch data for that field
      */
-    default Service getServiceForDynamicField(List<Service> services, String fieldName, Map<String, Object> arguments) {
+    default Service resolveServiceForField(List<Service> services, String fieldName, Map<String, Object> arguments) {
         return null;
     }
 }

--- a/api/src/main/java/graphql/nadel/hooks/ServiceOrError.java
+++ b/api/src/main/java/graphql/nadel/hooks/ServiceOrError.java
@@ -1,0 +1,26 @@
+package graphql.nadel.hooks;
+
+import graphql.GraphQLError;
+import graphql.nadel.Service;
+
+/**
+ * Represents either a {@link Service} or an error that was generated when trying to resolve the service.
+ */
+public class ServiceOrError {
+    private final Service service;
+    private final GraphQLError error;
+
+
+    public ServiceOrError(Service service, GraphQLError error) {
+        this.service = service;
+        this.error = error;
+    }
+
+    public Service getService() {
+        return service;
+    }
+
+    public GraphQLError getError() {
+        return error;
+    }
+}

--- a/api/src/main/java/graphql/nadel/schema/NadelDirectives.java
+++ b/api/src/main/java/graphql/nadel/schema/NadelDirectives.java
@@ -51,8 +51,15 @@ public class NadelDirectives {
     static final DirectiveDefinition RENAMED_DIRECTIVE_DEFINITION;
     static final DirectiveDefinition HYDRATED_DIRECTIVE_DEFINITION;
     static final InputObjectTypeDefinition NADEL_HYDRATION_ARGUMENT_DEFINITION;
+    static final DirectiveDefinition DYNAMIC_SERVICE_DIRECTIVE_DEFINITION;
 
     static {
+        DYNAMIC_SERVICE_DIRECTIVE_DEFINITION = DirectiveDefinition.newDirectiveDefinition()
+                .name("dynamicService")
+                .directiveLocation(newDirectiveLocation().name(FIELD_DEFINITION.name()).build())
+                .description(createDescription("Indicates that the field uses dynamic service resolution. This directive should only be used in commons fields, i.e. fields that are not part of a particular service."))
+                .build();
+
         RENAMED_DIRECTIVE_DEFINITION = DirectiveDefinition.newDirectiveDefinition()
                 .name("renamed")
                 .directiveLocation(newDirectiveLocation().name(FIELD_DEFINITION.name()).build())

--- a/api/src/main/java/graphql/nadel/schema/NadelDirectives.java
+++ b/api/src/main/java/graphql/nadel/schema/NadelDirectives.java
@@ -48,14 +48,14 @@ import static java.util.Collections.emptyMap;
 
 public class NadelDirectives {
 
-    static final DirectiveDefinition RENAMED_DIRECTIVE_DEFINITION;
-    static final DirectiveDefinition HYDRATED_DIRECTIVE_DEFINITION;
-    static final InputObjectTypeDefinition NADEL_HYDRATION_ARGUMENT_DEFINITION;
-    static final DirectiveDefinition DYNAMIC_SERVICE_DIRECTIVE_DEFINITION;
+    public static final DirectiveDefinition RENAMED_DIRECTIVE_DEFINITION;
+    public static final DirectiveDefinition HYDRATED_DIRECTIVE_DEFINITION;
+    public static final InputObjectTypeDefinition NADEL_HYDRATION_ARGUMENT_DEFINITION;
+    public static final DirectiveDefinition DYNAMIC_SERVICE_DIRECTIVE_DEFINITION;
 
     static {
         DYNAMIC_SERVICE_DIRECTIVE_DEFINITION = DirectiveDefinition.newDirectiveDefinition()
-                .name("dynamicService")
+                .name("dynamicServiceResolution")
                 .directiveLocation(newDirectiveLocation().name(FIELD_DEFINITION.name()).build())
                 .description(createDescription("Indicates that the field uses dynamic service resolution. This directive should only be used in commons fields, i.e. fields that are not part of a particular service."))
                 .build();

--- a/engine/src/main/java/graphql/nadel/engine/FieldInfo.java
+++ b/engine/src/main/java/graphql/nadel/engine/FieldInfo.java
@@ -8,6 +8,9 @@ import graphql.schema.GraphQLFieldDefinition;
 public class FieldInfo {
 
     public enum FieldKind {
+        /**
+         * A top level field is declared directly under the GraphQL operation types: query, mutation and subscription
+         */
         TOPLEVEL
     }
 

--- a/engine/src/main/java/graphql/nadel/engine/execution/Execution.java
+++ b/engine/src/main/java/graphql/nadel/engine/execution/Execution.java
@@ -31,7 +31,6 @@ import graphql.nadel.instrumentation.parameters.NadelInstrumentationExecuteOpera
 import graphql.nadel.introspection.IntrospectionRunner;
 import graphql.nadel.normalized.NormalizedQueryFactory;
 import graphql.nadel.normalized.NormalizedQueryFromAst;
-import graphql.nadel.schema.NadelDirectives;
 import graphql.schema.GraphQLFieldDefinition;
 import graphql.schema.GraphQLObjectType;
 import graphql.schema.GraphQLSchema;
@@ -164,16 +163,10 @@ public class Execution {
     private FieldInfos createFieldsInfos() {
         Map<GraphQLFieldDefinition, FieldInfo> fieldInfoByDefinition = new LinkedHashMap<>();
 
-        GraphQLObjectType schemaQueryType = overallSchema.getQueryType();
-
-        schemaQueryType.getFieldDefinitions()
-                .stream()
-                .filter(fieldDefinition -> fieldDefinition.getDirective(NadelDirectives.DYNAMIC_SERVICE_DIRECTIVE_DEFINITION.getName()) != null)
-                .forEach(fieldDefinition -> fieldInfoByDefinition.put(fieldDefinition, new FieldInfo(FieldInfo.FieldKind.TOPLEVEL, null, fieldDefinition)));
-
         for (Service service : services) {
             List<ObjectTypeDefinition> queryType = service.getDefinitionRegistry().getQueryType();
             if (queryType != null) {
+                GraphQLObjectType schemaQueryType = overallSchema.getQueryType();
                 for (ObjectTypeDefinition objectTypeDefinition : queryType) {
                     for (FieldDefinition fieldDefinition : objectTypeDefinition.getFieldDefinitions()) {
                         GraphQLFieldDefinition graphQLFieldDefinition = schemaQueryType.getFieldDefinition(fieldDefinition.getName());

--- a/engine/src/main/java/graphql/nadel/engine/execution/Execution.java
+++ b/engine/src/main/java/graphql/nadel/engine/execution/Execution.java
@@ -163,10 +163,17 @@ public class Execution {
     private FieldInfos createFieldsInfos() {
         Map<GraphQLFieldDefinition, FieldInfo> fieldInfoByDefinition = new LinkedHashMap<>();
 
+        GraphQLObjectType schemaQueryType = overallSchema.getQueryType();
+
+        schemaQueryType.getFieldDefinitions()
+                .stream()
+                // TODO: Move "dynamicService" to a constant somewhere
+                .filter(fieldDefinition -> fieldDefinition.getDirective("dynamicService") != null)
+                .forEach(fieldDefinition -> fieldInfoByDefinition.put(fieldDefinition, new FieldInfo(FieldInfo.FieldKind.TOPLEVEL, null, fieldDefinition)));
+
         for (Service service : services) {
             List<ObjectTypeDefinition> queryType = service.getDefinitionRegistry().getQueryType();
             if (queryType != null) {
-                GraphQLObjectType schemaQueryType = overallSchema.getQueryType();
                 for (ObjectTypeDefinition objectTypeDefinition : queryType) {
                     for (FieldDefinition fieldDefinition : objectTypeDefinition.getFieldDefinitions()) {
                         GraphQLFieldDefinition graphQLFieldDefinition = schemaQueryType.getFieldDefinition(fieldDefinition.getName());

--- a/engine/src/main/java/graphql/nadel/engine/execution/Execution.java
+++ b/engine/src/main/java/graphql/nadel/engine/execution/Execution.java
@@ -31,6 +31,7 @@ import graphql.nadel.instrumentation.parameters.NadelInstrumentationExecuteOpera
 import graphql.nadel.introspection.IntrospectionRunner;
 import graphql.nadel.normalized.NormalizedQueryFactory;
 import graphql.nadel.normalized.NormalizedQueryFromAst;
+import graphql.nadel.schema.NadelDirectives;
 import graphql.schema.GraphQLFieldDefinition;
 import graphql.schema.GraphQLObjectType;
 import graphql.schema.GraphQLSchema;
@@ -167,8 +168,7 @@ public class Execution {
 
         schemaQueryType.getFieldDefinitions()
                 .stream()
-                // TODO: Move "dynamicService" to a constant somewhere
-                .filter(fieldDefinition -> fieldDefinition.getDirective("dynamicService") != null)
+                .filter(fieldDefinition -> fieldDefinition.getDirective(NadelDirectives.DYNAMIC_SERVICE_DIRECTIVE_DEFINITION.getName()) != null)
                 .forEach(fieldDefinition -> fieldInfoByDefinition.put(fieldDefinition, new FieldInfo(FieldInfo.FieldKind.TOPLEVEL, null, fieldDefinition)));
 
         for (Service service : services) {

--- a/engine/src/main/java/graphql/nadel/engine/execution/NadelExecutionStrategy.java
+++ b/engine/src/main/java/graphql/nadel/engine/execution/NadelExecutionStrategy.java
@@ -25,6 +25,7 @@ import graphql.nadel.engine.result.ResultComplexityAggregator;
 import graphql.nadel.engine.result.RootExecutionResultNode;
 import graphql.nadel.hooks.CreateServiceContextParams;
 import graphql.nadel.hooks.ServiceExecutionHooks;
+import graphql.nadel.hooks.ServiceOrError;
 import graphql.nadel.instrumentation.NadelInstrumentation;
 import graphql.nadel.normalized.NormalizedQueryField;
 import graphql.nadel.normalized.NormalizedQueryFromAst;
@@ -132,7 +133,15 @@ public class NadelExecutionStrategy {
             final Service service;
 
             if(usesDynamicService) {
-                service = serviceExecutionHooks.resolveServiceForField(services, fieldExecutionStepInfo.getField().getName(), fieldExecutionStepInfo.getArguments());
+                ServiceOrError serviceOrError = serviceExecutionHooks.resolveServiceForField(services, fieldExecutionStepInfo.getField().getName(), fieldExecutionStepInfo.getArguments());
+
+                if(serviceOrError != null && serviceOrError.getService() != null) {
+                    service = serviceOrError.getService();
+                } else {
+                    // TODO: Deal with the case when the service couldn't be resolved
+                    service = null;
+                }
+
             } else {
                 service = getServiceForFieldDefinition(fieldExecutionStepInfo.getFieldDefinition());
             }

--- a/engine/src/main/java/graphql/nadel/engine/execution/NadelExecutionStrategy.java
+++ b/engine/src/main/java/graphql/nadel/engine/execution/NadelExecutionStrategy.java
@@ -28,6 +28,7 @@ import graphql.nadel.hooks.ServiceExecutionHooks;
 import graphql.nadel.instrumentation.NadelInstrumentation;
 import graphql.nadel.normalized.NormalizedQueryField;
 import graphql.nadel.normalized.NormalizedQueryFromAst;
+import graphql.nadel.schema.NadelDirectives;
 import graphql.schema.GraphQLFieldDefinition;
 import graphql.schema.GraphQLSchema;
 import org.slf4j.Logger;
@@ -126,13 +127,12 @@ public class NadelExecutionStrategy {
 
             boolean usesDynamicService = fieldExecutionStepInfo.getFieldDefinition().getDirectives()
                     .stream()
-                    //TODO: Move "dynamicService" to constant somewhere
-                    .anyMatch(directive -> directive.getName().equals("dynamicService"));
+                    .anyMatch(directive -> directive.getName().equals(NadelDirectives.DYNAMIC_SERVICE_DIRECTIVE_DEFINITION.getName()));
 
             final Service service;
 
             if(usesDynamicService) {
-                service = serviceExecutionHooks.getServiceForDynamicField(services, fieldExecutionStepInfo.getField().getName(), fieldExecutionStepInfo.getArguments());
+                service = serviceExecutionHooks.resolveServiceForField(services, fieldExecutionStepInfo.getField().getName(), fieldExecutionStepInfo.getArguments());
             } else {
                 service = getServiceForFieldDefinition(fieldExecutionStepInfo.getFieldDefinition());
             }

--- a/engine/src/test/groovy/graphql/nadel/e2e/NadelE2ETest.groovy
+++ b/engine/src/test/groovy/graphql/nadel/e2e/NadelE2ETest.groovy
@@ -1438,10 +1438,10 @@ class NadelE2ETest extends StrategyTestHelper {
 
     def 'Dynamic Service Resolution: simple case'() {
         def commonTypes = '''
-            directive @dynamicService on FIELD_DEFINITION
+            directive @dynamicServiceResolution on FIELD_DEFINITION
             
             type Query {
-                node(id: ID!): Node @dynamicService
+                node(id: ID!): Node @dynamicServiceResolution
             } 
             
             interface Node {
@@ -1490,7 +1490,7 @@ class NadelE2ETest extends StrategyTestHelper {
 
         def serviceHooks = new ServiceExecutionHooks() {
             @Override
-            Service getServiceForDynamicField(List<Service> services, String fieldName, Map<String, Object> arguments) {
+            Service resolveServiceForField(List<Service> services, String fieldName, Map<String, Object> arguments) {
                 def bitbucketService = services.stream().filter({ service -> (service.getName() == "BitbucketService") }).findFirst().get()
                 def ariArgument = arguments.get("id")
 
@@ -1524,10 +1524,10 @@ class NadelE2ETest extends StrategyTestHelper {
 
     def 'Dynamic Service Resolution: multiple services'() {
         def commonTypes = '''
-            directive @dynamicService on FIELD_DEFINITION
+            directive @dynamicServiceResolution on FIELD_DEFINITION
             
             type Query {
-                node(id: ID!): Node @dynamicService
+                node(id: ID!): Node @dynamicServiceResolution
             } 
             
             interface Node {
@@ -1616,7 +1616,7 @@ class NadelE2ETest extends StrategyTestHelper {
 
         def serviceHooks = new ServiceExecutionHooks() {
             @Override
-            Service getServiceForDynamicField(List<Service> services, String fieldName, Map<String, Object> arguments) {
+            Service resolveServiceForField(List<Service> services, String fieldName, Map<String, Object> arguments) {
                 def bitbucketService = services.stream().filter({ service -> (service.getName() == "BitbucketService") }).findFirst().get()
                 def jiraService = services.stream().filter({ service -> (service.getName() == "JiraService") }).findFirst().get()
                 def ariArgument = arguments.get("id")

--- a/engine/src/test/groovy/graphql/nadel/e2e/NadelE2ETest.groovy
+++ b/engine/src/test/groovy/graphql/nadel/e2e/NadelE2ETest.groovy
@@ -26,6 +26,7 @@ import graphql.nadel.engine.result.ResultNodesUtil
 import graphql.nadel.engine.result.RootExecutionResultNode
 import graphql.nadel.engine.testutils.TestUtil
 import graphql.nadel.hooks.ServiceExecutionHooks
+import graphql.nadel.hooks.ServiceOrError
 import graphql.nadel.instrumentation.ChainedNadelInstrumentation
 import graphql.nadel.instrumentation.NadelInstrumentation
 import graphql.nadel.instrumentation.parameters.NadelInstrumentRootExecutionResultParameters
@@ -1490,12 +1491,12 @@ class NadelE2ETest extends StrategyTestHelper {
 
         def serviceHooks = new ServiceExecutionHooks() {
             @Override
-            Service resolveServiceForField(List<Service> services, String fieldName, Map<String, Object> arguments) {
+            ServiceOrError resolveServiceForField(List<Service> services, String fieldName, Map<String, Object> arguments) {
                 def bitbucketService = services.stream().filter({ service -> (service.getName() == "BitbucketService") }).findFirst().get()
                 def ariArgument = arguments.get("id")
 
                 if(ariArgument.toString().contains("bitbucket")) {
-                    return bitbucketService
+                    return new ServiceOrError(bitbucketService, null)
                 }
 
                 return null
@@ -1616,17 +1617,17 @@ class NadelE2ETest extends StrategyTestHelper {
 
         def serviceHooks = new ServiceExecutionHooks() {
             @Override
-            Service resolveServiceForField(List<Service> services, String fieldName, Map<String, Object> arguments) {
+            ServiceOrError resolveServiceForField(List<Service> services, String fieldName, Map<String, Object> arguments) {
                 def bitbucketService = services.stream().filter({ service -> (service.getName() == "BitbucketService") }).findFirst().get()
                 def jiraService = services.stream().filter({ service -> (service.getName() == "JiraService") }).findFirst().get()
                 def ariArgument = arguments.get("id")
 
                 if(ariArgument.toString().contains("bitbucket")) {
-                    return bitbucketService
+                    return new ServiceOrError(bitbucketService, null)
                 }
 
                 if(ariArgument.toString().contains("jira")) {
-                    return jiraService
+                    return new ServiceOrError(jiraService, null)
                 }
 
                 return null

--- a/engine/src/test/groovy/graphql/nadel/e2e/NadelE2ETest.groovy
+++ b/engine/src/test/groovy/graphql/nadel/e2e/NadelE2ETest.groovy
@@ -1451,8 +1451,8 @@ class NadelE2ETest extends StrategyTestHelper {
         '''
 
         def overallSchema = TestUtil.schemaFromNdsl([
-                BitbucketService: '''   
-                    service BitbucketService {
+                RepoService: '''   
+                    service RepoService {
                        type PullRequest implements Node {
                             id: ID!
                             description: String
@@ -1461,7 +1461,7 @@ class NadelE2ETest extends StrategyTestHelper {
                     '''
         ], commonTypes)
 
-        def bitbucketSchema = TestUtil.schema("""
+        def repoSchema = TestUtil.schema("""
             type Query {
                 node(id: ID): Node
             }
@@ -1477,7 +1477,7 @@ class NadelE2ETest extends StrategyTestHelper {
 
         def query = '''
             {
-                node(id: "ari:bitbucket:activation-id-123:pull-request:id-123") {
+                node(id: "pull-request:id-123") {
                    ... on PullRequest {
                         id
                         description
@@ -1486,17 +1486,17 @@ class NadelE2ETest extends StrategyTestHelper {
             }
         '''
 
-        def expectedQuery1 = 'query nadel_2_BitbucketService {node(id:"ari:bitbucket:activation-id-123:pull-request:id-123") {... on PullRequest {id description} type_hint_typename__UUID:__typename}}'
+        def expectedQuery1 = 'query nadel_2_RepoService {node(id:"pull-request:id-123") {... on PullRequest {id description} type_hint_typename__UUID:__typename}}'
         Map response1 = [node: [id: "123", description: "this is a pull request", type_hint_typename__UUID: "PullRequest"]]
 
         def serviceHooks = new ServiceExecutionHooks() {
             @Override
             ServiceOrError resolveServiceForField(List<Service> services, String fieldName, Map<String, Object> arguments) {
-                def bitbucketService = services.stream().filter({ service -> (service.getName() == "BitbucketService") }).findFirst().get()
-                def ariArgument = arguments.get("id")
+                def repoService = services.stream().filter({ service -> (service.getName() == "RepoService") }).findFirst().get()
+                def idArgument = arguments.get("id")
 
-                if(ariArgument.toString().contains("bitbucket")) {
-                    return new ServiceOrError(bitbucketService, null)
+                if(idArgument.toString().contains("pull-request")) {
+                    return new ServiceOrError(repoService, null)
                 }
 
                 return null
@@ -1508,8 +1508,8 @@ class NadelE2ETest extends StrategyTestHelper {
         when:
         (response, errors) = test1Service(
                 overallSchema,
-                "BitbucketService",
-                bitbucketSchema,
+                "RepoService",
+                repoSchema,
                 query,
                 ["pullRequest"],
                 expectedQuery1,
@@ -1537,16 +1537,16 @@ class NadelE2ETest extends StrategyTestHelper {
         '''
 
         def overallSchema = TestUtil.schemaFromNdsl([
-                BitbucketService: '''   
-                    service BitbucketService {
+                RepoService: '''   
+                    service RepoService {
                        type PullRequest implements Node {
                             id: ID!
                             description: String
                        }
                     }
                    ''',
-                JiraService: '''   
-                    service JiraService {
+                IssueService: '''   
+                    service IssueService {
                        type Issue implements Node {
                             id: ID!
                             issueKey: String
@@ -1555,7 +1555,7 @@ class NadelE2ETest extends StrategyTestHelper {
                     '''
         ], commonTypes)
 
-        def bitbucketSchema = TestUtil.schema("""
+        def repoSchema = TestUtil.schema("""
             type Query {
                 node(id: ID): Node
             }
@@ -1569,7 +1569,7 @@ class NadelE2ETest extends StrategyTestHelper {
                 description: String
             }""")
 
-        def jiraSchema = TestUtil.schema("""
+        def issueSchema = TestUtil.schema("""
             type Query {
                 node(id: ID): Node
             }
@@ -1585,13 +1585,13 @@ class NadelE2ETest extends StrategyTestHelper {
 
         def query = '''
             {
-                pr:node(id: "ari:bitbucket:activation-id-123:pull-request:id-123") {
+                pr:node(id: "pull-request:id-123") {
                    ... on PullRequest {
                         id
                         description
                    }
                 }
-                issue:node(id: "ari:cloud:jira:site-id-123:issue/id-123") {
+                issue:node(id: "issue/id-123") {
                    ... on Issue {
                         id
                         issueKey
@@ -1599,35 +1599,35 @@ class NadelE2ETest extends StrategyTestHelper {
                 }
             }
         '''
-        def bitbucketTestService = new TestService(
-                name: "BitbucketService",
-                schema: bitbucketSchema,
+        def repoTestService = new TestService(
+                name: "RepoService",
+                schema: repoSchema,
                 topLevelFields: ["pullRequest"],
-                expectedQuery: 'query nadel_2_BitbucketService {pr:node(id:"ari:bitbucket:activation-id-123:pull-request:id-123") {... on PullRequest {id description} type_hint_typename__UUID:__typename}}',
-                response: [pr: [id: "ari:bitbucket:activation-id-123:pull-request:id-123", description: "this is a pull request", type_hint_typename__UUID: "PullRequest"]]
+                expectedQuery: 'query nadel_2_RepoService {pr:node(id:"pull-request:id-123") {... on PullRequest {id description} type_hint_typename__UUID:__typename}}',
+                response: [pr: [id: "pull-request:id-123", description: "this is a pull request", type_hint_typename__UUID: "PullRequest"]]
         )
 
-        def jiraTestService = new TestService(
-                name: "JiraService",
-                schema: jiraSchema,
+        def issueTestService = new TestService(
+                name: "IssueService",
+                schema: issueSchema,
                 topLevelFields: ["issue"],
-                expectedQuery: 'query nadel_2_JiraService {issue:node(id:"ari:cloud:jira:site-id-123:issue/id-123") {... on Issue {id issueKey} type_hint_typename__UUID:__typename}}',
-                response: [issue: [id: "ari:cloud:jira:site-id-123:issue/id-123", issueKey: "ISSUE-1", type_hint_typename__UUID: "Issue"]]
+                expectedQuery: 'query nadel_2_IssueService {issue:node(id:"issue/id-123") {... on Issue {id issueKey} type_hint_typename__UUID:__typename}}',
+                response: [issue: [id: "issue/id-123", issueKey: "ISSUE-1", type_hint_typename__UUID: "Issue"]]
         )
 
         def serviceHooks = new ServiceExecutionHooks() {
             @Override
             ServiceOrError resolveServiceForField(List<Service> services, String fieldName, Map<String, Object> arguments) {
-                def bitbucketService = services.stream().filter({ service -> (service.getName() == "BitbucketService") }).findFirst().get()
-                def jiraService = services.stream().filter({ service -> (service.getName() == "JiraService") }).findFirst().get()
-                def ariArgument = arguments.get("id")
+                def repoService = services.stream().filter({ service -> (service.getName() == "RepoService") }).findFirst().get()
+                def issueService = services.stream().filter({ service -> (service.getName() == "IssueService") }).findFirst().get()
+                def idArgument = arguments.get("id")
 
-                if(ariArgument.toString().contains("bitbucket")) {
-                    return new ServiceOrError(bitbucketService, null)
+                if(idArgument.toString().contains("pull-request")) {
+                    return new ServiceOrError(repoService, null)
                 }
 
-                if(ariArgument.toString().contains("jira")) {
-                    return new ServiceOrError(jiraService, null)
+                if(idArgument.toString().contains("issue")) {
+                    return new ServiceOrError(issueService, null)
                 }
 
                 return null
@@ -1641,14 +1641,14 @@ class NadelE2ETest extends StrategyTestHelper {
         (response, errors) = testServices(
                 overallSchema,
                 query,
-                [bitbucketTestService, jiraTestService],
+                [repoTestService, issueTestService],
                 serviceHooks,
                 Mock(ResultComplexityAggregator)
         )
         then:
         response == [
-                pr: [id: "ari:bitbucket:activation-id-123:pull-request:id-123", description: "this is a pull request"],
-                issue: [id: "ari:cloud:jira:site-id-123:issue/id-123", issueKey: "ISSUE-1"]
+                pr: [id: "pull-request:id-123", description: "this is a pull request"],
+                issue: [id: "issue/id-123", issueKey: "ISSUE-1"]
         ]
         errors.size() == 0
     }

--- a/engine/src/test/groovy/graphql/nadel/engine/StrategyTestHelper.groovy
+++ b/engine/src/test/groovy/graphql/nadel/engine/StrategyTestHelper.groovy
@@ -46,39 +46,16 @@ class StrategyTestHelper extends Specification {
                           Map variables = [:],
                           ResultComplexityAggregator resultComplexityAggregator
     ) {
-        def response1ServiceResult = new ServiceExecutionResult(response1)
-
-        boolean calledService1 = false
-        ServiceExecution service1Execution = { ServiceExecutionParameters sep ->
-            println printAstCompact(sep.query)
-            assert printAstCompact(sep.query) == expectedQuery1
-            calledService1 = true
-            return completedFuture(response1ServiceResult)
-        }
-        def serviceDefinition = ServiceDefinition.newServiceDefinition().build()
-        def definitionRegistry = Mock(DefinitionRegistry)
-        def instrumentation = new NadelInstrumentation() {}
-
-        def service1 = new Service(serviceOneName, underlyingOne, service1Execution, serviceDefinition, definitionRegistry)
-
-        Map fieldInfoByDefinition = [:]
-        topLevelFields.forEach({ it ->
-            def fd = overallSchema.getQueryType().getFieldDefinition(it)
-            FieldInfo fieldInfo = new FieldInfo(FieldInfo.FieldKind.TOPLEVEL, service1, fd)
-            fieldInfoByDefinition.put(fd, fieldInfo)
-        })
-        FieldInfos fieldInfos = new FieldInfos(fieldInfoByDefinition)
-
-        NadelExecutionStrategy nadelExecutionStrategy = new NadelExecutionStrategy([service1], fieldInfos, overallSchema, instrumentation, serviceExecutionHooks)
-
-
-        def executionData = createExecutionData(query, variables, overallSchema)
-
-        def response = nadelExecutionStrategy.execute(executionData.executionContext, executionHelper.getFieldSubSelection(executionData.executionContext), resultComplexityAggregator)
-
-        assert calledService1
-
-        return [resultData(response), resultErrors(response)]
+        return testServices(
+                overallSchema,
+                query,
+                [
+                        new TestService(name: serviceOneName, schema: underlyingOne, topLevelFields: topLevelFields, expectedQuery: expectedQuery1, response: response1),
+                ],
+                serviceExecutionHooks,
+                variables,
+                resultComplexityAggregator
+        )
     }
 
     Object[] test1ServiceWithNHydration(GraphQLSchema overallSchema,
@@ -151,48 +128,18 @@ class StrategyTestHelper extends Specification {
                            ResultComplexityAggregator resultComplexityAggregator
     ) {
 
-        def response1ServiceResult = new ServiceExecutionResult(response1)
-        def response2ServiceResult = new ServiceExecutionResult(response2)
 
-        boolean calledService1 = false
-        ServiceExecution service1Execution = { ServiceExecutionParameters sep ->
-            println printAstCompact(sep.query)
-            assert printAstCompact(sep.query) == expectedQuery1
-            calledService1 = true
-            return completedFuture(response1ServiceResult)
-        }
-        boolean calledService2 = false
-        ServiceExecution service2Execution = { ServiceExecutionParameters sep ->
-            println printAstCompact(sep.query)
-            assert printAstCompact(sep.query) == expectedQuery2
-            calledService2 = true
-            return completedFuture(response2ServiceResult)
-        }
-        def serviceDefinition = ServiceDefinition.newServiceDefinition().build()
-        def definitionRegistry = Mock(DefinitionRegistry)
-        def instrumentation = new NadelInstrumentation() {}
-
-        def service1 = new Service(serviceOneName, underlyingOne, service1Execution, serviceDefinition, definitionRegistry)
-        def service2 = new Service(serviceTwoName, underlyingTwo, service2Execution, serviceDefinition, definitionRegistry)
-
-        Map fieldInfoByDefinition = [:]
-        topLevelFields.forEach({ it ->
-            def fd = overallSchema.getQueryType().getFieldDefinition(it)
-            FieldInfo fieldInfo = new FieldInfo(FieldInfo.FieldKind.TOPLEVEL, service1, fd)
-            fieldInfoByDefinition.put(fd, fieldInfo)
-        })
-        FieldInfos fieldInfos = new FieldInfos(fieldInfoByDefinition)
-
-        NadelExecutionStrategy nadelExecutionStrategy = new NadelExecutionStrategy([service1, service2], fieldInfos, overallSchema, instrumentation, serviceExecutionHooks)
-
-        def executionData = createExecutionData(query, variables, overallSchema)
-
-        def response = nadelExecutionStrategy.execute(executionData.executionContext, executionHelper.getFieldSubSelection(executionData.executionContext), resultComplexityAggregator)
-
-        assert calledService1
-        assert calledService2
-
-        return [resultData(response), resultErrors(response)]
+        return testServices(
+                overallSchema,
+                query,
+                [
+                        new TestService(name: serviceOneName, schema: underlyingOne, topLevelFields: topLevelFields, expectedQuery: expectedQuery1, response: response1),
+                        new TestService(name: serviceTwoName, schema: underlyingTwo, topLevelFields: [], expectedQuery: expectedQuery2, response: response2)
+                ],
+                serviceExecutionHooks,
+                variables,
+                resultComplexityAggregator
+        )
     }
 
     Object[] testServices(GraphQLSchema overallSchema,


### PR DESCRIPTION
Implements dynamic service resolution to support top level Node queries, which are required by Relay.

- Introduces a new directive that identifies fields that require dynamic service resolution
- New service hook method to allow consumer to implement service resolution logic
- Some new features and refactoring in test helper code