### PR TITLE
Nextgen coerces like current gen

### DIFF
--- a/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/plan/NadelExecutionPlanFactory.kt
+++ b/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/plan/NadelExecutionPlanFactory.kt
@@ -4,6 +4,7 @@ import graphql.nadel.NextgenEngine
 import graphql.nadel.Service
 import graphql.nadel.enginekt.NadelExecutionContext
 import graphql.nadel.enginekt.blueprint.NadelOverallExecutionBlueprint
+import graphql.nadel.enginekt.transform.NadelCoerceTransform
 import graphql.nadel.enginekt.transform.NadelDeepRenameTransform
 import graphql.nadel.enginekt.transform.NadelRenameTransform
 import graphql.nadel.enginekt.transform.NadelServiceTypeFilterTransform
@@ -76,6 +77,7 @@ internal class NadelExecutionPlanFactory(
             return NadelExecutionPlanFactory(
                 executionBlueprint,
                 transforms = listOfTransforms(
+                    NadelCoerceTransform(),
                     SkipIncludeTransform(),
                     NadelServiceTypeFilterTransform(),
                     *transforms.toTypedArray(),

--- a/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/transform/NadelCoerceTransform.kt
+++ b/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/transform/NadelCoerceTransform.kt
@@ -42,14 +42,17 @@ internal class NadelCoerceTransform : NadelTransform<State> {
                 )
             }
             .map { it.type }
+            .map { GraphQLTypeUtil.unwrapAll(it) }
             .toList()
 
-        if (types.distinct().size != 1) {
+        val distinctTypes = types.distinct().count()
+
+        if (distinctTypes != 1) {
             // field type on all definitions should be the same
             return null
         }
 
-        val type = GraphQLTypeUtil.unwrapAll(types.first())
+        val type = types.first()
 
         if (GraphQLTypeUtil.isScalar(type)) {
             return State(type as GraphQLScalarType)

--- a/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/transform/NadelCoerceTransform.kt
+++ b/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/transform/NadelCoerceTransform.kt
@@ -1,0 +1,98 @@
+package graphql.nadel.enginekt.transform
+
+import graphql.nadel.Service
+import graphql.nadel.ServiceExecutionResult
+import graphql.nadel.enginekt.NadelExecutionContext
+import graphql.nadel.enginekt.blueprint.NadelOverallExecutionBlueprint
+import graphql.nadel.enginekt.transform.NadelCoerceTransform.State
+import graphql.nadel.enginekt.transform.query.NadelQueryPath.Companion.root
+import graphql.nadel.enginekt.transform.query.NadelQueryTransformer
+import graphql.nadel.enginekt.transform.result.NadelResultInstruction
+import graphql.nadel.enginekt.transform.result.json.JsonNode
+import graphql.nadel.enginekt.transform.result.json.JsonNodeExtractor
+import graphql.nadel.enginekt.transform.result.json.JsonNodeExtractor.getNodesAt
+import graphql.nadel.enginekt.util.queryPath
+import graphql.normalized.ExecutableNormalizedField
+import graphql.schema.FieldCoordinates
+import graphql.schema.GraphQLScalarType
+import graphql.schema.GraphQLTypeUtil
+
+internal class NadelCoerceTransform : NadelTransform<State> {
+    data class State(
+        val fieldType: GraphQLScalarType,
+    )
+
+    override suspend fun isApplicable(
+        executionContext: NadelExecutionContext,
+        executionBlueprint: NadelOverallExecutionBlueprint,
+        services: Map<String, Service>,
+        service: Service,
+        overallField: ExecutableNormalizedField
+    ): State? {
+        val schema = executionBlueprint.schema
+
+        val types = overallField.objectTypeNames
+            .asSequence()
+            .mapNotNull {
+                schema.getFieldDefinition(
+                    FieldCoordinates.coordinates(
+                        it,
+                        overallField.fieldName
+                    )
+                )
+            }
+            .map { it.type }
+            .toList()
+
+        if (types.distinct().size != 1) {
+            // field type on all definitions should be the same
+            return null
+        }
+
+        val type = GraphQLTypeUtil.unwrapAll(types.first())
+
+        if (GraphQLTypeUtil.isScalar(type)) {
+            return State(type as GraphQLScalarType)
+        }
+
+        return null
+    }
+
+    override suspend fun transformField(
+        executionContext: NadelExecutionContext,
+        transformer: NadelQueryTransformer.Continuation,
+        executionBlueprint: NadelOverallExecutionBlueprint,
+        service: Service,
+        field: ExecutableNormalizedField,
+        state: State
+    ): NadelTransformFieldResult {
+        return NadelTransformFieldResult.unmodified(field)
+    }
+
+    override suspend fun getResultInstructions(
+        executionContext: NadelExecutionContext,
+        executionBlueprint: NadelOverallExecutionBlueprint,
+        service: Service,
+        overallField: ExecutableNormalizedField,
+        underlyingParentField: ExecutableNormalizedField?,
+        result: ServiceExecutionResult,
+        state: State
+    ): List<NadelResultInstruction> {
+        val parentQueryPath = underlyingParentField?.queryPath ?: root
+
+        val valueNodes: List<JsonNode> = getNodesAt(
+            data = result.data,
+            queryPath = parentQueryPath.plus(overallField.resultKey),
+            flatten = true
+        )
+
+        return valueNodes
+            .mapNotNull { valueNode ->
+                JsonNodeExtractor.getNodeAt(result.data, valueNode.resultPath)?.let { jsonNode ->
+                    NadelResultInstruction.Set(
+                        valueNode.resultPath,
+                        jsonNode.value?.let { value -> state.fieldType.coercing.parseValue(value) })
+                }
+            }
+    }
+}

--- a/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/transform/NadelTransformUtil.kt
+++ b/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/transform/NadelTransformUtil.kt
@@ -2,13 +2,18 @@ package graphql.nadel.enginekt.transform
 
 import graphql.introspection.Introspection.TypeNameMetaFieldDef
 import graphql.nadel.Service
+import graphql.nadel.ServiceExecutionResult
 import graphql.nadel.enginekt.blueprint.NadelFieldInstruction
 import graphql.nadel.enginekt.blueprint.NadelOverallExecutionBlueprint
 import graphql.nadel.enginekt.transform.artificial.NadelAliasHelper
+import graphql.nadel.enginekt.transform.query.NadelQueryPath
+import graphql.nadel.enginekt.transform.result.NadelResultInstruction
 import graphql.nadel.enginekt.transform.result.json.JsonNode
+import graphql.nadel.enginekt.transform.result.json.JsonNodeExtractor
 import graphql.nadel.enginekt.util.JsonMap
 import graphql.nadel.enginekt.util.getField
 import graphql.nadel.enginekt.util.makeFieldCoordinates
+import graphql.nadel.enginekt.util.queryPath
 import graphql.normalized.ExecutableNormalizedField
 import graphql.normalized.ExecutableNormalizedField.newNormalizedField
 import graphql.schema.GraphQLFieldDefinition
@@ -69,6 +74,39 @@ object NadelTransformUtil {
 
         val coordinates = makeFieldCoordinates(overallTypeName, overallField.name)
         return executionBlueprint.schema.getField(coordinates)
+    }
+
+    /**
+     * Creates a list of Set instructions that will be used to modified the values of the result data
+     * for a particular field.
+     *
+     * This function will call the transformerFunction for all result nodes associated with the overallField. So the
+     * caller doesn't need to worry about whether the overallField is a collection or an individual field.
+     *
+     * Note that the transformer will only be called for non-null values.
+     */
+    fun createSetInstructions(
+        underlyingParentField: ExecutableNormalizedField?,
+        result: ServiceExecutionResult,
+        overallField: ExecutableNormalizedField,
+        transformerFunction: (Any) -> Any
+    ): List<NadelResultInstruction> {
+        val parentQueryPath = underlyingParentField?.queryPath ?: NadelQueryPath.root
+
+        val valueNodes: List<JsonNode> = JsonNodeExtractor.getNodesAt(
+            data = result.data,
+            queryPath = parentQueryPath.plus(overallField.resultKey),
+            flatten = true
+        )
+
+        return valueNodes
+            .mapNotNull { valueNode ->
+                JsonNodeExtractor.getNodeAt(result.data, valueNode.resultPath)?.let { jsonNode ->
+                    NadelResultInstruction.Set(
+                        valueNode.resultPath,
+                        jsonNode.value?.let { value -> transformerFunction(value) })
+                }
+            }
     }
 }
 

--- a/engine/src/main/java/graphql/nadel/engine/execution/ServiceResultToResultNodes.java
+++ b/engine/src/main/java/graphql/nadel/engine/execution/ServiceResultToResultNodes.java
@@ -362,6 +362,7 @@ public class ServiceResultToResultNodes {
                 throw new CoercingSerializeException("Unexpected value '" + toAnalyze + "'. String expected");
             }
         }
+        // NOTE: Current gen code that coerces value to the type defined in the overall schema
         return scalarType.getCoercing().serialize(toAnalyze);
     }
 

--- a/test/src/test/resources/fixtures/coerce-values-to-overall-types.yml
+++ b/test/src/test/resources/fixtures/coerce-values-to-overall-types.yml
@@ -1,0 +1,63 @@
+name: coerce values to overall types
+enabled:
+  current: true
+  nextgen: true
+overallSchema:
+  service: |
+    type Query {
+      aField: Int
+    }
+underlyingSchema:
+  service: |
+    type Query {
+      aField: String
+    }
+query: |
+  query {
+    aField
+  }
+variables: {}
+serviceCalls:
+  nextgen:
+    - serviceName: service
+      request:
+        query: |
+          query {
+            ... on Query {
+              aField
+            }
+          }
+        variables: {}
+        operationName: null
+      # language=JSON
+      response: |-
+        {
+          "data": {
+            "aField": "1000"
+          },
+          "extensions": {}
+        }
+  current:
+    - serviceName: service
+      request:
+        query: |
+          query nadel_2_service {
+            aField
+          }
+        variables: {}
+        operationName: nadel_2_service
+      # language=JSON
+      response: |-
+        {
+          "data": {
+            "aField": "1000"
+          },
+          "extensions": {}
+        }
+# language=JSON
+response: |-
+  {
+    "data": {
+      "aField": 1000
+    }
+  }

--- a/test/src/test/resources/fixtures/scalar coercing/coerce-values-basic-case.yml
+++ b/test/src/test/resources/fixtures/scalar coercing/coerce-values-basic-case.yml
@@ -1,4 +1,4 @@
-name: coerce values to overall types
+name: coerce values basic case
 enabled:
   current: true
   nextgen: true

--- a/test/src/test/resources/fixtures/scalar coercing/coerce-values-in-interfaces.yml
+++ b/test/src/test/resources/fixtures/scalar coercing/coerce-values-in-interfaces.yml
@@ -1,0 +1,100 @@
+name: coerce values in interfaces
+enabled:
+  current: true
+  nextgen: true
+overallSchema:
+  service: |
+    type Query {
+      user(id: ID!): User
+    }
+    interface User {
+      id: Int
+    }
+    type AccountUser implements User {
+      id: Int
+    }
+    type AdminUser implements User {
+      id: Int
+    }
+underlyingSchema:
+  service: |
+    type Query {
+      user(id: ID!): User
+    }
+    interface User {
+      id: Int
+    }
+    type AccountUser implements User {
+      id: Int
+    }
+    type AdminUser implements User {
+      id: Int
+    }
+query: |
+  query {
+    user(id: "1000") {
+      id
+    }
+  }
+variables: {}
+serviceCalls:
+  nextgen:
+    - serviceName: service
+      request:
+        query: |
+          query {
+            ... on Query {
+              user(id: "1000") {
+                ... on AccountUser {
+                  id
+                }
+                ... on AdminUser {
+                  id
+                }
+              }
+            }
+          }
+        variables: {}
+        operationName: null
+      # language=JSON
+      response: |-
+        {
+          "data": {
+            "user": {
+              "id": "1000"
+            }
+          },
+          "extensions": {}
+        }
+  current:
+    - serviceName: service
+      request:
+        query: |
+          query nadel_2_service {
+            user(id: "1000") {
+              id
+              type_hint_typename__UUID: __typename
+            }
+          }
+        variables: {}
+        operationName: nadel_2_service
+      # language=JSON
+      response: |-
+        {
+          "data": {
+            "user": {
+              "id": "1000",
+              "type_hint_typename__UUID": "AccountUser"
+            }
+          },
+          "extensions": {}
+        }
+# language=JSON
+response: |-
+  {
+    "data": {
+      "user": {
+        "id" : 1000
+      }
+    }
+  }

--- a/test/src/test/resources/fixtures/scalar coercing/coerce-values-in-interfaces.yml
+++ b/test/src/test/resources/fixtures/scalar coercing/coerce-values-in-interfaces.yml
@@ -11,7 +11,7 @@ overallSchema:
       id: Int
     }
     type AccountUser implements User {
-      id: Int
+      id: Int!
     }
     type AdminUser implements User {
       id: Int
@@ -25,7 +25,7 @@ underlyingSchema:
       id: Int
     }
     type AccountUser implements User {
-      id: Int
+      id: Int!
     }
     type AdminUser implements User {
       id: Int

--- a/test/src/test/resources/fixtures/scalar coercing/coerce-values-in-lists.yml
+++ b/test/src/test/resources/fixtures/scalar coercing/coerce-values-in-lists.yml
@@ -1,0 +1,63 @@
+name: coerce values in lists
+enabled:
+  current: true
+  nextgen: true
+overallSchema:
+  service: |
+    type Query {
+      listField: [Int!]!
+    }
+underlyingSchema:
+  service: |
+    type Query {
+      listField: [String!]!
+    }
+query: |
+  query {
+    listField
+  }
+variables: { }
+serviceCalls:
+  nextgen:
+    - serviceName: service
+      request:
+        query: |
+          query {
+            ... on Query {
+              listField
+            }
+          }
+        variables: { }
+        operationName: null
+      # language=JSON
+      response: |-
+        {
+          "data": {
+            "listField": ["1", "2", "3"]
+          },
+          "extensions": {}
+        }
+  current:
+    - serviceName: service
+      request:
+        query: |
+          query nadel_2_service {
+            listField
+          }
+        variables: { }
+        operationName: nadel_2_service
+      # language=JSON
+      response: |-
+        {
+          "data": {
+            "listField": ["1", "2", "3"]
+          },
+          "extensions": {}
+        }
+# language=JSON
+response: |-
+  {
+    "data": {
+      "listField": [1, 2, 3]
+    }
+  }

--- a/test/src/test/resources/fixtures/scalar coercing/coerce-values-non-null.yml
+++ b/test/src/test/resources/fixtures/scalar coercing/coerce-values-non-null.yml
@@ -1,0 +1,63 @@
+name: coerce values non null
+enabled:
+  current: true
+  nextgen: true
+overallSchema:
+  service: |
+    type Query {
+      aField: Int!
+    }
+underlyingSchema:
+  service: |
+    type Query {
+      aField: String!
+    }
+query: |
+  query {
+    aField
+  }
+variables: {}
+serviceCalls:
+  nextgen:
+    - serviceName: service
+      request:
+        query: |
+          query {
+            ... on Query {
+              aField
+            }
+          }
+        variables: {}
+        operationName: null
+      # language=JSON
+      response: |-
+        {
+          "data": {
+            "aField": "1000"
+          },
+          "extensions": {}
+        }
+  current:
+    - serviceName: service
+      request:
+        query: |
+          query nadel_2_service {
+            aField
+          }
+        variables: {}
+        operationName: nadel_2_service
+      # language=JSON
+      response: |-
+        {
+          "data": {
+            "aField": "1000"
+          },
+          "extensions": {}
+        }
+# language=JSON
+response: |-
+  {
+    "data": {
+      "aField": 1000
+    }
+  }

--- a/test/src/test/resources/fixtures/scalar coercing/coerce-values-with-alias.yml
+++ b/test/src/test/resources/fixtures/scalar coercing/coerce-values-with-alias.yml
@@ -1,0 +1,63 @@
+name: coerce values with alias
+enabled:
+  current: true
+  nextgen: true
+overallSchema:
+  service: |
+    type Query {
+      aField: Int!
+    }
+underlyingSchema:
+  service: |
+    type Query {
+      aField: String!
+    }
+query: |
+  query {
+    aFieldAliased: aField
+  }
+variables: {}
+serviceCalls:
+  nextgen:
+    - serviceName: service
+      request:
+        query: |
+          query {
+            ... on Query {
+              aFieldAliased: aField
+            }
+          }
+        variables: {}
+        operationName: null
+      # language=JSON
+      response: |-
+        {
+          "data": {
+            "aFieldAliased": "1000"
+          },
+          "extensions": {}
+        }
+  current:
+    - serviceName: service
+      request:
+        query: |
+          query nadel_2_service {
+            aFieldAliased: aField
+          }
+        variables: {}
+        operationName: nadel_2_service
+      # language=JSON
+      response: |-
+        {
+          "data": {
+            "aFieldAliased": "1000"
+          },
+          "extensions": {}
+        }
+# language=JSON
+response: |-
+  {
+    "data": {
+      "aFieldAliased": 1000
+    }
+  }

--- a/test/src/test/resources/fixtures/scalar coercing/coerce-values-with-renames.yml
+++ b/test/src/test/resources/fixtures/scalar coercing/coerce-values-with-renames.yml
@@ -1,0 +1,65 @@
+name: coerce values with renames
+enabled:
+  current: true
+  nextgen: true
+overallSchema:
+  service: |
+    type Query {
+      aFieldRenamed: Int! @renamed(from: "aField")
+    }
+underlyingSchema:
+  service: |
+    type Query {
+      aField: String!
+    }
+query: |
+  query {
+    aFieldRenamed
+  }
+variables: { }
+serviceCalls:
+  nextgen:
+    - serviceName: service
+      request:
+        query: |
+          query {
+            ... on Query {
+              rename__aFieldRenamed__aField: aField
+            }
+          }
+        variables: { }
+        operationName: null
+      # language=JSON
+      response: |-
+        {
+          "data": {
+            "rename__aFieldRenamed__aField": "1000"
+          },
+          "extensions": {}
+        }
+  current:
+    - serviceName: service
+      request:
+        query: |
+          query nadel_2_service {
+            aField
+          }
+        variables: { }
+        operationName: nadel_2_service
+      # language=JSON
+      response: |-
+        {
+          "data": {
+            "aField": "1000"
+          },
+          "extensions": {}
+        }
+# TODO: the returned data is not correct. The field is not being coerced to the overall type. But we'll leave
+# like this for now just to maintain the same behaviour for current and nextgen.
+# language=JSON
+response: |-
+  {
+    "data": {
+      "aFieldRenamed": "1000"
+    }
+  }


### PR DESCRIPTION
Current gen currently coerces the value of scalars using the type defined in the overall schema.

This PR reproduces this behaviour in Nextgen