### PR TITLE
Fix edge case where types are deleted by schema transformation

### DIFF
--- a/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/blueprint/NadelExecutionBlueprintFactory.kt
+++ b/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/blueprint/NadelExecutionBlueprintFactory.kt
@@ -535,8 +535,8 @@ private class SharedTypesAnalysis(
         }
 
         val overallOutputType = overallSchema.getType(overallOutputTypeName)
-            // Ensure type exists
-            .let { it ?: error("Unable to find output type: $overallOutputTypeName") }
+            // Ensure type exists, schema transformation can delete types, so let's just ignore it
+            .let { it ?: return emptyList() }
             // Return if not field container
             .let { it as? GraphQLFieldsContainer ?: return emptyList() }
             .let { it.definition as AnyImplementingTypeDefinition }

--- a/test/src/test/kotlin/graphql/nadel/tests/EngineTestHook.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/EngineTestHook.kt
@@ -4,6 +4,7 @@ import graphql.ExecutionResult
 import graphql.nadel.Nadel
 import graphql.nadel.NadelExecutionInput
 import graphql.nadel.enginekt.transform.NadelTransform
+import graphql.nadel.schema.SchemaTransformationHook
 import graphql.nadel.tests.util.join
 import graphql.nadel.tests.util.toSlug
 import org.reflections.Reflections
@@ -23,6 +24,9 @@ interface EngineTestHook {
 
     val customTransforms: List<NadelTransform<out Any>>
         get() = emptyList()
+
+    val schemaTransformationHook: SchemaTransformationHook
+        get() = SchemaTransformationHook.IDENTITY
 
     fun makeNadel(engineType: NadelEngineType, builder: Nadel.Builder): Nadel.Builder {
         return builder

--- a/test/src/test/kotlin/graphql/nadel/tests/EngineTests.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/EngineTests.kt
@@ -126,6 +126,7 @@ private suspend fun execute(
 
     try {
         val nadel = Nadel.newNadel()
+            .schemaTransformationHook(testHooks.schemaTransformationHook)
             .engineFactory { nadel ->
                 engineFactory.make(nadel, testHooks)
             }

--- a/test/src/test/kotlin/graphql/nadel/tests/hooks/can-delete-fields-and-types.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/hooks/can-delete-fields-and-types.kt
@@ -1,0 +1,70 @@
+package graphql.nadel.tests.hooks
+
+import graphql.ExecutionResult
+import graphql.nadel.enginekt.util.AnyList
+import graphql.nadel.schema.SchemaTransformationHook
+import graphql.nadel.tests.EngineTestHook
+import graphql.nadel.tests.KeepHook
+import graphql.nadel.tests.NadelEngineType
+import graphql.nadel.tests.assertJsonKeys
+import graphql.nadel.tests.util.data
+import graphql.schema.GraphQLFieldDefinition
+import graphql.schema.GraphQLObjectType
+import graphql.schema.GraphQLSchemaElement
+import graphql.schema.GraphQLTypeVisitorStub
+import graphql.schema.SchemaTransformer.transformSchema
+import graphql.util.TraversalControl
+import graphql.util.TraverserContext
+import strikt.api.expectThat
+import strikt.assertions.get
+import strikt.assertions.isA
+import strikt.assertions.isEqualTo
+import strikt.assertions.isNotNull
+import strikt.assertions.none
+import strikt.assertions.one
+
+@KeepHook
+class `can-delete-fields-and-types` : EngineTestHook {
+    override val schemaTransformationHook = SchemaTransformationHook { originalSchema, _ ->
+        transformSchema(originalSchema, object : GraphQLTypeVisitorStub() {
+            override fun visitGraphQLFieldDefinition(
+                node: GraphQLFieldDefinition,
+                context: TraverserContext<GraphQLSchemaElement>,
+            ): TraversalControl {
+                if (node.name == "foo") {
+                    return deleteNode(context)
+                }
+                return super.visitGraphQLFieldDefinition(node, context)
+            }
+
+            override fun visitGraphQLObjectType(
+                node: GraphQLObjectType,
+                context: TraverserContext<GraphQLSchemaElement>,
+            ): TraversalControl {
+                if (node.name == "Foo") {
+                    return deleteNode(context)
+                }
+                return super.visitGraphQLObjectType(node, context)
+            }
+        })
+    }
+
+    override fun assertResult(engineType: NadelEngineType, result: ExecutionResult) {
+        expectThat(result)
+            .data
+            .isNotNull()
+            .assertJsonKeys()["__schema"]
+            .isNotNull()
+            .isAJsonMap()["types"]
+            .isA<AnyList>()
+            .none {
+                isNotNull().isAJsonMap()["name"].isEqualTo("Foo")
+            }
+            .one {
+                isNotNull().isAJsonMap()["name"].isEqualTo("String")
+            }
+            .one {
+                isNotNull().isAJsonMap()["name"].isEqualTo("Query")
+            }
+    }
+}

--- a/test/src/test/resources/fixtures/schema/can-delete-fields-and-types.yml
+++ b/test/src/test/resources/fixtures/schema/can-delete-fields-and-types.yml
@@ -1,0 +1,42 @@
+name: can delete fields and types
+enabled:
+  current: true
+  nextgen: true
+overallSchema:
+  service: |
+    type Query {
+      foo: Foo
+      echo: String
+    }
+    type Foo {
+      id: ID
+    }
+    type Bar {
+      id: ID
+      foo: Foo
+    }
+underlyingSchema:
+  service: |
+    type Query {
+      foo: Foo
+      echo: String
+    }
+    type Foo {
+      id: ID
+    }
+    type Bar {
+      id: ID
+      foo: Foo
+    }
+query: |
+  query GetTypes {
+    __schema {
+      types {
+        name
+      }
+    }
+  }
+variables: {}
+serviceCalls: {}
+# language=JSON
+response: null


### PR DESCRIPTION
Ok ran into an issue where AGG uses `SchemaTransformationHook` to delete fields, for the deleted fields if there's no type leftover it deletes it.

The issue is that the `SchemaTransformationHook` operates on the composed `GraphQLSchema` but `SharedTypesAnalysis` operates on the AST definitions, TO BEGIN WITH. We operate on AST definitions because it lets easily check what a service owns via `Service#getDefinitionRegistry`.