### PR TITLE
allow polymorphic hydration hook return null

### DIFF
--- a/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/NadelEngineExecutionHooks.kt
+++ b/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/NadelEngineExecutionHooks.kt
@@ -8,5 +8,5 @@ interface NadelEngineExecutionHooks : ServiceExecutionHooks {
     fun <T : NadelGenericHydrationInstruction> getHydrationInstruction(
         instructions: List<T>,
         parentNode: JsonNode
-    ): T
+    ): T?
 }

--- a/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/transform/hydration/NadelHydrationTransform.kt
+++ b/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/transform/hydration/NadelHydrationTransform.kt
@@ -162,6 +162,7 @@ internal class NadelHydrationTransform(
         }
 
         val instruction = getHydrationFieldInstruction(instructions, executionContext.hooks, parentNode)
+            ?: return listOf(NadelResultInstruction.Set(parentNode.resultPath + state.hydratedField.fieldName, null))
 
         val actorQueryResults = coroutineScope {
             NadelHydrationFieldsBuilder.makeActorQueries(
@@ -176,7 +177,7 @@ internal class NadelHydrationTransform(
                         topLevelField = actorQuery,
                         pathToActorField = instruction.queryPathToActorField,
                         executionContext = executionContext,
-                        serviceHydrationDetails = ServiceExecutionHydrationDetails(instruction.timeout,1)
+                        serviceHydrationDetails = ServiceExecutionHydrationDetails(instruction.timeout, 1)
                     )
                 }
             }.awaitAll()
@@ -227,7 +228,7 @@ internal class NadelHydrationTransform(
         instructions: List<NadelHydrationFieldInstruction>,
         hooks: ServiceExecutionHooks,
         parentNode: JsonNode
-    ): NadelHydrationFieldInstruction {
+    ): NadelHydrationFieldInstruction? {
         return when (instructions.size) {
             1 -> instructions.single()
             else -> {
@@ -236,7 +237,7 @@ internal class NadelHydrationTransform(
                 } else {
                     error(
                         "Cannot decide which hydration instruction should be used. Provided ServiceExecutionHooks has " +
-                                "to be of type NadelEngineExecutionHooks"
+                            "to be of type NadelEngineExecutionHooks"
                     )
                 }
             }

--- a/test/src/test/kotlin/graphql/nadel/tests/hooks/polymorphic-hydration-hooks.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/hooks/polymorphic-hydration-hooks.kt
@@ -15,7 +15,7 @@ private class PolymorphicHydrationHooks : NadelEngineExecutionHooks {
     override fun <T : NadelGenericHydrationInstruction> getHydrationInstruction(
         instructions: List<T>,
         parentNode: JsonNode
-    ): T {
+    ): T? {
 
         val dataIdFieldName = if (instructions.any { it is NadelHydrationFieldInstruction })
             "hydration__data__dataId"
@@ -25,9 +25,10 @@ private class PolymorphicHydrationHooks : NadelEngineExecutionHooks {
             .value as String
         val actorFieldName = when {
             dataIdValue.startsWith("human", ignoreCase = true) -> "humanById"
+            dataIdValue.startsWith("null", ignoreCase = true) -> null
             else -> "petById"
         }
-        return instructions.single { it.actorFieldDef.name == actorFieldName }
+        return instructions.singleOrNull { it.actorFieldDef.name == actorFieldName }
     }
 }
 
@@ -68,6 +69,27 @@ class `batch-polymorphic-hydration-with-rename` : EngineTestHook {
 
 @UseHook
 class `batch-polymorphic-hydration-where-only-one-type-is-queried` : EngineTestHook {
+    override fun makeNadel(engineType: NadelEngineType, builder: Nadel.Builder): Nadel.Builder {
+        return builder.serviceExecutionHooks(PolymorphicHydrationHooks())
+    }
+}
+
+@UseHook
+class `batch-polymorphic-hydration-when-hook-returns-null` : EngineTestHook {
+    override fun makeNadel(engineType: NadelEngineType, builder: Nadel.Builder): Nadel.Builder {
+        return builder.serviceExecutionHooks(PolymorphicHydrationHooks())
+    }
+}
+
+@UseHook
+class `batch-polymorphic-hydration-when-hook-returns-null-1` : EngineTestHook {
+    override fun makeNadel(engineType: NadelEngineType, builder: Nadel.Builder): Nadel.Builder {
+        return builder.serviceExecutionHooks(PolymorphicHydrationHooks())
+    }
+}
+
+@UseHook
+class `solitary-polymorphic-hydration-when-hook-returns-null` : EngineTestHook {
     override fun makeNadel(engineType: NadelEngineType, builder: Nadel.Builder): Nadel.Builder {
         return builder.serviceExecutionHooks(PolymorphicHydrationHooks())
     }

--- a/test/src/test/kotlin/graphql/nadel/tests/hooks/polymorphic-hydration-hooks.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/hooks/polymorphic-hydration-hooks.kt
@@ -32,65 +32,35 @@ private class PolymorphicHydrationHooks : NadelEngineExecutionHooks {
     }
 }
 
-@UseHook
-class `solitary-polymorphic-hydration` : EngineTestHook {
+open class PolymorphicHydrationTestHook : EngineTestHook {
     override fun makeNadel(engineType: NadelEngineType, builder: Nadel.Builder): Nadel.Builder {
         return builder.serviceExecutionHooks(PolymorphicHydrationHooks())
     }
 }
 
 @UseHook
-class `batch-polymorphic-hydration` : EngineTestHook {
-    override fun makeNadel(engineType: NadelEngineType, builder: Nadel.Builder): Nadel.Builder {
-        return builder.serviceExecutionHooks(PolymorphicHydrationHooks())
-    }
-}
+class `solitary-polymorphic-hydration` : PolymorphicHydrationTestHook() {}
 
 @UseHook
-class `batch-polymorphic-hydration-with-interfaces` : EngineTestHook {
-    override fun makeNadel(engineType: NadelEngineType, builder: Nadel.Builder): Nadel.Builder {
-        return builder.serviceExecutionHooks(PolymorphicHydrationHooks())
-    }
-}
+class `batch-polymorphic-hydration` : PolymorphicHydrationTestHook() {}
 
 @UseHook
-class `batch-polymorphic-hydration-with-unions` : EngineTestHook {
-    override fun makeNadel(engineType: NadelEngineType, builder: Nadel.Builder): Nadel.Builder {
-        return builder.serviceExecutionHooks(PolymorphicHydrationHooks())
-    }
-}
+class `batch-polymorphic-hydration-with-interfaces` : PolymorphicHydrationTestHook() {}
 
 @UseHook
-class `batch-polymorphic-hydration-with-rename` : EngineTestHook {
-    override fun makeNadel(engineType: NadelEngineType, builder: Nadel.Builder): Nadel.Builder {
-        return builder.serviceExecutionHooks(PolymorphicHydrationHooks())
-    }
-}
+class `batch-polymorphic-hydration-with-unions` : PolymorphicHydrationTestHook() {}
 
 @UseHook
-class `batch-polymorphic-hydration-where-only-one-type-is-queried` : EngineTestHook {
-    override fun makeNadel(engineType: NadelEngineType, builder: Nadel.Builder): Nadel.Builder {
-        return builder.serviceExecutionHooks(PolymorphicHydrationHooks())
-    }
-}
+class `batch-polymorphic-hydration-with-rename` : PolymorphicHydrationTestHook() {}
 
 @UseHook
-class `batch-polymorphic-hydration-when-hook-returns-null` : EngineTestHook {
-    override fun makeNadel(engineType: NadelEngineType, builder: Nadel.Builder): Nadel.Builder {
-        return builder.serviceExecutionHooks(PolymorphicHydrationHooks())
-    }
-}
+class `batch-polymorphic-hydration-where-only-one-type-is-queried` : PolymorphicHydrationTestHook() {}
 
 @UseHook
-class `batch-polymorphic-hydration-when-hook-returns-null-1` : EngineTestHook {
-    override fun makeNadel(engineType: NadelEngineType, builder: Nadel.Builder): Nadel.Builder {
-        return builder.serviceExecutionHooks(PolymorphicHydrationHooks())
-    }
-}
+class `batch-polymorphic-hydration-when-hook-returns-null` : PolymorphicHydrationTestHook() {}
 
 @UseHook
-class `solitary-polymorphic-hydration-when-hook-returns-null` : EngineTestHook {
-    override fun makeNadel(engineType: NadelEngineType, builder: Nadel.Builder): Nadel.Builder {
-        return builder.serviceExecutionHooks(PolymorphicHydrationHooks())
-    }
-}
+class `batch-polymorphic-hydration-when-hook-returns-null-1` : PolymorphicHydrationTestHook() {}
+
+@UseHook
+class `solitary-polymorphic-hydration-when-hook-returns-null` : PolymorphicHydrationTestHook() {}

--- a/test/src/test/resources/fixtures/hydration/polymorphic hydrations/batch-polymorphic-hydration-when-hook-returns-null-1.yml
+++ b/test/src/test/resources/fixtures/hydration/polymorphic hydrations/batch-polymorphic-hydration-when-hook-returns-null-1.yml
@@ -1,0 +1,267 @@
+name: batch polymorphic hydration when hook returns null 1
+enabled:
+  current: false
+  nextgen: true
+overallSchema:
+  pets: |
+    type Query {
+      petById(ids: [ID]): [Pet]
+    }
+
+    type Pet {
+      id: ID
+      breed: String
+    }
+  people: |
+    type Query {
+      humanById(ids: [ID]): [Human]
+    }
+
+    type Human {
+      id: ID
+      name: String
+    }
+  foo: |
+    type Query {
+      foo: [Foo]
+    }
+
+    type Foo {
+      id: ID
+      dataId: ID
+      data: Data
+      @hydrated(
+        service: "pets"
+        field: "petById"
+        arguments: [
+          {name: "ids" value: "$source.dataId"}
+        ]
+      )
+      @hydrated(
+        service: "people"
+        field: "humanById"
+        arguments: [
+          {name: "ids" value: "$source.dataId"}
+        ]
+      )
+    }
+
+    union Data = Pet | Human
+underlyingSchema:
+  pets: |
+    type Query {
+      petById(ids: [ID]): [Pet]
+    }
+
+    type Pet {
+      id: ID
+      breed: String
+    }
+  people: |
+    type Query {
+      humanById(ids: [ID]): [Human]
+    }
+
+    type Human {
+      id: ID
+      name: String
+    }
+  foo: |
+    type Query {
+      foo: [Foo]
+    }
+
+    type Foo {
+      id: ID
+      dataId: ID
+    }
+
+query: |
+  query {
+    foo {
+      __typename
+      id
+      data {
+        ... on Pet {
+          __typename
+          id
+          breed
+        }
+        ... on Human {
+          __typename
+          id
+          name
+        }
+      }
+    }
+  }
+variables: { }
+serviceCalls:
+  nextgen:
+    - serviceName: foo
+      request:
+        query: |
+          query {
+            ... on Query {
+              foo {
+                ... on Foo {
+                  __typename
+                  __typename__batch_hydration__data: __typename
+                  batch_hydration__data__dataId: dataId
+                  batch_hydration__data__dataId: dataId
+                  id
+                }
+              }
+            }
+          }
+        variables: { }
+        operationName: null
+      # language=JSON
+      response: |-
+        {
+          "data": {
+            "foo": [{
+              "__typename": "Foo",
+              "__typename__batch_hydration__data": "Foo",
+              "batch_hydration__data__dataId": "PET-0",
+              "batch_hydration__data__dataId": "PET-0",
+              "id": "FOO-0"
+            }, {
+              "__typename": "Foo",
+              "__typename__batch_hydration__data": "Foo",
+              "batch_hydration__data__dataId": "HUMAN-0",
+              "batch_hydration__data__dataId": "HUMAN-0",
+              "id": "FOO-1"
+            }, {
+              "__typename": "Foo",
+              "__typename__batch_hydration__data": "Foo",
+              "batch_hydration__data__dataId": "NULL-1",
+              "batch_hydration__data__dataId": "NULL-1",
+              "id": "FOO-2"
+            }, {
+              "__typename": "Foo",
+              "__typename__batch_hydration__data": "Foo",
+              "batch_hydration__data__dataId": "HUMAN-1",
+              "batch_hydration__data__dataId": "HUMAN-1",
+              "id": "FOO-3"
+            } ]
+          },
+          "extensions": {}
+        }
+    - serviceName: pets
+      request:
+        query: |
+          query {
+            ... on Query {
+              petById(ids: ["PET-0"]) {
+                ... on Pet {
+                  __typename
+                  __typename__type_filter____typename: __typename
+                  __typename__type_filter__id: __typename
+                  __typename__type_filter__name: __typename
+                  breed
+                  id
+                  batch_hydration__data__id: id
+                }
+              }
+            }
+          }
+        variables: { }
+        operationName: null
+      # language=JSON
+      response: |-
+        {
+          "data": {
+            "petById": [{
+              "__typename": "Pet",
+              "__typename__type_filter____typename": "Pet",
+              "__typename__type_filter__id": "Pet",
+              "__typename__type_filter__name": "Pet",
+              "breed": "Akita",
+              "id": "PET-0",
+              "batch_hydration__data__id": "PET-0"
+            }]
+          },
+          "extensions": {}
+        }
+    - serviceName: people
+      request:
+        query: |
+          query {
+            ... on Query {
+              humanById(ids: ["HUMAN-0", "HUMAN-1"]) {
+                ... on Human {
+                  __typename__type_filter____typename: __typename
+                  __typename
+                  __typename__type_filter__id: __typename
+                  __typename__type_filter__breed: __typename
+                  id
+                  batch_hydration__data__id: id
+                  name
+                }
+              }
+            }
+          }
+        variables: { }
+        operationName: null
+      # language=JSON
+      response: |-
+        {
+          "data": {
+            "humanById": [{
+              "__typename__type_filter____typename": "Human",
+              "__typename": "Human",
+              "__typename__type_filter__id": "Human",
+              "__typename__type_filter__breed": "Human",
+              "id": "HUMAN-0",
+              "batch_hydration__data__id": "HUMAN-0",
+              "name": "Fanny Longbottom"
+            },
+            {
+              "__typename__type_filter____typename": "Human",
+              "__typename": "Human",
+              "__typename__type_filter__id": "Human",
+              "__typename__type_filter__breed": "Human",
+              "id": "HUMAN-1",
+              "batch_hydration__data__id": "HUMAN-1",
+              "name": "John Doe"
+            }]
+          },
+          "extensions": {}
+        }
+# language=JSON
+response: |-
+  {
+    "data": {
+      "foo": [{
+        "__typename": "Foo",
+        "id": "FOO-0",
+        "data" : {
+          "__typename": "Pet",
+          "id": "PET-0",
+          "breed": "Akita"
+        }
+      }, {
+        "__typename": "Foo",
+        "id": "FOO-1",
+        "data": {
+          "__typename": "Human",
+          "id": "HUMAN-0",
+          "name": "Fanny Longbottom"
+        }
+      }, {
+        "__typename": "Foo",
+        "id": "FOO-2",
+        "data": null
+      }, {
+        "__typename": "Foo",
+        "id": "FOO-3",
+        "data": {
+          "__typename": "Human",
+          "id": "HUMAN-1",
+          "name": "John Doe"
+        }
+      }]
+    },
+    "extensions": {}
+  }

--- a/test/src/test/resources/fixtures/hydration/polymorphic hydrations/batch-polymorphic-hydration-when-hook-returns-null.yml
+++ b/test/src/test/resources/fixtures/hydration/polymorphic hydrations/batch-polymorphic-hydration-when-hook-returns-null.yml
@@ -1,0 +1,227 @@
+name: batch polymorphic hydration when hook returns null
+enabled:
+  current: false
+  nextgen: true
+overallSchema:
+  pets: |
+    type Query {
+      petById(ids: [ID]): [Pet]
+    }
+
+    type Pet {
+      id: ID
+      breed: String
+    }
+  people: |
+    type Query {
+      humanById(ids: [ID]): [Human]
+    }
+
+    type Human {
+      id: ID
+      name: String
+    }
+  foo: |
+    type Query {
+      foo: [Foo]
+    }
+
+    type Foo {
+      id: ID
+      dataId: ID
+      data: Data
+      @hydrated(
+        service: "pets"
+        field: "petById"
+        arguments: [
+          {name: "ids" value: "$source.dataId"}
+        ]
+      )
+      @hydrated(
+        service: "people"
+        field: "humanById"
+        arguments: [
+          {name: "ids" value: "$source.dataId"}
+        ]
+      )
+    }
+
+    union Data = Pet | Human
+underlyingSchema:
+  pets: |
+    type Query {
+      petById(ids: [ID]): [Pet]
+    }
+
+    type Pet {
+      id: ID
+      breed: String
+    }
+  people: |
+    type Query {
+      humanById(ids: [ID]): [Human]
+    }
+
+    type Human {
+      id: ID
+      name: String
+    }
+  foo: |
+    type Query {
+      foo: [Foo]
+    }
+
+    type Foo {
+      id: ID
+      dataId: ID
+    }
+
+query: |
+  query {
+    foo {
+      __typename
+      id
+      data {
+        ... on Pet {
+          __typename
+          id
+          breed
+        }
+        ... on Human {
+          __typename
+          id
+          name
+        }
+      }
+    }
+  }
+variables: { }
+serviceCalls:
+  nextgen:
+    - serviceName: foo
+      request:
+        query: |
+          query {
+            ... on Query {
+              foo {
+                ... on Foo {
+                  __typename
+                  __typename__batch_hydration__data: __typename
+                  batch_hydration__data__dataId: dataId
+                  batch_hydration__data__dataId: dataId
+                  id
+                }
+              }
+            }
+          }
+        variables: { }
+        operationName: null
+      # language=JSON
+      response: |-
+        {
+          "data": {
+            "foo": [{
+              "__typename": "Foo",
+              "__typename__batch_hydration__data": "Foo",
+              "batch_hydration__data__dataId": "NULL-0",
+              "batch_hydration__data__dataId": "NULL-0",
+              "id": "FOO-0"
+            }, {
+              "__typename": "Foo",
+              "__typename__batch_hydration__data": "Foo",
+              "batch_hydration__data__dataId": "HUMAN-0",
+              "batch_hydration__data__dataId": "HUMAN-0",
+              "id": "FOO-1"
+            }, {
+              "__typename": "Foo",
+              "__typename__batch_hydration__data": "Foo",
+              "batch_hydration__data__dataId": "NULL-1",
+              "batch_hydration__data__dataId": "NULL-1",
+              "id": "FOO-2"
+            }, {
+              "__typename": "Foo",
+              "__typename__batch_hydration__data": "Foo",
+              "batch_hydration__data__dataId": "HUMAN-1",
+              "batch_hydration__data__dataId": "HUMAN-1",
+              "id": "FOO-3"
+            } ]
+          },
+          "extensions": {}
+        }
+    - serviceName: people
+      request:
+        query: |
+          query {
+            ... on Query {
+              humanById(ids: ["HUMAN-0", "HUMAN-1"]) {
+                ... on Human {
+                  __typename__type_filter____typename: __typename
+                  __typename
+                  __typename__type_filter__id: __typename
+                  __typename__type_filter__breed: __typename
+                  id
+                  batch_hydration__data__id: id
+                  name
+                }
+              }
+            }
+          }
+        variables: { }
+        operationName: null
+      # language=JSON
+      response: |-
+        {
+          "data": {
+            "humanById": [{
+              "__typename__type_filter____typename": "Human",
+              "__typename": "Human",
+              "__typename__type_filter__id": "Human",
+              "__typename__type_filter__breed": "Human",
+              "id": "HUMAN-0",
+              "batch_hydration__data__id": "HUMAN-0",
+              "name": "Fanny Longbottom"
+            },
+            {
+              "__typename__type_filter____typename": "Human",
+              "__typename": "Human",
+              "__typename__type_filter__id": "Human",
+              "__typename__type_filter__breed": "Human",
+              "id": "HUMAN-1",
+              "batch_hydration__data__id": "HUMAN-1",
+              "name": "John Doe"
+            }]
+          },
+          "extensions": {}
+        }
+# language=JSON
+response: |-
+  {
+    "data": {
+      "foo": [{
+        "__typename": "Foo",
+        "id": "FOO-0",
+        "data" : null
+      }, {
+        "__typename": "Foo",
+        "id": "FOO-1",
+        "data": {
+          "__typename": "Human",
+          "id": "HUMAN-0",
+          "name": "Fanny Longbottom"
+        }
+      }, {
+        "__typename": "Foo",
+        "id": "FOO-2",
+        "data" : null
+      }, {
+        "__typename": "Foo",
+        "id": "FOO-3",
+        "data": {
+          "__typename": "Human",
+          "id": "HUMAN-1",
+          "name": "John Doe"
+        }
+      }]
+    },
+    "extensions": {}
+  }

--- a/test/src/test/resources/fixtures/hydration/polymorphic hydrations/solitary-polymorphic-hydration-when-hook-returns-null.yml
+++ b/test/src/test/resources/fixtures/hydration/polymorphic hydrations/solitary-polymorphic-hydration-when-hook-returns-null.yml
@@ -1,0 +1,191 @@
+name: solitary polymorphic hydration when hook returns null
+enabled:
+  current: false
+  nextgen: true
+overallSchema:
+  pets: |
+    type Query {
+      petById(id: ID): Pet
+    }
+
+    type Pet {
+      id: ID
+      breed: String
+    }
+  people: |
+    type Query {
+      humanById(id: ID): Human
+    }
+
+    type Human {
+      id: ID
+      name: String
+    }
+  foo: |
+    type Query {
+      foo: [Foo]
+    }
+
+    type Foo {
+      id: ID
+      dataId: ID
+      data: Data
+      @hydrated(
+        service: "pets"
+        field: "petById"
+        arguments: [
+          {name: "id" value: "$source.dataId"}
+        ]
+      )
+      @hydrated(
+        service: "people"
+        field: "humanById"
+        arguments: [
+          {name: "id" value: "$source.dataId"}
+        ]
+      )
+    }
+
+    union Data = Pet | Human
+underlyingSchema:
+  pets: |
+    type Query {
+      petById(id: ID): Pet
+    }
+
+    type Pet {
+      id: ID
+      breed: String
+    }
+  people: |
+    type Query {
+      humanById(id: ID): Human
+    }
+
+    type Human {
+      id: ID
+      name: String
+    }
+  foo: |
+    type Query {
+      foo: [Foo]
+    }
+
+    type Foo {
+      id: ID
+      dataId: ID
+    }
+
+query: |
+  query {
+    foo {
+      __typename
+      id
+      data {
+        ... on Pet {
+          __typename
+          id
+          breed
+        }
+        ... on Human {
+          __typename
+          id
+          name
+        }
+      }
+    }
+  }
+variables: { }
+serviceCalls:
+  nextgen:
+    - serviceName: foo
+      request:
+        query: |
+          query {
+            ... on Query {
+              foo {
+                ... on Foo {
+                  __typename
+                  __typename__hydration__data: __typename
+                  hydration__data__dataId: dataId
+                  hydration__data__dataId: dataId
+                  id
+                }
+              }
+            }
+          }
+        variables: { }
+        operationName: null
+      # language=JSON
+      response: |-
+        {
+          "data": {
+            "foo": [{
+              "__typename": "Foo",
+              "__typename__hydration__data": "Foo",
+              "hydration__data__dataId": "NULL-0",
+              "id": "FOO-0"
+            },{
+              "__typename": "Foo",
+              "__typename__hydration__data": "Foo",
+              "hydration__data__dataId": "HUMAN-0",
+              "id": "FOO-1"
+            }]
+          },
+          "extensions": {}
+        }
+    - serviceName: people
+      request:
+        query: |
+          query {
+            ... on Query {
+              humanById(id: "HUMAN-0") {
+                ... on Human {
+                  __typename__type_filter____typename: __typename
+                  __typename
+                  __typename__type_filter__id: __typename
+                  __typename__type_filter__breed: __typename
+                  id
+                  name
+                }
+              }
+            }
+          }
+        variables: { }
+        operationName: null
+      # language=JSON
+      response: |-
+        {
+          "data": {
+            "humanById": {
+              "__typename__type_filter____typename": "Human",
+              "__typename": "Human",
+              "__typename__type_filter__id": "Human",
+              "__typename__type_filter__breed": "Human",
+              "id": "HUMAN-0",
+              "name": "Fanny Longbottom"
+            }
+          },
+          "extensions": {}
+        }
+# language=JSON
+response: |-
+  {
+    "data": {
+      "foo": [{
+        "__typename": "Foo",
+        "id": "FOO-0",
+        "data": null
+      },
+      {
+        "__typename": "Foo",
+        "id": "FOO-1",
+        "data": {
+          "__typename": "Human",
+          "id": "HUMAN-0",
+          "name": "Fanny Longbottom"
+        }
+      }]
+    },
+    "extensions": {}
+  }


### PR DESCRIPTION
We need this when AGG cannot decide what hydration instruction should be used. Real use case might be something like:
activity starts returning an ARI unknown to AGG yet and AGG cannot match the ARI with any hydration definition. We shouldn't fail in this case but rather return `null` for the field that is being hydrated.


Please make sure you consider the following:

- [x] Add tests that use __typename in queries
- [x] Does this change work with all nadel transformations (rename, type rename, hydration, etc)? Add tests for this.
- [x] Is it worth using hints for this change in order to be able to enable a percentage rollout?
- [x] Do we need to add integration tests for this change in the graphql gateway?
- [x] Do we need a pollinator check for this?
