### PR TITLE
route __typename field to the service for the parent field

### DIFF
--- a/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/blueprint/NadelExecutionBlueprint.kt
+++ b/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/blueprint/NadelExecutionBlueprint.kt
@@ -1,5 +1,6 @@
 package graphql.nadel.enginekt.blueprint
 
+import graphql.introspection.Introspection
 import graphql.nadel.Service
 import graphql.nadel.enginekt.util.filterValuesOfType
 import graphql.nadel.enginekt.util.makeFieldCoordinates
@@ -47,8 +48,12 @@ data class NadelOverallExecutionBlueprint(
         }
     }
 
-    fun getService(fieldCoordinates: FieldCoordinates): Service? {
-        return coordinatesToService[fieldCoordinates]
+    fun getService(field: NormalizedField): Service? {
+        val typeName = field.objectTypeNames.single()
+        if (field.name == Introspection.TypeNameMetaFieldDef.name) {
+            return getService(field.parent)
+        }
+        return coordinatesToService[makeFieldCoordinates(typeName, field.name)]
     }
 }
 

--- a/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/blueprint/NadelExecutionBlueprint.kt
+++ b/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/blueprint/NadelExecutionBlueprint.kt
@@ -48,7 +48,7 @@ data class NadelOverallExecutionBlueprint(
         }
     }
 
-    fun getService(field: NormalizedField): Service? {
+    fun getService(field: ExecutableNormalizedField): Service? {
         val typeName = field.objectTypeNames.single()
         if (field.name == Introspection.TypeNameMetaFieldDef.name) {
             return getService(field.parent)

--- a/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/transform/query/NadelFieldToService.kt
+++ b/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/transform/query/NadelFieldToService.kt
@@ -35,7 +35,7 @@ class NadelFieldToService(private val overallExecutionBlueprint: NadelOverallExe
     private fun getService(overallField: NormalizedField): Service {
         val operationTypeName = overallField.objectTypeNames.single()
         val fieldCoordinates = makeFieldCoordinates(operationTypeName, overallField.name)
-        return overallExecutionBlueprint.getService(fieldCoordinates)
+        return overallExecutionBlueprint.getService(overallField)
             ?: error("Unable to find service for field at: $fieldCoordinates")
     }
 }

--- a/test/src/test/resources/fixtures/__typename-is-passed-on-namespaced-fields.yml
+++ b/test/src/test/resources/fixtures/__typename-is-passed-on-namespaced-fields.yml
@@ -36,12 +36,15 @@ query: |
   {
     issue {
       __typename
+      aliasTypename: __typename
       getIssue {
+        __typename
+        aliasTypename: __typename
         text
       }
     }
   }
-variables: {}
+variables: { }
 serviceCalls:
   current:
     - serviceName: Issues
@@ -50,12 +53,15 @@ serviceCalls:
           query nadel_2_Issues {
             issue {
               __typename
+              aliasTypename: __typename
               getIssue {
+                __typename
+                aliasTypename: __typename
                 text
               }
             }
           }
-        variables: {}
+        variables: { }
         operationName: nadel_2_Issues
       # language=JSON
       response: |-
@@ -63,8 +69,11 @@ serviceCalls:
           "data": {
             "issue": {
               "__typename": "IssueQuery",
+              "aliasTypename": "IssueQuery",
               "getIssue": {
-                "text": "Foo"
+                "text": "Foo",
+                "__typename": "Issue",
+                "aliasTypename": "Issue"
               }
             }
           },
@@ -81,7 +90,16 @@ serviceCalls:
                   __typename
                 }
                 ... on IssueQuery {
+                  aliasTypename: __typename
+                }
+                ... on IssueQuery {
                   getIssue {
+                    ... on Issue {
+                      __typename
+                    }
+                    ... on Issue {
+                      aliasTypename: __typename
+                    }
                     ... on Issue {
                       text
                     }
@@ -98,8 +116,11 @@ serviceCalls:
           "data": {
             "issue": {
               "__typename": "IssueQuery",
+              "aliasTypename": "IssueQuery",
               "getIssue": {
-                "text": "Foo"
+                "text": "Foo",
+                "__typename": "Issue",
+                "aliasTypename": "Issue"
               }
             }
           },
@@ -111,8 +132,11 @@ response: |-
     "data": {
       "issue": {
         "__typename": "IssueQuery",
+        "aliasTypename": "IssueQuery",
         "getIssue": {
-          "text": "Foo"
+          "text": "Foo",
+          "__typename": "Issue",
+          "aliasTypename": "Issue"
         }
       }
     },

--- a/test/src/test/resources/fixtures/__typename-is-passed-on-namespaced-fields.yml
+++ b/test/src/test/resources/fixtures/__typename-is-passed-on-namespaced-fields.yml
@@ -1,6 +1,6 @@
 name: __typename is passed on namespaced fields
 enabled:
-  nextgen: false
+  nextgen: true
   current: true
 overallSchema:
   Issues: |
@@ -56,6 +56,41 @@ serviceCalls:
             }
           }
         variables: {}
+        operationName: nadel_2_Issues
+      # language=JSON
+      response: |-
+        {
+          "data": {
+            "issue": {
+              "__typename": "IssueQuery",
+              "getIssue": {
+                "text": "Foo"
+              }
+            }
+          },
+          "extensions": {}
+        }
+  nextgen:
+    - serviceName: Issues
+      request:
+        query: |
+          query {
+            ... on Query {
+              issue {
+                ... on IssueQuery {
+                  __typename
+                }
+                ... on IssueQuery {
+                  getIssue {
+                    ... on Issue {
+                      text
+                    }
+                  }
+                }
+              }
+            }
+          }
+        variables: { }
         operationName: nadel_2_Issues
       # language=JSON
       response: |-


### PR DESCRIPTION
bugfix for the same scenario as here https://github.com/atlassian-labs/nadel/pull/268 but in the next-gen engine.
routing `__typename` field to the service owning the parent field