### PR TITLE
pass alias helper to getHydrationInstruction hook

### DIFF
--- a/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/NadelEngineExecutionHooks.kt
+++ b/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/NadelEngineExecutionHooks.kt
@@ -1,12 +1,14 @@
 package graphql.nadel.enginekt
 
 import graphql.nadel.enginekt.blueprint.NadelGenericHydrationInstruction
+import graphql.nadel.enginekt.transform.artificial.NadelAliasHelper
 import graphql.nadel.enginekt.transform.result.json.JsonNode
 import graphql.nadel.hooks.ServiceExecutionHooks
 
 interface NadelEngineExecutionHooks : ServiceExecutionHooks {
     fun <T : NadelGenericHydrationInstruction> getHydrationInstruction(
         instructions: List<T>,
-        parentNode: JsonNode
+        parentNode: JsonNode,
+        aliasHelper: NadelAliasHelper
     ): T?
 }

--- a/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/transform/hydration/NadelHydrationTransform.kt
+++ b/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/transform/hydration/NadelHydrationTransform.kt
@@ -161,7 +161,7 @@ internal class NadelHydrationTransform(
             return emptyList()
         }
 
-        val instruction = getHydrationFieldInstruction(instructions, executionContext.hooks, parentNode)
+        val instruction = getHydrationFieldInstruction(state.aliasHelper, instructions, executionContext.hooks, parentNode)
             ?: return listOf(NadelResultInstruction.Set(parentNode.resultPath + state.hydratedField.fieldName, null))
 
         val actorQueryResults = coroutineScope {
@@ -225,6 +225,7 @@ internal class NadelHydrationTransform(
     }
 
     private fun getHydrationFieldInstruction(
+        aliasHelper: NadelAliasHelper,
         instructions: List<NadelHydrationFieldInstruction>,
         hooks: ServiceExecutionHooks,
         parentNode: JsonNode
@@ -233,7 +234,7 @@ internal class NadelHydrationTransform(
             1 -> instructions.single()
             else -> {
                 if (hooks is NadelEngineExecutionHooks) {
-                    hooks.getHydrationInstruction(instructions, parentNode)
+                    hooks.getHydrationInstruction(instructions, parentNode, aliasHelper)
                 } else {
                     error(
                         "Cannot decide which hydration instruction should be used. Provided ServiceExecutionHooks has " +

--- a/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/transform/hydration/batch/NadelBatchHydrator.kt
+++ b/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/transform/hydration/batch/NadelBatchHydrator.kt
@@ -136,7 +136,8 @@ internal class NadelBatchHydrator(
         }
         return state.executionContext.hooks.getHydrationInstruction(
             instructions,
-            parentNode
+            parentNode,
+            state.aliasHelper
         )
     }
 }

--- a/test/src/test/kotlin/graphql/nadel/tests/hooks/polymorphic-hydration-hook-using-alias-helper.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/hooks/polymorphic-hydration-hook-using-alias-helper.kt
@@ -1,0 +1,47 @@
+package graphql.nadel.tests.hooks
+
+import graphql.nadel.Nadel
+import graphql.nadel.enginekt.NadelEngineExecutionHooks
+import graphql.nadel.enginekt.blueprint.NadelGenericHydrationInstruction
+import graphql.nadel.enginekt.blueprint.hydration.NadelHydrationActorInputDef
+import graphql.nadel.enginekt.transform.artificial.NadelAliasHelper
+import graphql.nadel.enginekt.transform.result.json.JsonNode
+import graphql.nadel.enginekt.util.JsonMap
+import graphql.nadel.tests.EngineTestHook
+import graphql.nadel.tests.NadelEngineType
+import graphql.nadel.tests.UseHook
+
+private class PolymorphicHydrationHookUsingAliasHelper : NadelEngineExecutionHooks {
+
+    override fun <T : NadelGenericHydrationInstruction> getHydrationInstruction(
+        instructions: List<T>,
+        parentNode: JsonNode,
+        aliasHelper: NadelAliasHelper
+    ): T? {
+        return instructions.firstOrNull {
+            val (_, _, valueSource) = it.actorInputValueDefs.single()
+            if (valueSource !is NadelHydrationActorInputDef.ValueSource.FieldResultValue) {
+                return@firstOrNull false
+            }
+            val actorFieldName = valueSource.fieldDefinition.name
+            val targetFieldName = aliasHelper.getResultKey(actorFieldName)
+            val hydrationArgumentValue = (parentNode.value as JsonMap)[targetFieldName]
+            hydrationInstructionMatchesArgumentValue(it, hydrationArgumentValue as String)
+        }
+    }
+
+    private fun <T : NadelGenericHydrationInstruction> hydrationInstructionMatchesArgumentValue(
+        instruction: T,
+        hydrationArgumentValue: String
+    ): Boolean {
+        return instruction.actorService.name == "pets" && hydrationArgumentValue.startsWith("pet", ignoreCase = true) ||
+            instruction.actorService.name == "people" && hydrationArgumentValue.startsWith("human", ignoreCase = true)
+    }
+}
+
+@UseHook
+class `batch-polymorphic-hydration` : EngineTestHook {
+    override fun makeNadel(engineType: NadelEngineType, builder: Nadel.Builder): Nadel.Builder {
+        return builder.serviceExecutionHooks(PolymorphicHydrationHookUsingAliasHelper())
+    }
+}

--- a/test/src/test/kotlin/graphql/nadel/tests/hooks/polymorphic-hydration-hooks.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/hooks/polymorphic-hydration-hooks.kt
@@ -44,9 +44,6 @@ open class PolymorphicHydrationTestHook : EngineTestHook {
 class `solitary-polymorphic-hydration` : PolymorphicHydrationTestHook() {}
 
 @UseHook
-class `batch-polymorphic-hydration` : PolymorphicHydrationTestHook() {}
-
-@UseHook
 class `batch-polymorphic-hydration-with-interfaces` : PolymorphicHydrationTestHook() {}
 
 @UseHook

--- a/test/src/test/kotlin/graphql/nadel/tests/hooks/polymorphic-hydration-hooks.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/hooks/polymorphic-hydration-hooks.kt
@@ -4,6 +4,7 @@ import graphql.nadel.Nadel
 import graphql.nadel.enginekt.NadelEngineExecutionHooks
 import graphql.nadel.enginekt.blueprint.NadelGenericHydrationInstruction
 import graphql.nadel.enginekt.blueprint.NadelHydrationFieldInstruction
+import graphql.nadel.enginekt.transform.artificial.NadelAliasHelper
 import graphql.nadel.enginekt.transform.result.json.JsonNode
 import graphql.nadel.enginekt.transform.result.json.JsonNodeExtractor
 import graphql.nadel.enginekt.transform.result.json.JsonNodePath
@@ -14,7 +15,8 @@ import graphql.nadel.tests.UseHook
 private class PolymorphicHydrationHooks : NadelEngineExecutionHooks {
     override fun <T : NadelGenericHydrationInstruction> getHydrationInstruction(
         instructions: List<T>,
-        parentNode: JsonNode
+        parentNode: JsonNode,
+        aliasHelper: NadelAliasHelper
     ): T? {
 
         val dataIdFieldName = if (instructions.any { it is NadelHydrationFieldInstruction })


### PR DESCRIPTION
currently we are passing a parent node to the hook (which is a json map) which is something like this:
```json
{
  "__typename": "Foo"
  "__typename__batch_hydration__data": "Foo"
  "batch_hydration__data__dataId": "ari:cloud:something/PET-0"
  "id": "FOO-0"
}
```

In the hook we look at every hydration instruction and we need to understand which one is the appropriate one based on the value of the hydration argument (value of "batch_hydration__data__dataId" field in this example). Just by looking at the `parentNode` json map alone, we don't know that `batch_hydration__data__dataId` is the special field that we need to be examining. So I propose we pass the alias helper as well and then inside the hook we will know that `batch_hydration__data__dataId` is the special field that we need to look at. 

I tested it with locally deployed nadel here: https://bitbucket.org/atlassian/graphql-gateway/pull-requests/891#chg_internal/src/main/java/io/atlassian/graphql/gateway/hooks/GatewayServiceExecutionHooks.java_newline307


Alternatively what we could do is to pass these artificial fields to the hook https://github.com/atlassian-labs/nadel/blob/master/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/transform/hydration/batch/NadelBatchHydrationTransform.kt#L82. This is a list of `ExecutableNormalizedField` and it has the field name and the alias. So in the hook we know that we need to find the value of the field `dataId` (based on the hydration instruction), we check what the alias is for this artificial field (it's `batch_hydration__data__dataId`) and then we know what field we need to look in the json map. So it's similar but different.

Please make sure you consider the following:

- [x] Add tests that use __typename in queries
- [x] Does this change work with all nadel transformations (rename, type rename, hydration, etc)? Add tests for this.
- [x] Is it worth using hints for this change in order to be able to enable a percentage rollout?
- [x] Do we need to add integration tests for this change in the graphql gateway?
- [x] Do we need a pollinator check for this?
