### PR TITLE
Permit empty operation name

### DIFF
--- a/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/util/GraphQLUtil.kt
+++ b/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/util/GraphQLUtil.kt
@@ -330,7 +330,9 @@ fun ExecutableNormalizedField.getOperationKind(
  * operation and fragment definitions in [Map]s.
  */
 internal fun Document.getOperationDefinitionOrNull(operationName: String?): OperationDefinition? {
-    operationName ?: return definitions.singleOfTypeOrNull()
+    if (operationName == null || operationName.isEmpty()) {
+        return definitions.singleOfTypeOrNull()
+    }
 
     return definitions.singleOfTypeOrNull<OperationDefinition> { def ->
         def.name == operationName

--- a/test/src/test/resources/fixtures/basic/can-execute-single-named-operation-when-operation-name-is-empty.yml
+++ b/test/src/test/resources/fixtures/basic/can-execute-single-named-operation-when-operation-name-is-empty.yml
@@ -1,0 +1,48 @@
+name: can execute single named operation when operation name is empty
+enabled:
+  current: false
+  nextgen: true
+overallSchema:
+  service: |
+    type Query {
+      foo: String
+    }
+underlyingSchema:
+  service: |
+    type Query {
+      foo: String
+    }
+query: |
+  query Test {
+    test: foo
+  }
+operationName: ""
+variables: {}
+serviceCalls:
+  nextgen:
+    - serviceName: service
+      request:
+        query: |
+          query Test {
+            ... on Query {
+              test: foo
+            }
+          }
+        variables: {}
+        operationName: Test
+      # language=JSON
+      response: |-
+        {
+          "data": {
+            "test": "Test Working"
+          },
+          "extensions": {}
+        }
+# language=JSON
+response: |-
+  {
+    "data": {
+      "test": "Test Working"
+    },
+    "extensions": {}
+  }


### PR DESCRIPTION
Misread the other code, didn't realize this was permitted. Fixes a bug that was caught by AGG tests.