### PR TITLE
Align how __typename fields are processed for namespaced

### DIFF
--- a/api/src/main/java/graphql/nadel/util/NamespacedUtil.java
+++ b/api/src/main/java/graphql/nadel/util/NamespacedUtil.java
@@ -1,0 +1,23 @@
+package graphql.nadel.util;
+
+import graphql.language.ObjectTypeDefinition;
+import graphql.language.ObjectTypeExtensionDefinition;
+import graphql.nadel.Service;
+import graphql.schema.GraphQLObjectType;
+
+public final class NamespacedUtil {
+    private NamespacedUtil() {
+    }
+
+    public static boolean serviceOwnsNamespacedField(GraphQLObjectType namespacedObjectType, Service service) {
+        return serviceOwnsNamespacedField(namespacedObjectType.getName(), service);
+    }
+
+    public static boolean serviceOwnsNamespacedField(String namespacedObjectTypeName, Service service) {
+        return service.getDefinitionRegistry().getDefinitions(ObjectTypeDefinition.class)
+                .stream()
+                // the type can't be an extension in the owning service
+                .filter(objectTypeDef -> !(objectTypeDef instanceof ObjectTypeExtensionDefinition))
+                .anyMatch(objectTypeDef -> objectTypeDef.getName().equals(namespacedObjectTypeName));
+    }
+}

--- a/engine-nextgen/src/main/kotlin/graphql/nadel/NextgenEngine.kt
+++ b/engine-nextgen/src/main/kotlin/graphql/nadel/NextgenEngine.kt
@@ -82,6 +82,7 @@ class NextgenEngine @JvmOverloads constructor(
         overallExecutionBlueprint = overallExecutionBlueprint,
         introspectionRunnerFactory = introspectionRunnerFactory,
         dynamicServiceResolution = dynamicServiceResolution,
+        services,
     )
     private val executionIdProvider = nadel.executionIdProvider
 

--- a/test/src/test/resources/fixtures/namespaced/typename-is-sent-owning-service-even-when-namespaced-field-and-type-are-defined-in-different-services.yml
+++ b/test/src/test/resources/fixtures/namespaced/typename-is-sent-owning-service-even-when-namespaced-field-and-type-are-defined-in-different-services.yml
@@ -1,0 +1,160 @@
+name: typename is sent owning service even when namespaced field and type are defined in different services
+enabled:
+  nextgen: true
+  current: true
+overallSchema:
+  Issues: |
+    directive @namespaced on FIELD_DEFINITION
+
+    type IssueQuery {
+      getIssue: Issue
+    }
+
+    extend type IssueQuery {
+      getIssues: [Issue]
+    }
+
+    type Issue {
+      id: ID
+      text: String
+    }
+  IssueSearch: |
+    type Query {
+      issue: IssueQuery @namespaced
+    }
+
+    extend type IssueQuery {
+      search: SearchResult
+    }
+
+    type SearchResult {
+      id: ID
+      count: Int
+    }
+  IssueComments: |
+    extend type IssueQuery {
+      commentsCount: Int
+    }
+underlyingSchema:
+  Issues: |
+    type Query {
+      issue: IssueQuery
+    }
+
+    type IssueQuery {
+      getIssue: Issue
+    }
+
+    extend type IssueQuery {
+      getIssues: [Issue]
+    }
+
+    type Issue {
+      id: ID
+      text: String
+    }
+  IssueSearch: |
+    type Query {
+      issue: IssueQuery
+    }
+
+    type IssueQuery {
+      search: SearchResult
+    }
+
+    type SearchResult {
+      id: ID
+      count: Int
+    }
+  IssueComments: |
+    type Query {
+      issue: IssueQuery
+    }
+
+    type IssueQuery {
+      commentsCount: Int
+    }
+query: |
+  {
+    issue {
+      __typename
+      getIssue {
+        text
+      }
+    }
+  }
+variables: {}
+serviceCalls:
+  current:
+    - serviceName: Issues
+      request:
+        query: |
+          query nadel_2_Issues {
+            issue {
+              __typename
+              getIssue {
+                text
+              }
+            }
+          }
+        variables: {}
+        operationName: nadel_2_Issues
+      # language=JSON
+      response: |-
+        {
+          "data": {
+            "issue": {
+              "__typename": "IssueQuery",
+              "getIssue": {
+                "text": "Foo"
+              }
+            }
+          },
+          "extensions": {}
+        }
+  nextgen:
+    - serviceName: Issues
+      request:
+        query: |
+          query {
+            ... on Query {
+              issue {
+                ... on IssueQuery {
+                  __typename
+                  getIssue {
+                    ... on Issue {
+                      text
+                    }
+                  }
+                }
+              }
+            }
+          }
+        variables: {}
+        operationName: null
+      # language=JSON
+      response: |-
+        {
+          "data": {
+            "issue": {
+              "__typename": "IssueQuery",
+              "getIssue": {
+                "text": "Foo"
+              }
+            }
+          },
+          "extensions": {}
+        }
+# language=JSON
+response: |-
+  {
+    "data": {
+      "issue": {
+        "__typename": "IssueQuery",
+        "getIssue": {
+          "text": "Foo"
+        }
+      }
+    },
+    "extensions": {}
+  }


### PR DESCRIPTION
BEFORE this change

To determine who gets the __typename
* Nextgen looks at who defines the namespaced __field__ in the overall schema
* Current gen looks at who defines (not extends) the namespaced __type__

AFTER this change both engines look at who defines (not extends) the namespaced __type__.
