### PR TITLE
Don't check for batched in Nadel directive

### DIFF
--- a/api/src/main/java/graphql/nadel/schema/NadelDirectives.java
+++ b/api/src/main/java/graphql/nadel/schema/NadelDirectives.java
@@ -175,7 +175,8 @@ public class NadelDirectives {
         String field = getDirectiveValue(directive, "field", String.class);
         String objectIdentifier = getDirectiveValue(directive, "identifiedBy", String.class);
         Boolean objectIndexed = getDirectiveValue(directive, "indexed", Boolean.class, false);
-        Boolean batched = getDirectiveValue(directive, "batched", Boolean.class, false);
+        // Note: this is not properly implemented yet, so the value does not matter
+        Boolean batched = false; // getDirectiveValue(directive, "batched", Boolean.class, false);
         if (objectIndexed) {
             objectIdentifier = null; // we cant have both but it has a default
         }


### PR DESCRIPTION
The `batched` keyword is for explicit batching _in the future_, but the central schema doesn't have this argument which causes it to fail on parsing.