### PR TITLE
Prevent errors when merging null result nodes

### DIFF
--- a/engine/src/main/java/graphql/nadel/engine/execution/StrategyUtil.java
+++ b/engine/src/main/java/graphql/nadel/engine/execution/StrategyUtil.java
@@ -10,6 +10,7 @@ import graphql.nadel.dsl.NodeId;
 import graphql.nadel.engine.result.ExecutionResultNode;
 import graphql.nadel.engine.result.ObjectExecutionResultNode;
 import graphql.nadel.engine.result.RootExecutionResultNode;
+import graphql.nadel.util.FpKit;
 import graphql.schema.GraphQLSchema;
 import graphql.util.Breadcrumb;
 import graphql.util.NodeMultiZipper;
@@ -159,11 +160,9 @@ public class StrategyUtil {
     private static ExecutionResultNode combineResultNodes(List<ExecutionResultNode> resultNodes) {
         List<ExecutionResultNode> children = new ArrayList<>();
         Map<String, Object> completedValueMap = new LinkedHashMap<>();
-        // TODO: feature flag check, perhaps?
-        List<ExecutionResultNode> nonNullNodes = resultNodes
-                .stream()
-                .filter(resultNode -> resultNode.getCompletedValue() != null)
-                .collect(Collectors.toList());
+
+        List<ExecutionResultNode> nonNullNodes =
+                FpKit.filter(resultNodes, resultNode -> resultNode.getCompletedValue() != null);
 
         for (ExecutionResultNode resultNode : nonNullNodes) {
             Object completedValue = resultNode.getCompletedValue();
@@ -175,7 +174,7 @@ public class StrategyUtil {
             completedValueMap.putAll(childValue);
         }
 
-        return nonNullNodes.stream().findFirst()
+        return FpKit.findOne(nonNullNodes, node -> true)
                 .map(objectNode -> objectNode.transform(
                         builder -> builder.children(children).completedValue(completedValueMap)
                 ))

--- a/test/src/test/resources/fixtures/namespaced/both-of-the-namespaced-services-returns-error.yml
+++ b/test/src/test/resources/fixtures/namespaced/both-of-the-namespaced-services-returns-error.yml
@@ -1,0 +1,208 @@
+name: both of the namespaced services returns error
+enabled:
+  nextgen: true
+  current: true
+overallSchema:
+  Issues: |
+    directive @namespaced on FIELD_DEFINITION
+
+    type Query {
+      issue: IssueQuery @namespaced
+    }
+
+    type IssueQuery {
+      getIssue: Issue
+    }
+
+    type Issue {
+      id: ID
+      text: String
+    }
+  IssueSearch: |
+    extend type IssueQuery {
+      search: SearchResult
+    }
+
+    type SearchResult {
+      id: ID
+      count: Int
+    }
+underlyingSchema:
+  Issues: |
+    type Query {
+      issue: IssueQuery
+    }
+
+    type IssueQuery {
+      getIssue: Issue
+    }
+
+    type Issue {
+      id: ID
+      text: String
+    }
+  IssueSearch: |
+    type Query {
+      issue: IssueQuery
+    }
+
+    type IssueQuery {
+      search: SearchResult
+    }
+
+    type SearchResult {
+      id: ID
+      count: Int
+    }
+query: |
+  {
+    issue {
+      getIssue {
+        text
+      }
+      search {
+        count
+      }
+    }
+  }
+variables: { }
+serviceCalls:
+  current:
+    - serviceName: Issues
+      request:
+        query: |
+          query nadel_2_Issues {
+            issue {
+              getIssue {
+                text
+              }
+            }
+          }
+        variables: { }
+        operationName: nadel_2_Issues
+      # language=JSON
+      response: |-
+        {
+          "data": {
+            "issue": null
+          },
+          "errors": [
+            {
+              "message": "Error"
+            }
+          ],
+          "extensions": {}
+        }
+    - serviceName: IssueSearch
+      request:
+        query: |
+          query nadel_2_IssueSearch {
+            issue {
+              search {
+                count
+              }
+            }
+          }
+        variables: { }
+        operationName: nadel_2_IssueSearch
+      # language=JSON
+      response: |-
+        {
+          "data": {
+            "issue": null
+          },
+          "errors": [
+            {
+              "message": "Error"
+            }
+          ],
+          "extensions": {}
+        }
+  nextgen:
+    - serviceName: Issues
+      request:
+        query: |
+          query {
+            ... on Query {
+              issue {
+                ... on IssueQuery {
+                  getIssue {
+                    ... on Issue {
+                      text
+                    }
+                  }
+                }
+              }
+            }
+          }
+        variables: { }
+        operationName: nadel_2_Issues
+      # language=JSON
+      response: |-
+        {
+          "data": {
+            "issue": null
+          },
+          "errors": [
+            {
+              "message": "Error"
+            }
+          ],
+          "extensions": {}
+        }
+    - serviceName: IssueSearch
+      request:
+        query: |
+          query {
+            ... on Query {
+              issue {
+                ... on IssueQuery {
+                  search {
+                    ... on SearchResult {
+                      count
+                    }
+                  }
+                }
+              }
+            }
+          }
+        variables: { }
+        operationName: nadel_2_IssueSearch
+      # language=JSON
+      response: |-
+        {
+          "data": {
+            "issue": null
+          },
+          "errors": [
+            {
+              "message": "Error"
+            }
+          ],
+          "extensions": {}
+        }
+# language=JSON
+response: |-
+  {
+    "data": {
+      "issue": null
+    },
+    "errors": [
+      {
+        "message": "Error",
+        "locations": [],
+        "extensions": {
+          "classification": "DataFetchingException"
+        }
+      },
+      {
+        "message": "Error",
+        "locations": [],
+        "extensions": {
+          "classification": "DataFetchingException"
+        }
+      }
+    ],
+    "extensions": {}
+  }
+

--- a/test/src/test/resources/fixtures/namespaced/one-of-the-namespaced-services-returns-error.yml
+++ b/test/src/test/resources/fixtures/namespaced/one-of-the-namespaced-services-returns-error.yml
@@ -1,0 +1,203 @@
+name: one of the namespaced services returns error
+enabled:
+  nextgen: true
+  current: true
+overallSchema:
+  Issues: |
+    directive @namespaced on FIELD_DEFINITION
+
+    type Query {
+      issue: IssueQuery @namespaced
+    }
+
+    type IssueQuery {
+      getIssue: Issue
+    }
+
+    type Issue {
+      id: ID
+      text: String
+    }
+  IssueSearch: |
+    extend type IssueQuery {
+      search: SearchResult
+    }
+
+    type SearchResult {
+      id: ID
+      count: Int
+    }
+underlyingSchema:
+  Issues: |
+    type Query {
+      issue: IssueQuery
+    }
+
+    type IssueQuery {
+      getIssue: Issue
+    }
+
+    type Issue {
+      id: ID
+      text: String
+    }
+  IssueSearch: |
+    type Query {
+      issue: IssueQuery
+    }
+
+    type IssueQuery {
+      search: SearchResult
+    }
+
+    type SearchResult {
+      id: ID
+      count: Int
+    }
+query: |
+  {
+    issue {
+      getIssue {
+        text
+      }
+      search {
+        count
+      }
+    }
+  }
+variables: { }
+serviceCalls:
+  current:
+    - serviceName: Issues
+      request:
+        query: |
+          query nadel_2_Issues {
+            issue {
+              getIssue {
+                text
+              }
+            }
+          }
+        variables: { }
+        operationName: nadel_2_Issues
+      # language=JSON
+      response: |-
+        {
+          "data": {
+            "issue": {
+              "getIssue": {
+                "text": "Foo"
+              }
+            }
+          },
+          "extensions": {}
+        }
+    - serviceName: IssueSearch
+      request:
+        query: |
+          query nadel_2_IssueSearch {
+            issue {
+              search {
+                count
+              }
+            }
+          }
+        variables: { }
+        operationName: nadel_2_IssueSearch
+      # language=JSON
+      response: |-
+        {
+          "data": {
+            "issue": null
+          },
+          "errors": [
+            {
+              "message": "Error on IssueSearch"
+            }
+          ],
+          "extensions": {}
+        }
+  nextgen:
+    - serviceName: Issues
+      request:
+        query: |
+          query {
+            ... on Query {
+              issue {
+                ... on IssueQuery {
+                  getIssue {
+                    ... on Issue {
+                      text
+                    }
+                  }
+                }
+              }
+            }
+          }
+        variables: { }
+        operationName: nadel_2_Issues
+      # language=JSON
+      response: |-
+        {
+          "data": {
+            "issue": {
+              "getIssue": {
+                "text": "Foo"
+              }
+            }
+          },
+          "extensions": {}
+        }
+    - serviceName: IssueSearch
+      request:
+        query: |
+          query {
+            ... on Query {
+              issue {
+                ... on IssueQuery {
+                  search {
+                    ... on SearchResult {
+                      count
+                    }
+                  }
+                }
+              }
+            }
+          }
+        variables: { }
+        operationName: nadel_2_IssueSearch
+      # language=JSON
+      response: |-
+        {
+          "data": {
+            "issue": null
+          },
+          "errors": [
+            {
+              "message": "Error on IssueSearch"
+            }
+          ],
+          "extensions": {}
+        }
+# language=JSON
+response: |-
+  {
+    "data": {
+      "issue": {
+        "getIssue": {
+          "text": "Foo"
+        }
+      }
+    },
+    "errors": [
+      {
+        "message": "Error on IssueSearch",
+        "locations": [],
+        "extensions": {
+          "classification": "DataFetchingException"
+        }
+      }
+    ],
+    "extensions": {}
+  }
+


### PR DESCRIPTION
When merging result nodes, we want to merge `null` values with objects.

Like, if `serviceA` returns an error when serving a query for `field1`, but `serviceB` returns data for it (`field1: { data: "text"}`, we want to merged result to content the data from `serviceB` + the errors from `serviceA`