### PR TITLE
GQLGW-1076: Add serviceContext to Service object

### DIFF
--- a/api/src/main/java/graphql/nadel/Service.java
+++ b/api/src/main/java/graphql/nadel/Service.java
@@ -13,17 +13,28 @@ public class Service {
     private final ServiceExecution serviceExecution;
     private final ServiceDefinition serviceDefinition;
     private final DefinitionRegistry definitionRegistry;
+    private final Object serviceContext;
+
+    public Service(String name,
+                   GraphQLSchema underlyingSchema,
+                   ServiceExecution serviceExecution,
+                   ServiceDefinition serviceDefinition,
+                   DefinitionRegistry definitionRegistry,
+                   Object serviceContext) {
+        this.name = name;
+        this.underlyingSchema = underlyingSchema;
+        this.serviceExecution = serviceExecution;
+        this.serviceDefinition = serviceDefinition;
+        this.definitionRegistry = definitionRegistry;
+        this.serviceContext = serviceContext;
+    }
 
     public Service(String name,
                    GraphQLSchema underlyingSchema,
                    ServiceExecution serviceExecution,
                    ServiceDefinition serviceDefinition,
                    DefinitionRegistry definitionRegistry) {
-        this.name = name;
-        this.underlyingSchema = underlyingSchema;
-        this.serviceExecution = serviceExecution;
-        this.serviceDefinition = serviceDefinition;
-        this.definitionRegistry = definitionRegistry;
+        this(name, underlyingSchema, serviceExecution, serviceDefinition, definitionRegistry, null);
     }
 
     public String getName() {
@@ -44,5 +55,20 @@ public class Service {
 
     public DefinitionRegistry getDefinitionRegistry() {
         return definitionRegistry;
+    }
+
+    public Object getServiceContext() {
+        return serviceContext;
+    }
+
+    public Service withContext(Object serviceContext) {
+        return new Service(
+                this.name,
+                this.underlyingSchema,
+                this.serviceExecution,
+                this.serviceDefinition,
+                this.definitionRegistry,
+                serviceContext
+        );
     }
 }


### PR DESCRIPTION
This adds `serviceContext` to `Service`. I think it makes sense to have the service and the context packaged together, as consumers would often need the service + the context when writing their transformers.