### PR TITLE
Fix master

### DIFF
--- a/engine-nextgen/src/main/kotlin/graphql/nadel/NextgenEngine.kt
+++ b/engine-nextgen/src/main/kotlin/graphql/nadel/NextgenEngine.kt
@@ -12,7 +12,6 @@ import graphql.nadel.enginekt.NadelExecutionContext
 import graphql.nadel.enginekt.blueprint.NadelExecutionBlueprintFactory
 import graphql.nadel.enginekt.plan.NadelExecutionPlan
 import graphql.nadel.enginekt.plan.NadelExecutionPlanFactory
-import graphql.nadel.enginekt.transform.AnyNadelTransform
 import graphql.nadel.enginekt.transform.NadelTransform
 import graphql.nadel.enginekt.transform.query.NadelFieldToService
 import graphql.nadel.enginekt.transform.query.NadelQueryPath
@@ -43,7 +42,7 @@ import java.util.concurrent.CompletableFuture
 
 class NextgenEngine @JvmOverloads constructor(
     nadel: Nadel,
-    transforms: List<AnyNadelTransform> = emptyList(),
+    transforms: List<NadelTransform<out Any>> = emptyList(),
 ) : NadelExecutionEngine {
     private val services: Map<String, Service> = nadel.services.strictAssociateBy { it.name }
     private val overallSchema = nadel.overallSchema

--- a/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/blueprint/NadelExecutionBlueprint.kt
+++ b/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/blueprint/NadelExecutionBlueprint.kt
@@ -1,6 +1,5 @@
 package graphql.nadel.enginekt.blueprint
 
-import graphql.introspection.Introspection
 import graphql.nadel.Service
 import graphql.nadel.enginekt.util.filterValuesOfType
 import graphql.nadel.enginekt.util.makeFieldCoordinates

--- a/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/plan/NadelExecutionPlanFactory.kt
+++ b/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/plan/NadelExecutionPlanFactory.kt
@@ -4,7 +4,6 @@ import graphql.nadel.NextgenEngine
 import graphql.nadel.Service
 import graphql.nadel.enginekt.NadelExecutionContext
 import graphql.nadel.enginekt.blueprint.NadelOverallExecutionBlueprint
-import graphql.nadel.enginekt.transform.AnyNadelTransform
 import graphql.nadel.enginekt.transform.NadelDeepRenameTransform
 import graphql.nadel.enginekt.transform.NadelRenameTransform
 import graphql.nadel.enginekt.transform.NadelTransform
@@ -15,7 +14,7 @@ import graphql.normalized.ExecutableNormalizedField
 
 internal class NadelExecutionPlanFactory(
     private val executionBlueprint: NadelOverallExecutionBlueprint,
-    private val transforms: List<AnyNadelTransform>,
+    private val transforms: List<NadelTransform<Any>>,
 ) {
     /**
      * This derives an execution plan from with the main input parameters being the
@@ -56,7 +55,10 @@ internal class NadelExecutionPlanFactory(
         )
     }
 
-    private suspend fun traverseQuery(root: ExecutableNormalizedField, consumer: suspend (ExecutableNormalizedField) -> Unit) {
+    private suspend fun traverseQuery(
+        root: ExecutableNormalizedField,
+        consumer: suspend (ExecutableNormalizedField) -> Unit,
+    ) {
         consumer(root)
         root.children.forEach {
             traverseQuery(it, consumer)
@@ -82,10 +84,10 @@ internal class NadelExecutionPlanFactory(
             )
         }
 
-        private fun listOfTransforms(vararg elements: NadelTransform<out Any>): List<AnyNadelTransform> {
+        private fun listOfTransforms(vararg elements: NadelTransform<out Any>): List<NadelTransform<Any>> {
             return elements.map {
                 @Suppress("UNCHECKED_CAST") // Ssh it's okay
-                it as AnyNadelTransform
+                it as NadelTransform<Any>
             }
         }
     }

--- a/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/transform/NadelDeepRenameTransform.kt
+++ b/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/transform/NadelDeepRenameTransform.kt
@@ -8,8 +8,8 @@ import graphql.nadel.enginekt.blueprint.NadelOverallExecutionBlueprint
 import graphql.nadel.enginekt.blueprint.getInstructionsOfTypeForField
 import graphql.nadel.enginekt.transform.artificial.NadelAliasHelper
 import graphql.nadel.enginekt.transform.query.NFUtil
-import graphql.nadel.enginekt.transform.query.NadelQueryTransformer
 import graphql.nadel.enginekt.transform.query.NadelQueryPath
+import graphql.nadel.enginekt.transform.query.NadelQueryTransformer
 import graphql.nadel.enginekt.transform.result.NadelResultInstruction
 import graphql.nadel.enginekt.transform.result.json.JsonNodeExtractor
 import graphql.nadel.enginekt.util.emptyOrSingle

--- a/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/transform/NadelRenameTransform.kt
+++ b/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/transform/NadelRenameTransform.kt
@@ -9,8 +9,8 @@ import graphql.nadel.enginekt.blueprint.getInstructionsOfTypeForField
 import graphql.nadel.enginekt.transform.NadelRenameTransform.State
 import graphql.nadel.enginekt.transform.artificial.NadelAliasHelper
 import graphql.nadel.enginekt.transform.query.NFUtil.createField
-import graphql.nadel.enginekt.transform.query.NadelQueryTransformer
 import graphql.nadel.enginekt.transform.query.NadelQueryPath
+import graphql.nadel.enginekt.transform.query.NadelQueryTransformer
 import graphql.nadel.enginekt.transform.result.NadelResultInstruction
 import graphql.nadel.enginekt.transform.result.json.JsonNode
 import graphql.nadel.enginekt.transform.result.json.JsonNodeExtractor

--- a/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/transform/NadelTransform.kt
+++ b/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/transform/NadelTransform.kt
@@ -11,8 +11,6 @@ import graphql.nadel.enginekt.transform.result.NadelResultInstruction
 import graphql.normalized.ExecutableNormalizedField
 import graphql.schema.GraphQLSchema
 
-internal typealias AnyNadelTransform = NadelTransform<Any>
-
 interface NadelTransform<State : Any> {
     /**
      * Determines whether the [NadelTransform] should run. If it should run return a [State].

--- a/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/transform/NadelTypeRenameResultTransform.kt
+++ b/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/transform/NadelTypeRenameResultTransform.kt
@@ -5,8 +5,8 @@ import graphql.nadel.Service
 import graphql.nadel.ServiceExecutionResult
 import graphql.nadel.enginekt.NadelExecutionContext
 import graphql.nadel.enginekt.blueprint.NadelOverallExecutionBlueprint
-import graphql.nadel.enginekt.transform.query.NadelQueryTransformer
 import graphql.nadel.enginekt.transform.query.NadelQueryPath
+import graphql.nadel.enginekt.transform.query.NadelQueryTransformer
 import graphql.nadel.enginekt.transform.result.NadelResultInstruction
 import graphql.nadel.enginekt.transform.result.json.JsonNodeExtractor
 import graphql.nadel.enginekt.util.queryPath

--- a/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/transform/hydration/NadelHydrationTransform.kt
+++ b/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/transform/hydration/NadelHydrationTransform.kt
@@ -15,8 +15,8 @@ import graphql.nadel.enginekt.transform.artificial.NadelAliasHelper
 import graphql.nadel.enginekt.transform.getInstructionForNode
 import graphql.nadel.enginekt.transform.hydration.NadelHydrationTransform.State
 import graphql.nadel.enginekt.transform.hydration.NadelHydrationUtil.getInstructionsToAddErrors
-import graphql.nadel.enginekt.transform.query.NadelQueryTransformer
 import graphql.nadel.enginekt.transform.query.NadelQueryPath
+import graphql.nadel.enginekt.transform.query.NadelQueryTransformer
 import graphql.nadel.enginekt.transform.result.NadelResultInstruction
 import graphql.nadel.enginekt.transform.result.json.JsonNode
 import graphql.nadel.enginekt.transform.result.json.JsonNodeExtractor

--- a/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/transform/hydration/batch/NadelBatchHydrationTransform.kt
+++ b/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/transform/hydration/batch/NadelBatchHydrationTransform.kt
@@ -13,8 +13,8 @@ import graphql.nadel.enginekt.transform.NadelTransformUtil.makeTypeNameField
 import graphql.nadel.enginekt.transform.artificial.NadelAliasHelper
 import graphql.nadel.enginekt.transform.hydration.NadelHydrationFieldsBuilder
 import graphql.nadel.enginekt.transform.hydration.batch.NadelBatchHydrationTransform.State
-import graphql.nadel.enginekt.transform.query.NadelQueryTransformer
 import graphql.nadel.enginekt.transform.query.NadelQueryPath
+import graphql.nadel.enginekt.transform.query.NadelQueryTransformer
 import graphql.nadel.enginekt.transform.result.NadelResultInstruction
 import graphql.nadel.enginekt.transform.result.json.JsonNodeExtractor
 import graphql.nadel.enginekt.util.queryPath

--- a/engine/src/test/groovy/graphql/nadel/e2e/NadelE2ETest.groovy
+++ b/engine/src/test/groovy/graphql/nadel/e2e/NadelE2ETest.groovy
@@ -19,14 +19,10 @@ import graphql.nadel.ServiceExecution
 import graphql.nadel.ServiceExecutionFactory
 import graphql.nadel.ServiceExecutionParameters
 import graphql.nadel.ServiceExecutionResult
-import graphql.nadel.engine.StrategyTestHelper
 import graphql.nadel.engine.instrumentation.NadelEngineInstrumentation
-import graphql.nadel.engine.result.ResultComplexityAggregator
 import graphql.nadel.engine.result.ResultNodesUtil
 import graphql.nadel.engine.result.RootExecutionResultNode
 import graphql.nadel.engine.testutils.TestUtil
-import graphql.nadel.hooks.ServiceExecutionHooks
-import graphql.nadel.hooks.ServiceOrError
 import graphql.nadel.instrumentation.ChainedNadelInstrumentation
 import graphql.nadel.instrumentation.NadelInstrumentation
 import graphql.nadel.instrumentation.parameters.NadelInstrumentRootExecutionResultParameters

--- a/test/src/test/kotlin/graphql/nadel/tests/EngineTestHook.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/EngineTestHook.kt
@@ -4,7 +4,6 @@ import graphql.ExecutionResult
 import graphql.nadel.Nadel
 import graphql.nadel.NadelExecutionInput
 import graphql.nadel.tests.util.join
-import graphql.nadel.tests.util.packageName
 import graphql.nadel.tests.util.toSlug
 import org.reflections.Reflections
 import java.io.File

--- a/test/src/test/kotlin/graphql/nadel/tests/TestFixture.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/TestFixture.kt
@@ -33,12 +33,16 @@ data class TestFixture(
     }
 }
 
-val customTestTransforms = listOf(RemoveFieldTestTransform())
+val customTestTransforms = listOf(
+    RemoveFieldTestTransform(),
+)
 
 data class EngineTypeFactories(
     override val current: NadelExecutionEngineFactory = NadelExecutionEngineFactory(::NadelEngine),
     // TODO: test transforms should be set via the engine test hook.
-    override val nextgen: NadelExecutionEngineFactory = NadelExecutionEngineFactory { nadel -> NextgenEngine(nadel, customTestTransforms) },
+    override val nextgen: NadelExecutionEngineFactory = NadelExecutionEngineFactory { nadel ->
+        NextgenEngine(nadel, customTestTransforms)
+    },
 ) : NadelEngineTypeValueProvider<NadelExecutionEngineFactory> {
     val all = engines(factories = this)
 

--- a/test/src/test/kotlin/graphql/nadel/tests/hooks/can-instrument-root-execution-result.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/hooks/can-instrument-root-execution-result.kt
@@ -6,7 +6,6 @@ import graphql.nadel.Nadel
 import graphql.nadel.engine.instrumentation.NadelEngineInstrumentation
 import graphql.nadel.engine.result.ResultNodesUtil
 import graphql.nadel.engine.result.RootExecutionResultNode
-import graphql.nadel.instrumentation.NadelInstrumentation
 import graphql.nadel.instrumentation.parameters.NadelInstrumentRootExecutionResultParameters
 import graphql.nadel.instrumentation.parameters.NadelInstrumentationCreateStateParameters
 import graphql.nadel.tests.EngineTestHook

--- a/test/src/test/kotlin/graphql/nadel/tests/hooks/execution-id-is-transferred-from-provider-if-missing-in-input.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/hooks/execution-id-is-transferred-from-provider-if-missing-in-input.kt
@@ -9,7 +9,6 @@ import graphql.nadel.tests.EngineTestHook
 import graphql.nadel.tests.KeepHook
 import graphql.nadel.tests.NadelEngineType
 import graphql.nadel.tests.util.serviceExecutionFactory
-import graphql.schema.idl.TypeDefinitionRegistry
 import strikt.api.expectThat
 import strikt.assertions.isEqualTo
 import strikt.assertions.isGreaterThan

--- a/test/src/test/kotlin/graphql/nadel/tests/hooks/execution-is-aborted-when-begin-execute-completes-exceptionally-using-chained-instrumentation.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/hooks/execution-is-aborted-when-begin-execute-completes-exceptionally-using-chained-instrumentation.kt
@@ -15,7 +15,6 @@ import graphql.nadel.tests.NadelEngineType
 import graphql.nadel.tests.util.data
 import graphql.nadel.tests.util.errors
 import graphql.nadel.tests.util.message
-import org.junit.jupiter.api.fail
 import strikt.api.expectThat
 import strikt.assertions.isEqualTo
 import strikt.assertions.isNull

--- a/test/src/test/kotlin/graphql/nadel/tests/hooks/execution-is-aborted-when-begin-execute-completes-exceptionally.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/hooks/execution-is-aborted-when-begin-execute-completes-exceptionally.kt
@@ -16,7 +16,6 @@ import graphql.nadel.tests.NadelEngineType
 import graphql.nadel.tests.util.data
 import graphql.nadel.tests.util.errors
 import graphql.nadel.tests.util.extensions
-import graphql.nadel.tests.util.getHashCode
 import graphql.nadel.tests.util.getToString
 import graphql.nadel.tests.util.message
 import strikt.api.expectThat

--- a/test/src/test/kotlin/graphql/nadel/tests/hooks/makes-timing-metrics-available.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/hooks/makes-timing-metrics-available.kt
@@ -13,7 +13,6 @@ import graphql.nadel.tests.KeepHook
 import graphql.nadel.tests.NadelEngineType
 import graphql.nadel.tests.util.serviceExecutionFactory
 import strikt.api.expectThat
-import strikt.assertions.first
 import strikt.assertions.isGreaterThan
 import strikt.assertions.isLessThan
 import strikt.assertions.isNotNull

--- a/test/src/test/kotlin/graphql/nadel/tests/hooks/remove-fields.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/hooks/remove-fields.kt
@@ -2,7 +2,6 @@ package graphql.nadel.tests.hooks
 
 import graphql.ErrorClassification
 import graphql.GraphQLError
-import graphql.execution.AbortExecutionException
 import graphql.nadel.Nadel
 import graphql.nadel.hooks.HydrationArguments
 import graphql.nadel.hooks.ServiceExecutionHooks

--- a/test/src/test/kotlin/graphql/nadel/tests/hooks/test-batch-hydration-null-pointer-when-hydrated-query-field-does-not-exist.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/hooks/test-batch-hydration-null-pointer-when-hydrated-query-field-does-not-exist.kt
@@ -3,13 +3,8 @@ package graphql.nadel.tests.hooks
 import graphql.nadel.tests.EngineTestHook
 import graphql.nadel.tests.KeepHook
 import graphql.nadel.tests.NadelEngineType
-import io.kotest.mpp.stacktraces
-import strikt.api.Assertion
-import strikt.api.DescribeableBuilder
-import strikt.api.expect
 import strikt.api.expectThat
 import strikt.assertions.any
-import strikt.assertions.isA
 import strikt.assertions.isEqualTo
 
 @KeepHook

--- a/test/src/test/kotlin/graphql/nadel/tests/transforms/RemoveFieldTestTransform.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/transforms/RemoveFieldTestTransform.kt
@@ -8,8 +8,8 @@ import graphql.nadel.enginekt.NadelExecutionContext
 import graphql.nadel.enginekt.blueprint.NadelOverallExecutionBlueprint
 import graphql.nadel.enginekt.transform.NadelTransform
 import graphql.nadel.enginekt.transform.NadelTransformFieldResult
+import graphql.nadel.enginekt.transform.query.NadelQueryPath
 import graphql.nadel.enginekt.transform.query.NadelQueryTransformer
-import graphql.nadel.enginekt.transform.query.QueryPath
 import graphql.nadel.enginekt.transform.result.NadelResultInstruction
 import graphql.nadel.enginekt.transform.result.json.JsonNodeExtractor
 import graphql.nadel.enginekt.util.queryPath
@@ -18,13 +18,12 @@ import graphql.validation.ValidationError
 import graphql.validation.ValidationErrorType
 
 class RemoveFieldTestTransform : NadelTransform<GraphQLError> {
-
     override suspend fun isApplicable(
         executionContext: NadelExecutionContext,
         executionBlueprint: NadelOverallExecutionBlueprint,
         services: Map<String, Service>,
         service: Service,
-        overallField: ExecutableNormalizedField
+        overallField: ExecutableNormalizedField,
     ): GraphQLError? {
         if (overallField.objectTypeNames
                 .map { executionBlueprint.schema.getType(it) }
@@ -47,7 +46,7 @@ class RemoveFieldTestTransform : NadelTransform<GraphQLError> {
         executionBlueprint: NadelOverallExecutionBlueprint,
         service: Service,
         field: ExecutableNormalizedField,
-        state: GraphQLError
+        state: GraphQLError,
     ): NadelTransformFieldResult {
         return NadelTransformFieldResult(
             newField = null,
@@ -70,15 +69,15 @@ class RemoveFieldTestTransform : NadelTransform<GraphQLError> {
         overallField: ExecutableNormalizedField,
         underlyingParentField: ExecutableNormalizedField?,
         result: ServiceExecutionResult,
-        state: GraphQLError
+        state: GraphQLError,
     ): List<NadelResultInstruction> {
-        val nodesAt = JsonNodeExtractor.getNodesAt(
+        val parentNodes = JsonNodeExtractor.getNodesAt(
             data = result.data,
-            queryPath = underlyingParentField?.queryPath ?: QueryPath.root,
+            queryPath = underlyingParentField?.queryPath ?: NadelQueryPath.root,
             flatten = true,
         )
 
-        return nodesAt.map { parentNode ->
+        return parentNodes.map { parentNode ->
             val destinationPath = parentNode.resultPath + overallField.resultKey
             NadelResultInstruction.Set(
                 subjectPath = destinationPath,

--- a/test/src/test/kotlin/graphql/nadel/tests/util/FileUtil.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/util/FileUtil.kt
@@ -1,6 +1,5 @@
 package graphql.nadel.tests.util
 
-import io.kotest.matchers.file.exist
 import java.io.File
 import java.io.FileNotFoundException
 

--- a/test/src/test/kotlin/graphql/nadel/tests/util/StriktUtil.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/util/StriktUtil.kt
@@ -6,7 +6,6 @@ import graphql.nadel.enginekt.util.AnyMap
 import graphql.nadel.enginekt.util.JsonMap
 import graphql.nadel.tests.assertJsonKeys
 import strikt.api.Assertion
-import strikt.assertions.isNotNull
 
 fun <T : Map<K, V>, K, V> Assertion.Builder<T>.keysEqual(expectedKeys: Collection<K>): Assertion.Builder<T> {
     compose("keys match expected") { actual ->


### PR DESCRIPTION
Had semantic merge conflict due to renaming of `QueryPath` to `NadelQueryPath`.

Also removed `AnyNadelTransform` because its definition didn't line up with the other `Any*` type aliases, and was kinda confusing.