### PR TITLE
Fix rename transform chaining

### DIFF
--- a/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/transform/NadelDeepRenameTransform.kt
+++ b/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/transform/NadelDeepRenameTransform.kt
@@ -69,7 +69,7 @@ internal class NadelDeepRenameTransform : NadelTransform<NadelDeepRenameTransfor
         /**
          * Stored for easy access in other functions.
          */
-        val field: ExecutableNormalizedField,
+        val overallField: ExecutableNormalizedField,
     )
 
     /**

--- a/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/transform/NadelRenameTransform.kt
+++ b/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/transform/NadelRenameTransform.kt
@@ -73,7 +73,7 @@ internal class NadelRenameTransform : NadelTransform<State> {
             } else {
                 null
             },
-            artificialFields = makeRenamedFields(state, transformer, executionBlueprint).let {
+            artificialFields = makeRenamedFields(state, transformer, field, executionBlueprint).let {
                 when (val typeNameField = makeTypeNameField(state)) {
                     null -> it
                     else -> it + typeNameField
@@ -108,6 +108,7 @@ internal class NadelRenameTransform : NadelTransform<State> {
     private suspend fun makeRenamedFields(
         state: State,
         transformer: NadelQueryTransformer.Continuation,
+        field: ExecutableNormalizedField,
         executionBlueprint: NadelOverallExecutionBlueprint,
     ): List<ExecutableNormalizedField> {
         return state.instructionsByObjectTypeNames.map { (typeName, instruction) ->
@@ -116,7 +117,7 @@ internal class NadelRenameTransform : NadelTransform<State> {
                 transformer,
                 executionBlueprint,
                 state.service,
-                state.overallField,
+                field,
                 typeName,
                 rename = instruction,
             )

--- a/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/transform/NadelRenameTransform.kt
+++ b/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/transform/NadelRenameTransform.kt
@@ -19,11 +19,16 @@ import graphql.nadel.enginekt.util.queryPath
 import graphql.nadel.enginekt.util.toBuilder
 import graphql.normalized.ExecutableNormalizedField
 import graphql.schema.FieldCoordinates
+import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.mapNotNull
+import kotlinx.coroutines.flow.toList
 
 internal class NadelRenameTransform : NadelTransform<State> {
     data class State(
         val instructionsByObjectTypeNames: Map<GraphQLObjectTypeName, NadelRenameFieldInstruction>,
-        val objectTypesWithoutRename: List<String>,
+        val objectTypesWithoutRename: Set<String>,
         val aliasHelper: NadelAliasHelper,
         val overallField: ExecutableNormalizedField,
         val service: Service,
@@ -42,9 +47,10 @@ internal class NadelRenameTransform : NadelTransform<State> {
             return null
         }
 
-        val objectsWithoutRename = overallField.objectTypeNames.filterNot {
-            it in renameInstructions
-        }
+        val objectsWithoutRename = overallField.objectTypeNames
+            .asSequence()
+            .filterNot { it in renameInstructions }
+            .toHashSet()
 
         return State(
             renameInstructions,
@@ -67,14 +73,14 @@ internal class NadelRenameTransform : NadelTransform<State> {
             newField = if (state.objectTypesWithoutRename.isNotEmpty()) {
                 field.toBuilder()
                     .clearObjectTypesNames()
-                    .objectTypeNames(state.objectTypesWithoutRename)
+                    .objectTypeNames(field.objectTypeNames.filter { it in state.objectTypesWithoutRename })
                     .children(transformer.transform(field.children))
                     .build()
             } else {
                 null
             },
             artificialFields = makeRenamedFields(state, transformer, field, executionBlueprint).let {
-                when (val typeNameField = makeTypeNameField(state)) {
+                when (val typeNameField = makeTypeNameField(state, field)) {
                     null -> it
                     else -> it + typeNameField
                 }
@@ -93,15 +99,17 @@ internal class NadelRenameTransform : NadelTransform<State> {
      */
     private fun makeTypeNameField(
         state: State,
+        field: ExecutableNormalizedField,
     ): ExecutableNormalizedField? {
         // No need for typename on top level field
         if (state.overallField.queryPath.size == 1) {
             return null
         }
 
+        val typeNamesWithInstructions = state.instructionsByObjectTypeNames.keys
         return NadelTransformUtil.makeTypeNameField(
             aliasHelper = state.aliasHelper,
-            objectTypeNames = state.instructionsByObjectTypeNames.keys.toList(),
+            objectTypeNames = field.objectTypeNames.filter { it in typeNamesWithInstructions },
         )
     }
 
@@ -111,17 +119,26 @@ internal class NadelRenameTransform : NadelTransform<State> {
         field: ExecutableNormalizedField,
         executionBlueprint: NadelOverallExecutionBlueprint,
     ): List<ExecutableNormalizedField> {
-        return state.instructionsByObjectTypeNames.map { (typeName, instruction) ->
-            makeRenamedField(
-                state,
-                transformer,
-                executionBlueprint,
-                state.service,
-                field,
-                typeName,
-                rename = instruction,
-            )
-        }
+        val setOfFieldObjectTypeNames = field.objectTypeNames.toSet()
+        return state.instructionsByObjectTypeNames
+            .asSequence()
+            .asFlow() // For coroutines
+            .filter { (typeName) ->
+                // Don't insert type renames for fields that were never asked for
+                typeName in setOfFieldObjectTypeNames
+            }
+            .map { (typeName, instruction) ->
+                makeRenamedField(
+                    state,
+                    transformer,
+                    executionBlueprint,
+                    state.service,
+                    field,
+                    typeName,
+                    rename = instruction,
+                )
+            }
+            .toList()
     }
 
     private suspend fun makeRenamedField(

--- a/test/src/test/kotlin/graphql/nadel/tests/hooks/chain-rename-transform.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/hooks/chain-rename-transform.kt
@@ -1,0 +1,86 @@
+package graphql.nadel.tests.hooks
+
+import graphql.language.EnumValue
+import graphql.language.StringValue
+import graphql.nadel.Service
+import graphql.nadel.ServiceExecutionResult
+import graphql.nadel.enginekt.NadelExecutionContext
+import graphql.nadel.enginekt.blueprint.NadelOverallExecutionBlueprint
+import graphql.nadel.enginekt.transform.NadelTransform
+import graphql.nadel.enginekt.transform.NadelTransformFieldResult
+import graphql.nadel.enginekt.transform.query.NadelQueryTransformer
+import graphql.nadel.enginekt.transform.result.NadelResultInstruction
+import graphql.nadel.enginekt.util.toBuilder
+import graphql.nadel.tests.EngineTestHook
+import graphql.nadel.tests.UseHook
+import graphql.normalized.ExecutableNormalizedField
+import graphql.normalized.NormalizedInputValue
+
+private class ChainRenameTransform : NadelTransform<Any> {
+    override suspend fun isApplicable(
+        executionContext: NadelExecutionContext,
+        executionBlueprint: NadelOverallExecutionBlueprint,
+        services: Map<String, Service>,
+        service: Service,
+        overallField: ExecutableNormalizedField,
+    ): Any? {
+        return overallField.takeIf { it.name == "test" || it.name == "cities" }
+    }
+
+    override suspend fun transformField(
+        executionContext: NadelExecutionContext,
+        transformer: NadelQueryTransformer.Continuation,
+        executionBlueprint: NadelOverallExecutionBlueprint,
+        service: Service,
+        field: ExecutableNormalizedField,
+        state: Any,
+    ): NadelTransformFieldResult {
+        if (field.normalizedArguments["arg"] != null) {
+            return NadelTransformFieldResult(
+                newField = field.toBuilder()
+                    .normalizedArguments(field.normalizedArguments.let {
+                        it + ("arg" to NormalizedInputValue("String", StringValue("aaarrg")))
+                    })
+                    .build(),
+            )
+        }
+
+        if (field.normalizedArguments["continent"] != null) {
+            return NadelTransformFieldResult(
+                newField = field.toBuilder()
+                    .normalizedArguments(field.normalizedArguments.let {
+                        it + ("continent" to NormalizedInputValue("Continent", EnumValue("Asia")))
+                    })
+                    .build(),
+            )
+        }
+
+        error("Did not match transform conditions")
+    }
+
+    override suspend fun getResultInstructions(
+        executionContext: NadelExecutionContext,
+        executionBlueprint: NadelOverallExecutionBlueprint,
+        service: Service,
+        overallField: ExecutableNormalizedField,
+        underlyingParentField: ExecutableNormalizedField?,
+        result: ServiceExecutionResult,
+        state: Any,
+    ): List<NadelResultInstruction> {
+        return emptyList()
+    }
+}
+
+@UseHook
+class `chain-rename-transform` : EngineTestHook {
+    override val customTransforms: List<NadelTransform<Any>> = listOf(
+        ChainRenameTransform(),
+    )
+}
+
+@UseHook
+class `chain-rename-transform-with-type-rename` : EngineTestHook {
+    override val customTransforms: List<NadelTransform<Any>> = listOf(
+        ChainRenameTransform(),
+    )
+}

--- a/test/src/test/resources/fixtures/renames/chain-rename-transform-with-type-rename.yml
+++ b/test/src/test/resources/fixtures/renames/chain-rename-transform-with-type-rename.yml
@@ -1,0 +1,98 @@
+name: chain rename transform with type rename
+enabled:
+  current: false
+  nextgen: true
+overallSchema:
+  MyService: |
+    type Query {
+      test(arg: String): Test @renamed(from: "world")
+    }
+    type Test @renamed(from: "World") {
+      id: ID
+      cities(continent: Continent): [String] @renamed(from: "places")
+    }
+    enum Continent {
+      Africa
+      Antarctica
+      Asia
+      Oceania
+      Europe
+      NorthAmerica
+      SouthAmerica
+    }
+underlyingSchema:
+  MyService: |
+    type Query {
+      world(arg: String): World
+    }
+    type World {
+      id: ID
+      places(continent: Continent): [String]
+    }
+    enum Continent {
+      Africa
+      Antarctica
+      Asia
+      Oceania
+      Europe
+      NorthAmerica
+      SouthAmerica
+    }
+# So the hook associated with this test will change the arg values
+query: |
+  query {
+    test(arg: "Hello World") {
+      __typename
+      id
+      cities(continent: Oceania)
+    }
+  }
+variables: {}
+serviceCalls:
+  nextgen:
+    - serviceName: MyService
+      request:
+        # Notice the changed values to "aaarrg" and "Asia"
+        query: |
+          query {
+            ... on Query {
+              rename__test__world: world(arg: "aaarrg") {
+                ... on World {
+                  __typename
+                  __typename__rename__cities: __typename
+                  id
+                  rename__cities__places: places(continent: Asia)
+                }
+              }
+            }
+          }
+        variables: {}
+        operationName: null
+      # language=JSON
+      response: |-
+        {
+          "data": {
+            "rename__test__world": {
+              "__typename": "World",
+              "__typename__rename__cities": "World",
+              "id": "Earth",
+              "rename__cities__places": ["Uhh yea I know cities"]
+            }
+          },
+          "extensions": {}
+        }
+# language=JSON
+response: |-
+  {
+    "data": {
+      "test": {
+        "__typename": "Test",
+        "id": "Earth",
+        "cities": [
+          "Uhh yea I know cities"
+        ]
+      }
+    },
+    "errors": []
+  }
+

--- a/test/src/test/resources/fixtures/renames/chain-rename-transform.yml
+++ b/test/src/test/resources/fixtures/renames/chain-rename-transform.yml
@@ -1,0 +1,98 @@
+name: chain rename transform
+enabled:
+  current: false
+  nextgen: true
+overallSchema:
+  MyService: |
+    type Query {
+      test(arg: String): World @renamed(from: "world")
+    }
+    type World {
+      id: ID
+      cities(continent: Continent): [String] @renamed(from: "places")
+    }
+    enum Continent {
+      Africa
+      Antarctica
+      Asia
+      Oceania
+      Europe
+      NorthAmerica
+      SouthAmerica
+    }
+underlyingSchema:
+  MyService: |
+    type Query {
+      world(arg: String): World
+    }
+    type World {
+      id: ID
+      places(continent: Continent): [String]
+    }
+    enum Continent {
+      Africa
+      Antarctica
+      Asia
+      Oceania
+      Europe
+      NorthAmerica
+      SouthAmerica
+    }
+# So the hook associated with this test will change the arg values
+query: |
+  query {
+    test(arg: "Hello World") {
+      __typename
+      id
+      cities(continent: Oceania)
+    }
+  }
+variables: {}
+serviceCalls:
+  nextgen:
+    - serviceName: MyService
+      request:
+        # Notice the changed values to "aaarrg" and "Asia"
+        query: |
+          query {
+            ... on Query {
+              rename__test__world: world(arg: "aaarrg") {
+                ... on World {
+                  __typename
+                  __typename__rename__cities: __typename
+                  id
+                  rename__cities__places: places(continent: Asia)
+                }
+              }
+            }
+          }
+        variables: {}
+        operationName: null
+      # language=JSON
+      response: |-
+        {
+          "data": {
+            "rename__test__world": {
+              "__typename": "World",
+              "__typename__rename__cities": "World",
+              "id": "Earth",
+              "rename__cities__places": ["Uhh yea I know cities"]
+            }
+          },
+          "extensions": {}
+        }
+# language=JSON
+response: |-
+  {
+    "data": {
+      "test": {
+        "__typename": "World",
+        "id": "Earth",
+        "cities": [
+          "Uhh yea I know cities"
+        ]
+      }
+    },
+    "errors": []
+  }
+

--- a/test/src/test/resources/fixtures/renames/rename-on-shared-abstract-type.yml
+++ b/test/src/test/resources/fixtures/renames/rename-on-shared-abstract-type.yml
@@ -1,0 +1,86 @@
+name: rename on shared abstract type
+enabled:
+  current: false
+  nextgen: true
+overallSchema:
+  shared: |
+    interface Node {
+      id: ID!
+    }
+  worlds: |
+    type Query {
+      node(id: ID): [Node]
+    }
+    type World implements Node {
+      id: ID!
+    }
+  planets: |
+    type Planet implements Node {
+      id: ID! @renamed(from: "identifier")
+    }
+underlyingSchema:
+  planets: |
+    type Query {
+      echo: String
+    }
+    type Planet {
+      identifier: String
+    }
+  worlds: |
+    type Query {
+      worlds: [World]
+    }
+    type World {
+      id: ID!
+    }
+  shared: |
+    type Query {
+      echo: String
+    }
+# Bug is that normally the rename transform will transform based on the
+# possible instructions. This field will go to the worlds service but the
+# rename transform may insert ... on Planet { rename_id: identifier } as it
+# sees it as a possibility if it hasn't worked on the new filtered types
+query: |
+  query {
+    node(id: "world-1") {
+      id
+    }
+  }
+variables: {}
+serviceCalls:
+  nextgen:
+    - serviceName: worlds
+      request:
+        query: |
+          query {
+            ... on Query {
+              node(id: "world-1") {
+                ... on World {
+                  id
+                }
+              }
+            }
+          }
+        variables: {}
+        operationName: null
+      # language=JSON
+      response: |-
+        {
+          "data": {
+            "node": {
+              "id": "Test"
+            }
+          },
+          "extensions": {}
+        }
+# language=JSON
+response: |-
+  {
+    "data": {
+      "node": {
+        "id": "Test"
+      }
+    },
+    "extensions": {}
+  }


### PR DESCRIPTION
This transform was made a long time ago before we had transform chaining in mind. What it does is it just takes the overall field and renames it. But it doesn't take into consideration the new field from transformations before it.

We will actually have a similar issue with hydrations. Will fix that in another PR.

Please make sure you consider the following:

- [X] Add tests that use __typename in queries
- [X] Does this change work with all nadel transformations (rename, type rename, hydration, etc)? Add tests for this.
- [X] Is it worth using hints for this change in order to be able to enable a percentage rollout?
No
- [ ] Do we need to add integration tests for this change in the graphql gateway?
Yes, will add
- [X] Do we need a pollinator check for this?
No
