### PR TITLE
Delete IncompatibleFieldOutputTypeName for IncompatibleFieldOutputType

### DIFF
--- a/engine-nextgen/src/main/kotlin/graphql/nadel/validation/NadelRenameValidation.kt
+++ b/engine-nextgen/src/main/kotlin/graphql/nadel/validation/NadelRenameValidation.kt
@@ -1,6 +1,5 @@
 package graphql.nadel.validation
 
-import graphql.nadel.Service
 import graphql.nadel.enginekt.util.getFieldAt
 import graphql.nadel.validation.NadelSchemaUtil.getRename
 import graphql.nadel.validation.NadelSchemaUtil.hasHydration

--- a/engine-nextgen/src/main/kotlin/graphql/nadel/validation/NadelSchemaValidationError.kt
+++ b/engine-nextgen/src/main/kotlin/graphql/nadel/validation/NadelSchemaValidationError.kt
@@ -88,25 +88,6 @@ sealed interface NadelSchemaValidationError {
         override val subject = duplicates.first().overall
     }
 
-    data class IncompatibleFieldOutputTypeName(
-        val parentType: NadelServiceSchemaElement,
-        val overallField: GraphQLFieldDefinition,
-        val underlyingField: GraphQLFieldDefinition,
-    ) : NadelSchemaValidationError {
-        val service: Service get() = parentType.service
-
-        override val message = run {
-            val s = parentType.service.name
-            val of = makeFieldCoordinates(parentType.overall.name, overallField.name)
-            val uf = makeFieldCoordinates(parentType.underlying.name, underlyingField.name)
-            val ot = overallField.type.unwrapAll().name
-            val ut = underlyingField.type.unwrapAll().name
-            "Overall field $of has output type name $ot but underlying field $uf in service $s has output type name $ut"
-        }
-
-        override val subject = overallField
-    }
-
     data class IncompatibleFieldOutputType(
         val parentType: NadelServiceSchemaElement,
         val overallField: GraphQLFieldDefinition,

--- a/engine-nextgen/src/test/kotlin/graphql/nadel/validation/NadelRenameValidationTest.kt
+++ b/engine-nextgen/src/test/kotlin/graphql/nadel/validation/NadelRenameValidationTest.kt
@@ -3,7 +3,7 @@ package graphql.nadel.validation
 import graphql.nadel.enginekt.util.singleOfType
 import graphql.nadel.enginekt.util.unwrapAll
 import graphql.nadel.validation.NadelSchemaValidationError.DuplicatedUnderlyingType
-import graphql.nadel.validation.NadelSchemaValidationError.IncompatibleFieldOutputTypeName
+import graphql.nadel.validation.NadelSchemaValidationError.IncompatibleFieldOutputType
 import graphql.nadel.validation.NadelSchemaValidationError.MissingRename
 import graphql.nadel.validation.NadelSchemaValidationError.MissingUnderlyingType
 import io.kotest.core.spec.style.DescribeSpec
@@ -208,7 +208,7 @@ class NadelRenameValidationTest : DescribeSpec({
             val errors = validate(fixture)
             assert(errors.map { it.message }.isNotEmpty())
 
-            val incompatibleTypeName = errors.singleOfType<IncompatibleFieldOutputTypeName>()
+            val incompatibleTypeName = errors.singleOfType<IncompatibleFieldOutputType>()
             assert(incompatibleTypeName.parentType.overall.name == "Query")
             assert(incompatibleTypeName.parentType.underlying.name == "Query")
             assert(incompatibleTypeName.overallField.type.unwrapAll().name == "Test")

--- a/engine-nextgen/src/test/kotlin/graphql/nadel/validation/NadelTypeValidationTest.kt
+++ b/engine-nextgen/src/test/kotlin/graphql/nadel/validation/NadelTypeValidationTest.kt
@@ -3,7 +3,6 @@ package graphql.nadel.validation
 import graphql.nadel.enginekt.util.singleOfType
 import graphql.nadel.validation.NadelSchemaValidationError.DuplicatedUnderlyingType
 import graphql.nadel.validation.NadelSchemaValidationError.IncompatibleFieldOutputType
-import graphql.nadel.validation.NadelSchemaValidationError.IncompatibleFieldOutputTypeName
 import graphql.nadel.validation.NadelSchemaValidationError.IncompatibleType
 import graphql.nadel.validation.NadelSchemaValidationError.MissingUnderlyingField
 import io.kotest.core.spec.style.DescribeSpec
@@ -421,7 +420,7 @@ class NadelTypeValidationTest : DescribeSpec({
             val errors = validate(fixture)
             assert(errors.map { it.message }.isNotEmpty())
 
-            val error = errors.singleOfType<IncompatibleFieldOutputTypeName>()
+            val error = errors.singleOfType<IncompatibleFieldOutputType>()
             assert(error.parentType.overall.name == "Echo")
             assert(error.parentType.underlying.name == "Echo")
             assert(error.overallField.name == "world")


### PR DESCRIPTION
This type was basically duplicated.

The idea was one error was for issues about type wrappings, and one about the type name being wrong. But funnily enough the former inadvertently covered the latter. So I'm removing the latter.