### PR TITLE
support field rename with arguments

### DIFF
--- a/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/transform/NadelDeepRenameTransform.kt
+++ b/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/transform/NadelDeepRenameTransform.kt
@@ -221,7 +221,7 @@ internal class NadelDeepRenameTransform : NadelTransform<NadelDeepRenameTransfor
                 schema = service.underlyingSchema,
                 parentType = underlyingObjectType,
                 queryPathToField = deepRename.queryPathToField,
-                fieldArguments = emptyMap(),
+                fieldArguments = field.normalizedArguments,
                 fieldChildren = transformer.transform(field.children),
             ),
         )

--- a/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/transform/NadelRenameTransform.kt
+++ b/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/transform/NadelRenameTransform.kt
@@ -140,7 +140,7 @@ internal class NadelRenameTransform : NadelTransform<State> {
                 schema = service.underlyingSchema,
                 parentType = underlyingObjectType,
                 queryPathToField = NadelQueryPath(rename.underlyingName),
-                fieldArguments = emptyMap(),
+                fieldArguments = field.normalizedArguments,
                 fieldChildren = transformer.transform(field.children),
             )
         )

--- a/test/src/test/resources/fixtures/deep renames/deep-rename-with-argument-works.yml
+++ b/test/src/test/resources/fixtures/deep renames/deep-rename-with-argument-works.yml
@@ -1,0 +1,103 @@
+name: deep rename with argument works
+enabled:
+  current: false
+  nextgen: true
+overallSchema:
+  IssueService: |
+    service IssueService {
+      type Query {
+        issue: Issue
+      }
+      type Issue {
+        name(userId: ID!): String => renamed from detail.detailName
+      }
+    }
+underlyingSchema:
+  IssueService: |
+    type Issue {
+      detail: IssueDetails
+    }
+
+    type IssueDetails {
+      detailName(userId: ID!): String
+    }
+
+    type Query {
+      issue: Issue
+    }
+query: |
+  query {
+    issue {
+      name(userId: "USER-01")
+    }
+  }
+variables: {}
+serviceCalls:
+  current:
+    - serviceName: IssueService
+      request:
+        query: |
+          query nadel_2_IssueService {
+            issue {
+              detail {
+                detailName(userId: "USER-01")
+              }
+            }
+          }
+        variables: {}
+        operationName: nadel_2_IssueService
+      # language=JSON
+      response: |-
+        {
+          "data": {
+            "issue": {
+              "detail": {
+                "detailName": "My Issue"
+              }
+            }
+          },
+          "extensions": {}
+        }
+  nextgen:
+    - serviceName: IssueService
+      request:
+        query: |
+          query {
+            ... on Query {
+              issue {
+                ... on Issue {
+                  __typename__deep_rename__name: __typename
+                  deep_rename__name__detail: detail {
+                    ... on IssueDetails {
+                      detailName(userId: "USER-01")
+                    }
+                  }
+                }
+              }
+            }
+          }
+        variables: {}
+        operationName: null
+      # language=JSON
+      response: |-
+        {
+          "data": {
+            "issue": {
+              "deep_rename__name__detail": {
+                "detailName": "My Issue"
+              },
+              "__typename__deep_rename__name": "Issue"
+            }
+          },
+          "extensions": {}
+        }
+# language=JSON
+response: |-
+  {
+    "data": {
+      "issue": {
+        "name": "My Issue"
+      }
+    },
+    "extensions": {}
+  }

--- a/test/src/test/resources/fixtures/renames/renamed-top-level-field-with-argument.yml
+++ b/test/src/test/resources/fixtures/renames/renamed-top-level-field-with-argument.yml
@@ -1,0 +1,87 @@
+name: renamed top level field with argument
+enabled:
+  current: true
+  nextgen: true
+overallSchema:
+  MyService: |
+    service MyService {
+      type Query {
+        renameObject(id: ID!): ObjectOverall @renamed(from: "renameObjectUnderlying")
+      }
+      type ObjectOverall @renamed(from: "ObjectUnderlying") {
+        name: String
+      }
+    }
+underlyingSchema:
+  MyService: |
+    type ObjectUnderlying {
+      name: String
+    }
+
+    type Query {
+      renameObjectUnderlying(id: ID!): ObjectUnderlying
+    }
+query: |
+  query {
+    renameObject(id: "OBJECT-001") {
+      name
+    }
+  }
+variables: { }
+serviceCalls:
+  current:
+    - serviceName: MyService
+      request:
+        query: |
+          query nadel_2_MyService {
+            renameObjectUnderlying(id: "OBJECT-001") {
+              name
+            }
+          }
+        variables: { }
+        operationName: nadel_2_MyService
+      # language=JSON
+      response: |-
+        {
+          "data": {
+            "renameObjectUnderlying": {
+              "name": "Object 001"
+            }
+          },
+          "extensions": {}
+        }
+  nextgen:
+    - serviceName: MyService
+      request:
+        query: |
+          query {
+            ... on Query {
+              rename__renameObject__renameObjectUnderlying: renameObjectUnderlying(id: "OBJECT-001") {
+                ... on ObjectUnderlying {
+                  name
+                }
+              }
+            }
+          }
+        variables: { }
+        operationName: null
+      # language=JSON
+      response: |-
+        {
+          "data": {
+            "rename__renameObject__renameObjectUnderlying": {
+              "name": "Object 001"
+            }
+          },
+          "extensions": {}
+        }
+# language=JSON
+response: |-
+  {
+    "data": {
+      "renameObject": {
+        "name": "Object 001"
+      }
+    },
+    "extensions": { }
+  }


### PR DESCRIPTION
Seems like renamed fields with arguments were never supported in the nextgen. A bit scary that we never caught it with tests. I only noticed this because some tests in the gateway were failing