### PR TITLE
log level debug for master build and publish

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -20,4 +20,4 @@ jobs:
         with:
           java-version: '11.0.9'
       - name: build test and publish
-        run: ./gradlew assemble && ./gradlew check --info && ./gradlew artifactoryPublish -x check --info
+        run: ./gradlew assemble && ./gradlew check --info && ./gradlew artifactoryPublish -x check --debug


### PR DESCRIPTION
a thing to note is: gradle does not recommend running with debug on public ci/cd builds https://docs.gradle.org/7.1/userguide/logging.html#sec:debug_security