### PR TITLE
Error out as temp hack to stop sending broken queries to services

### DIFF
--- a/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/transform/NadelServiceTypeFilterTransform.kt
+++ b/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/transform/NadelServiceTypeFilterTransform.kt
@@ -134,6 +134,10 @@ class NadelServiceTypeFilterTransform : NadelTransform<State> {
                 .toSet()
                 .toList()
 
+            if (objectTypeNames.isEmpty()) {
+                error("Service does not own return type. Unable to insert __typename as schema is not configured properly.")
+            }
+
             return NadelTransformFieldResult(
                 newField = null,
                 artificialFields = listOf(


### PR DESCRIPTION
This blocks broken queries from going to underlying services to avoid polluting their error logs etc.

Proper fix WIP.