### PR TITLE
Perf improvements

### DIFF
--- a/api/src/main/java/graphql/nadel/NadelExecutionHints.java
+++ b/api/src/main/java/graphql/nadel/NadelExecutionHints.java
@@ -12,11 +12,13 @@ public class NadelExecutionHints {
         this.transformsOnHydrationFields = builder.transformsOnHydrationFields;
         this.legacyOperationNames = builder.legacyOperationNames;
         this.newJsonNodeTraversal = builder.newJsonNodeTraversal;
+        this.asyncResultTransform = builder.asyncResultTransform;
     }
 
     private final LegacyOperationNamesHint legacyOperationNames;
     private final boolean transformsOnHydrationFields;
     private final boolean newJsonNodeTraversal;
+    private final boolean asyncResultTransform;
 
     /**
      * Flag to determine whether nextgen will generate the traditional nadel_2_service_opName
@@ -45,6 +47,13 @@ public class NadelExecutionHints {
     }
 
     /**
+     * Flag to use faster async result transform. Flagged due to concerns.
+     */
+    public boolean getAsyncResultTransform() {
+        return asyncResultTransform;
+    }
+
+    /**
      * Returns a builder with the same field values as this object.
      * <p>
      * This is useful for transforming the object.
@@ -67,6 +76,7 @@ public class NadelExecutionHints {
     public static class Builder {
         private boolean transformsOnHydrationFields;
         private boolean newJsonNodeTraversal;
+        private boolean asyncResultTransform;
         private LegacyOperationNamesHint legacyOperationNames = service -> false;
 
         private Builder() {
@@ -86,6 +96,14 @@ public class NadelExecutionHints {
          */
         public Builder newJsonNodeTraversal(boolean flag) {
             this.newJsonNodeTraversal = flag;
+            return this;
+        }
+
+        /**
+         * @see NadelExecutionHints#getAsyncResultTransform()
+         */
+        public Builder asyncResultTransform(boolean flag) {
+            this.asyncResultTransform = flag;
             return this;
         }
 

--- a/api/src/main/java/graphql/nadel/NadelExecutionHints.java
+++ b/api/src/main/java/graphql/nadel/NadelExecutionHints.java
@@ -11,10 +11,12 @@ public class NadelExecutionHints {
     private NadelExecutionHints(Builder builder) {
         this.transformsOnHydrationFields = builder.transformsOnHydrationFields;
         this.legacyOperationNames = builder.legacyOperationNames;
+        this.newJsonNodeTraversal = builder.newJsonNodeTraversal;
     }
 
     private final LegacyOperationNamesHint legacyOperationNames;
     private final boolean transformsOnHydrationFields;
+    private final boolean newJsonNodeTraversal;
 
     /**
      * Flag to determine whether nextgen will generate the traditional nadel_2_service_opName
@@ -33,6 +35,13 @@ public class NadelExecutionHints {
      */
     public boolean getTransformsOnHydrationFields() {
         return transformsOnHydrationFields;
+    }
+
+    /**
+     * Flag to use JsonNodes with traversal caching over the slower but battle-tested JsonNodeExtractor.
+     */
+    public boolean getNewJsonNodeTraversal() {
+        return newJsonNodeTraversal;
     }
 
     /**
@@ -57,6 +66,7 @@ public class NadelExecutionHints {
 
     public static class Builder {
         private boolean transformsOnHydrationFields;
+        private boolean newJsonNodeTraversal;
         private LegacyOperationNamesHint legacyOperationNames = service -> false;
 
         private Builder() {
@@ -68,6 +78,14 @@ public class NadelExecutionHints {
 
         public Builder transformsOnHydrationFields(boolean flag) {
             this.transformsOnHydrationFields = flag;
+            return this;
+        }
+
+        /**
+         * @see NadelExecutionHints#getNewJsonNodeTraversal()
+         */
+        public Builder newJsonNodeTraversal(boolean flag) {
+            this.newJsonNodeTraversal = flag;
             return this;
         }
 

--- a/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/transform/NadelCoerceTransform.kt
+++ b/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/transform/NadelCoerceTransform.kt
@@ -7,6 +7,7 @@ import graphql.nadel.enginekt.blueprint.NadelOverallExecutionBlueprint
 import graphql.nadel.enginekt.transform.NadelCoerceTransform.State
 import graphql.nadel.enginekt.transform.query.NadelQueryTransformer
 import graphql.nadel.enginekt.transform.result.NadelResultInstruction
+import graphql.nadel.enginekt.transform.result.json.JsonNodes
 import graphql.nadel.enginekt.util.makeFieldCoordinates
 import graphql.nadel.enginekt.util.unwrapAll
 import graphql.normalized.ExecutableNormalizedField
@@ -92,9 +93,7 @@ internal class NadelCoerceTransform : NadelTransform<State> {
         // In the case of scalars, there should only be 1 unwrapped type.
         // Object types could result in more than 1 distinct type, in the case of different interface implementations
         // having different concrete types, but this transform only cares about scalar types.
-        val singleType = distinctUnwrappedTypes.singleOrNull()
-
-        return when (singleType) {
+        return when (val singleType = distinctUnwrappedTypes.singleOrNull()) {
             is GraphQLScalarType -> State(singleType)
             else -> null
         }
@@ -119,8 +118,10 @@ internal class NadelCoerceTransform : NadelTransform<State> {
         underlyingParentField: ExecutableNormalizedField?,
         result: ServiceExecutionResult,
         state: State,
+        nodes: JsonNodes,
     ): List<NadelResultInstruction> {
         return NadelTransformUtil.createSetInstructions(
+            nodes,
             underlyingParentField,
             result,
             overallField,

--- a/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/transform/NadelDeepRenameTransform.kt
+++ b/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/transform/NadelDeepRenameTransform.kt
@@ -12,6 +12,7 @@ import graphql.nadel.enginekt.transform.query.NadelQueryPath
 import graphql.nadel.enginekt.transform.query.NadelQueryTransformer
 import graphql.nadel.enginekt.transform.result.NadelResultInstruction
 import graphql.nadel.enginekt.transform.result.json.JsonNodeExtractor
+import graphql.nadel.enginekt.transform.result.json.JsonNodes
 import graphql.nadel.enginekt.util.emptyOrSingle
 import graphql.nadel.enginekt.util.queryPath
 import graphql.nadel.enginekt.util.toBuilder
@@ -288,9 +289,9 @@ internal class NadelDeepRenameTransform : NadelTransform<NadelDeepRenameTransfor
         underlyingParentField: ExecutableNormalizedField?, // Overall field
         result: ServiceExecutionResult,
         state: State,
+        nodes: JsonNodes,
     ): List<NadelResultInstruction> {
-        val parentNodes = JsonNodeExtractor.getNodesAt(
-            data = result.data,
+        val parentNodes = nodes.getNodesAt(
             queryPath = underlyingParentField?.queryPath ?: NadelQueryPath.root,
             flatten = true,
         )

--- a/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/transform/NadelRenameTransform.kt
+++ b/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/transform/NadelRenameTransform.kt
@@ -14,6 +14,7 @@ import graphql.nadel.enginekt.transform.query.NadelQueryTransformer
 import graphql.nadel.enginekt.transform.result.NadelResultInstruction
 import graphql.nadel.enginekt.transform.result.json.JsonNode
 import graphql.nadel.enginekt.transform.result.json.JsonNodeExtractor
+import graphql.nadel.enginekt.transform.result.json.JsonNodes
 import graphql.nadel.enginekt.util.emptyOrSingle
 import graphql.nadel.enginekt.util.queryPath
 import graphql.nadel.enginekt.util.toBuilder
@@ -175,9 +176,9 @@ internal class NadelRenameTransform : NadelTransform<State> {
         underlyingParentField: ExecutableNormalizedField?, // Overall field
         result: ServiceExecutionResult,
         state: State,
+        nodes: JsonNodes,
     ): List<NadelResultInstruction> {
-        val parentNodes = JsonNodeExtractor.getNodesAt(
-            data = result.data,
+        val parentNodes = nodes.getNodesAt(
             queryPath = underlyingParentField?.queryPath ?: NadelQueryPath.root,
             flatten = true,
         )

--- a/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/transform/NadelServiceTypeFilterTransform.kt
+++ b/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/transform/NadelServiceTypeFilterTransform.kt
@@ -10,6 +10,7 @@ import graphql.nadel.enginekt.transform.NadelServiceTypeFilterTransform.State
 import graphql.nadel.enginekt.transform.artificial.NadelAliasHelper
 import graphql.nadel.enginekt.transform.query.NadelQueryTransformer
 import graphql.nadel.enginekt.transform.result.NadelResultInstruction
+import graphql.nadel.enginekt.transform.result.json.JsonNodes
 import graphql.nadel.enginekt.util.resolveObjectTypes
 import graphql.nadel.enginekt.util.toBuilder
 import graphql.normalized.ExecutableNormalizedField
@@ -176,6 +177,7 @@ class NadelServiceTypeFilterTransform : NadelTransform<State> {
         underlyingParentField: ExecutableNormalizedField?,
         result: ServiceExecutionResult,
         state: State,
+        nodes: JsonNodes,
     ): List<NadelResultInstruction> {
         return emptyList()
     }

--- a/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/transform/NadelTransform.kt
+++ b/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/transform/NadelTransform.kt
@@ -7,6 +7,7 @@ import graphql.nadel.enginekt.NadelExecutionContext
 import graphql.nadel.enginekt.blueprint.NadelOverallExecutionBlueprint
 import graphql.nadel.enginekt.transform.query.NadelQueryTransformer
 import graphql.nadel.enginekt.transform.result.NadelResultInstruction
+import graphql.nadel.enginekt.transform.result.json.JsonNodes
 import graphql.normalized.ExecutableNormalizedField
 
 interface NadelTransform<State : Any> {
@@ -66,6 +67,7 @@ interface NadelTransform<State : Any> {
         underlyingParentField: ExecutableNormalizedField?,
         result: ServiceExecutionResult,
         state: State,
+        nodes: JsonNodes,
     ): List<NadelResultInstruction>
 }
 

--- a/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/transform/NadelTransformJavaCompat.kt
+++ b/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/transform/NadelTransformJavaCompat.kt
@@ -7,6 +7,7 @@ import graphql.nadel.enginekt.blueprint.NadelOverallExecutionBlueprint
 import graphql.nadel.enginekt.transform.query.NadelQueryTransformer
 import graphql.nadel.enginekt.transform.query.NadelQueryTransformerJavaCompat
 import graphql.nadel.enginekt.transform.result.NadelResultInstruction
+import graphql.nadel.enginekt.transform.result.json.JsonNodes
 import graphql.normalized.ExecutableNormalizedField
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.future.asDeferred
@@ -102,6 +103,7 @@ interface NadelTransformJavaCompat<State : Any> {
                     underlyingParentField: ExecutableNormalizedField?,
                     result: ServiceExecutionResult,
                     state: State,
+                    nodes: JsonNodes,
                 ): List<NadelResultInstruction> {
                     return compat.getResultInstructions(
                         executionContext = executionContext,

--- a/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/transform/NadelTypeRenameResultTransform.kt
+++ b/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/transform/NadelTypeRenameResultTransform.kt
@@ -10,6 +10,7 @@ import graphql.nadel.enginekt.transform.query.NadelQueryPath
 import graphql.nadel.enginekt.transform.query.NadelQueryTransformer
 import graphql.nadel.enginekt.transform.result.NadelResultInstruction
 import graphql.nadel.enginekt.transform.result.json.JsonNodeExtractor
+import graphql.nadel.enginekt.transform.result.json.JsonNodes
 import graphql.nadel.enginekt.util.queryPath
 import graphql.normalized.ExecutableNormalizedField
 
@@ -53,9 +54,9 @@ internal class NadelTypeRenameResultTransform : NadelTransform<State> {
         underlyingParentField: ExecutableNormalizedField?,
         result: ServiceExecutionResult,
         state: State,
+        nodes: JsonNodes,
     ): List<NadelResultInstruction> {
-        val typeNameNodes = JsonNodeExtractor.getNodesAt(
-            result.data,
+        val typeNameNodes = nodes.getNodesAt(
             (underlyingParentField?.queryPath ?: NadelQueryPath.root) + overallField.resultKey,
             flatten = true,
         )

--- a/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/transform/hydration/NadelHydrationTransform.kt
+++ b/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/transform/hydration/NadelHydrationTransform.kt
@@ -23,6 +23,7 @@ import graphql.nadel.enginekt.transform.query.NadelQueryTransformer
 import graphql.nadel.enginekt.transform.result.NadelResultInstruction
 import graphql.nadel.enginekt.transform.result.json.JsonNode
 import graphql.nadel.enginekt.transform.result.json.JsonNodeExtractor
+import graphql.nadel.enginekt.transform.result.json.JsonNodes
 import graphql.nadel.enginekt.util.emptyOrSingle
 import graphql.nadel.enginekt.util.queryPath
 import graphql.nadel.enginekt.util.toBuilder
@@ -138,9 +139,9 @@ internal class NadelHydrationTransform(
         underlyingParentField: ExecutableNormalizedField?,
         result: ServiceExecutionResult,
         state: State,
+        nodes: JsonNodes,
     ): List<NadelResultInstruction> {
-        val parentNodes = JsonNodeExtractor.getNodesAt(
-            data = result.data ?: return emptyList(),
+        val parentNodes = nodes.getNodesAt(
             queryPath = underlyingParentField?.queryPath ?: NadelQueryPath.root,
             flatten = true,
         )
@@ -186,8 +187,7 @@ internal class NadelHydrationTransform(
                 parentNode = parentNode,
             ).map { actorQuery ->
                 async {
-                    val hydrationSourceService =
-                        executionBlueprint.getServiceOwning(instruction.location)
+                    val hydrationSourceService = executionBlueprint.getServiceOwning(instruction.location)
                     engine.executeHydration(
                         service = instruction.actorService,
                         topLevelField = actorQuery,

--- a/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/transform/hydration/batch/NadelBatchHydrationTransform.kt
+++ b/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/transform/hydration/batch/NadelBatchHydrationTransform.kt
@@ -18,6 +18,7 @@ import graphql.nadel.enginekt.transform.query.NadelQueryPath
 import graphql.nadel.enginekt.transform.query.NadelQueryTransformer
 import graphql.nadel.enginekt.transform.result.NadelResultInstruction
 import graphql.nadel.enginekt.transform.result.json.JsonNodeExtractor
+import graphql.nadel.enginekt.transform.result.json.JsonNodes
 import graphql.nadel.enginekt.util.queryPath
 import graphql.nadel.enginekt.util.toBuilder
 import graphql.normalized.ExecutableNormalizedField
@@ -106,9 +107,9 @@ internal class NadelBatchHydrationTransform(
         underlyingParentField: ExecutableNormalizedField?,
         result: ServiceExecutionResult,
         state: State,
+        nodes: JsonNodes,
     ): List<NadelResultInstruction> {
-        val parentNodes = JsonNodeExtractor.getNodesAt(
-            data = result.data,
+        val parentNodes = nodes.getNodesAt(
             queryPath = underlyingParentField?.queryPath ?: NadelQueryPath.root,
             flatten = true,
         )

--- a/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/transform/result/NadelResultTransformer.kt
+++ b/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/transform/result/NadelResultTransformer.kt
@@ -8,9 +8,9 @@ import graphql.nadel.enginekt.plan.NadelExecutionPlan
 import graphql.nadel.enginekt.transform.result.NadelResultTransformer.DataMutation
 import graphql.nadel.enginekt.transform.result.json.AnyJsonNodePathSegment
 import graphql.nadel.enginekt.transform.result.json.JsonNode
-import graphql.nadel.enginekt.transform.result.json.JsonNodeExtractor
 import graphql.nadel.enginekt.transform.result.json.JsonNodePath
 import graphql.nadel.enginekt.transform.result.json.JsonNodePathSegment
+import graphql.nadel.enginekt.transform.result.json.JsonNodes
 import graphql.nadel.enginekt.util.AnyList
 import graphql.nadel.enginekt.util.AnyMap
 import graphql.nadel.enginekt.util.AnyMutableList
@@ -20,6 +20,7 @@ import graphql.nadel.enginekt.util.MutableJsonMap
 import graphql.nadel.enginekt.util.asMutableJsonMap
 import graphql.nadel.enginekt.util.queryPath
 import graphql.normalized.ExecutableNormalizedField
+import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
@@ -34,29 +35,41 @@ internal class NadelResultTransformer(private val executionBlueprint: NadelOvera
         service: Service,
         result: ServiceExecutionResult,
     ): ServiceExecutionResult {
-        val instructions = coroutineScope {
-            executionPlan.transformationSteps.flatMap { (field, steps) ->
-                steps.map { step ->
-                    async {
-                        // This can be null if we did not end up sending the field e.g. for hydration
-                        val underlyingFields = overallToUnderlyingFields[field]
-                        if (underlyingFields == null || underlyingFields.isEmpty()) {
-                            return@async emptyList()
-                        }
+        val nodes = JsonNodes(result.data, executionContext.hints)
 
-                        step.transform.getResultInstructions(
-                            executionContext,
-                            executionBlueprint,
-                            service,
-                            field,
-                            underlyingFields.first().parent,
-                            result,
-                            step.state,
-                        )
-                    }
+        val deferredInstructions = ArrayList<Deferred<List<NadelResultInstruction>>>()
+
+        coroutineScope {
+            for ((field, steps) in executionPlan.transformationSteps) {
+                // This can be null if we did not end up sending the field e.g. for hydration
+                val underlyingFields = overallToUnderlyingFields[field]
+                if (underlyingFields == null || underlyingFields.isEmpty()) {
+                    continue
                 }
-            }.awaitAll().flatten() + getRemoveArtificialFieldInstructions(result, artificialFields)
+
+                for (step in steps) {
+                    deferredInstructions.add(
+                        async {
+                            step.transform.getResultInstructions(
+                                executionContext,
+                                executionBlueprint,
+                                service,
+                                field,
+                                underlyingFields.first().parent,
+                                result,
+                                step.state,
+                                nodes,
+                            )
+                        },
+                    )
+                }
+            }
         }
+
+        val instructions = deferredInstructions
+            .awaitAll()
+            .flatten() +
+            getRemoveArtificialFieldInstructions(artificialFields, nodes)
 
         mutate(result, instructions)
 
@@ -64,7 +77,7 @@ internal class NadelResultTransformer(private val executionBlueprint: NadelOvera
     }
 
     private fun mutate(result: ServiceExecutionResult, instructions: List<NadelResultInstruction>) {
-        // For now we don't have any instructions to modify anything other than data, so return early
+        // For now, we don't have any instructions to modify anything other than data, so return early
         if (result.data == null) {
             return
         }
@@ -192,19 +205,21 @@ internal class NadelResultTransformer(private val executionBlueprint: NadelOvera
     }
 
     private fun getRemoveArtificialFieldInstructions(
-        result: ServiceExecutionResult,
         artificialFields: List<ExecutableNormalizedField>,
+        nodes: JsonNodes,
     ): List<NadelResultInstruction> {
-        return artificialFields.flatMap { field ->
-            JsonNodeExtractor.getNodesAt(
-                data = result.data,
-                queryPath = field.queryPath,
-            ).map { jsonNode ->
-                NadelResultInstruction.Remove(
-                    subjectPath = jsonNode.resultPath,
-                )
+        return artificialFields
+            .asSequence()
+            .flatMap { field ->
+                nodes.getNodesAt(
+                    queryPath = field.queryPath,
+                ).map { jsonNode ->
+                    NadelResultInstruction.Remove(
+                        subjectPath = jsonNode.resultPath,
+                    )
+                }
             }
-        }
+            .toList()
     }
 
     private data class TransformContext(
@@ -234,7 +249,32 @@ private fun JsonMap.getJsonMapAt(path: JsonNodePath): JsonMap? {
 }
 
 private fun JsonMap.getAt(path: JsonNodePath): JsonNode {
-    return path.segments.fold(JsonNode(JsonNodePath.root, this), JsonNode::get)
+    var cursor: Any = this
+
+    for (segment in path.segments) {
+        cursor = when (segment) {
+            is JsonNodePathSegment.Int -> {
+                if (cursor is AnyList) {
+                    cursor[segment.value]
+                } else {
+                    error("Requires List")
+                }
+            }
+            is JsonNodePathSegment.String -> {
+                if (cursor is AnyMap) {
+                    cursor[segment.value]
+                } else {
+                    error("Requires List")
+                }
+            }
+        } ?: return JsonNode(path, null)
+    }
+
+    return JsonNode(
+        path,
+        cursor,
+    )
+    // return path.segments.fold(JsonNode(JsonNodePath.root, this), JsonNode::get)
 }
 
 /**

--- a/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/transform/result/json/JsonNodeExtractor.kt
+++ b/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/transform/result/json/JsonNodeExtractor.kt
@@ -6,6 +6,7 @@ import graphql.nadel.enginekt.util.AnyMap
 import graphql.nadel.enginekt.util.JsonMap
 import graphql.nadel.enginekt.util.foldWhileNotNull
 
+@Deprecated("Start moving to JsonNodes for performance reasons")
 object JsonNodeExtractor {
     /**
      * Extracts the nodes at the given query selection path.
@@ -107,7 +108,7 @@ object JsonNodeExtractor {
     }
 }
 
-private class IllegalNodeTypeException private constructor(message: String) : RuntimeException(message) {
+class IllegalNodeTypeException private constructor(message: String) : RuntimeException(message) {
     companion object {
         operator fun invoke(node: JsonNode): IllegalNodeTypeException {
             val nodeType = node.value?.javaClass?.name ?: "null"

--- a/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/transform/result/json/JsonNodePath.kt
+++ b/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/transform/result/json/JsonNodePath.kt
@@ -22,7 +22,9 @@ data class JsonNodePath(
     }
 
     fun dropLast(n: Int): JsonNodePath {
-        return copy(segments = segments.dropLast(n))
+        return copy(
+            segments = segments.subList(0, segments.size - n),
+        )
     }
 
     companion object {

--- a/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/transform/result/json/JsonNodes.kt
+++ b/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/transform/result/json/JsonNodes.kt
@@ -1,0 +1,148 @@
+package graphql.nadel.enginekt.transform.result.json
+
+import graphql.nadel.NadelExecutionHints
+import graphql.nadel.enginekt.transform.query.NadelQueryPath
+import graphql.nadel.enginekt.util.AnyList
+import graphql.nadel.enginekt.util.AnyMap
+import graphql.nadel.enginekt.util.JsonMap
+import graphql.nadel.enginekt.util.foldWhileNotNull
+import java.util.Collections
+
+/**
+ * Utility class to extract data out of the given
+ */
+class JsonNodes(
+    private val data: JsonMap,
+    private val executionFlags: NadelExecutionHints,
+) {
+    private val nodes = Collections.synchronizedMap(
+        mutableMapOf<NadelQueryPath, List<JsonNode>>(),
+    )
+
+    /**
+     * Extracts the nodes at the given query selection path.
+     */
+    fun getNodesAt(queryPath: NadelQueryPath, flatten: Boolean = false): List<JsonNode> {
+        if (!executionFlags.newJsonNodeTraversal) {
+            return JsonNodeExtractor.getNodesAt(data, queryPath, flatten)
+        }
+
+        val rootNode = JsonNode(JsonNodePath.root, data)
+        return getNodesAt(rootNode, queryPath, flatten)
+    }
+
+    /**
+     * Extract the node at the given json node path.
+     */
+    fun getNodeAt(path: JsonNodePath): JsonNode? {
+        if (!executionFlags.newJsonNodeTraversal) {
+            return JsonNodeExtractor.getNodeAt(data, path)
+        }
+
+        val rootNode = JsonNode(JsonNodePath.root, data)
+        return getNodeAt(rootNode, path)
+    }
+
+    /**
+     * Extracts the nodes at the given query selection path.
+     */
+    private fun getNodesAt(rootNode: JsonNode, queryPath: NadelQueryPath, flatten: Boolean = false): List<JsonNode> {
+        var queue = listOf(rootNode)
+
+        // todo work backwards here instead of forwards
+        for (index in queryPath.segments.indices) {
+            val subPath = NadelQueryPath(
+                queryPath.segments.subList(0, index + 1) // +1 as endIndex is exclusive
+            )
+            val hasMore = index < queryPath.segments.lastIndex
+            val pathSegment = queryPath.segments[index]
+
+            queue = if (hasMore) {
+                nodes.computeIfAbsent(subPath) {
+                    queue.flatMap { node ->
+                        getNodes(node, pathSegment, flattenLists = true)
+                    }
+                }
+            } else {
+                queue.flatMap { node ->
+                    getNodes(node, pathSegment, flattenLists = flatten)
+                }
+            }
+        }
+
+        return queue
+    }
+
+    /**
+     * Extract the node at the given json node path.
+     */
+    private fun getNodeAt(rootNode: JsonNode, path: JsonNodePath): JsonNode? {
+        return path.segments.foldWhileNotNull(rootNode as JsonNode?) { currentNode, segment ->
+            when (currentNode?.value) {
+                is AnyMap -> currentNode.value[segment.value]?.let {
+                    JsonNode(currentNode.resultPath + segment, it)
+                }
+                is AnyList -> when (segment) {
+                    is JsonNodePathSegment.Int -> currentNode.value.getOrNull(segment.value)?.let {
+                        JsonNode(currentNode.resultPath + segment, it)
+                    }
+                    else -> null
+                }
+                else -> null
+            }
+        }
+    }
+
+    private fun getNodes(node: JsonNode, segment: String, flattenLists: Boolean): Sequence<JsonNode> {
+        return when (node.value) {
+            is AnyMap -> getNodes(node.resultPath, node.value, segment, flattenLists)
+            null -> emptySequence()
+            else -> throw IllegalNodeTypeException(node)
+        }
+    }
+
+    private fun getNodes(
+        parentPath: JsonNodePath,
+        map: AnyMap,
+        segment: String,
+        flattenLists: Boolean,
+    ): Sequence<JsonNode> {
+        val newPath = parentPath + segment
+        val value = map[segment]
+
+        // We flatten lists as these nodes contribute to the BFS queue
+        if (value is AnyList && flattenLists) {
+            return getFlatNodes(parentPath = newPath, value)
+        }
+
+        return sequenceOf(
+            JsonNode(newPath, value),
+        )
+    }
+
+    /**
+     * Collects [JsonMap] nodes inside a [List]. Effectively we call this function to remove
+     * traces of [List]s.
+     *
+     * For example for the path /users we return the following nodes:
+     *
+     * `/users/[0]`
+     *
+     * `/users/[1]`
+     *
+     * etc.
+     */
+    private fun getFlatNodes(parentPath: JsonNodePath, values: AnyList): Sequence<JsonNode> {
+        return values
+            .asSequence()
+            .flatMapIndexed { index, value ->
+                val newPath = parentPath + index
+                when (value) {
+                    is AnyList -> getFlatNodes(newPath, value)
+                    else -> sequenceOf(
+                        JsonNode(newPath, value),
+                    )
+                }
+            }
+    }
+}

--- a/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/transform/skipInclude/SkipIncludeTransform.kt
+++ b/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/transform/skipInclude/SkipIncludeTransform.kt
@@ -12,6 +12,7 @@ import graphql.nadel.enginekt.transform.NadelTransformFieldResult
 import graphql.nadel.enginekt.transform.artificial.NadelAliasHelper
 import graphql.nadel.enginekt.transform.query.NadelQueryTransformer
 import graphql.nadel.enginekt.transform.result.NadelResultInstruction
+import graphql.nadel.enginekt.transform.result.json.JsonNodes
 import graphql.nadel.enginekt.transform.skipInclude.SkipIncludeTransform.State
 import graphql.nadel.enginekt.util.resolveObjectTypes
 import graphql.nadel.enginekt.util.toBuilder
@@ -95,6 +96,7 @@ internal class SkipIncludeTransform : NadelTransform<State> {
         underlyingParentField: ExecutableNormalizedField?,
         result: ServiceExecutionResult,
         state: State,
+        nodes: JsonNodes,
     ): List<NadelResultInstruction> {
         return emptyList()
     }

--- a/engine/src/test/java/benchmark/LargeRenamedResponseBenchmark.java
+++ b/engine/src/test/java/benchmark/LargeRenamedResponseBenchmark.java
@@ -91,7 +91,9 @@ public class LargeRenamedResponseBenchmark {
                             (Map<String, Object>) deepClone(ktResponseMap.get("data"))
                     );
                 } else {
-                    result = new ServiceExecutionResult((Map<String, Object>) responseMap.get("data"));
+                    result = new ServiceExecutionResult(
+                            (Map<String, Object>) deepClone(responseMap.get("data"))
+                    );
                 }
                 return CompletableFuture.completedFuture(result);
             };
@@ -178,7 +180,7 @@ public class LargeRenamedResponseBenchmark {
 
     @Benchmark
     @Warmup(iterations = 2)
-    @Measurement(iterations = 3, time = 10)
+    @Measurement(iterations = 4, time = 10)
     @Threads(8)
     @BenchmarkMode(Mode.AverageTime)
     @OutputTimeUnit(TimeUnit.MILLISECONDS)

--- a/engine/src/test/java/benchmark/LargeResponseBenchmark.java
+++ b/engine/src/test/java/benchmark/LargeResponseBenchmark.java
@@ -43,8 +43,6 @@ import java.util.concurrent.TimeUnit;
  */
 
 public class LargeResponseBenchmark {
-
-
     @State(Scope.Benchmark)
     public static class NadelInstance {
         Nadel nadel;
@@ -94,7 +92,7 @@ public class LargeResponseBenchmark {
     @Benchmark
     @Warmup(iterations = 2)
     @Measurement(iterations = 3, time = 10)
-    @Threads(1)
+    @Threads(8)
     @BenchmarkMode(Mode.AverageTime)
     @OutputTimeUnit(TimeUnit.MILLISECONDS)
     public ExecutionResult benchMarkAvgTime(NadelInstance nadelInstance) throws ExecutionException, InterruptedException {
@@ -103,9 +101,7 @@ public class LargeResponseBenchmark {
                 .build();
         ExecutionResult executionResult = nadelInstance.nadel.execute(nadelExecutionInput).get();
         Assert.assertTrue(executionResult.getErrors().size() == 0);
-//        System.out.println("data:" +executionResult.getData());
+        // System.out.println("data:" +executionResult.getData());
         return executionResult;
     }
-
-
 }

--- a/engine/src/test/java/benchmark/LargeResponseBenchmark.java
+++ b/engine/src/test/java/benchmark/LargeResponseBenchmark.java
@@ -7,7 +7,9 @@ import com.google.common.io.Resources;
 import graphql.Assert;
 import graphql.ExecutionResult;
 import graphql.nadel.Nadel;
+import graphql.nadel.NadelEngine;
 import graphql.nadel.NadelExecutionInput;
+import graphql.nadel.NextgenEngine;
 import graphql.nadel.ServiceExecution;
 import graphql.nadel.ServiceExecutionFactory;
 import graphql.nadel.ServiceExecutionResult;
@@ -30,8 +32,6 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
-
-import static graphql.nadel.NadelEngine.newNadel;
 
 /**
  * See http://hg.openjdk.java.net/code-tools/jmh/file/tip/jmh-samples/src/main/java/org/openjdk/jmh/samples/ for more samples
@@ -56,10 +56,14 @@ public class LargeResponseBenchmark {
             String schemaString = readFromClasspath("large_response_benchmark_schema.graphqls");
             TypeDefinitionRegistry typeDefinitionRegistry = new SchemaParser().parse(schemaString);
 
+            boolean kt = true;
+
             String responseString = readFromClasspath("large_underlying_service_result.json");
             Map responseMap = objectMapper.readValue(responseString, Map.class);
             ServiceExecutionResult serviceExecutionResult = new ServiceExecutionResult((Map<String, Object>) responseMap.get("data"));
-            ServiceExecution serviceExecution = serviceExecutionParameters -> CompletableFuture.completedFuture(serviceExecutionResult);
+            ServiceExecution serviceExecution = serviceExecutionParameters -> {
+                return CompletableFuture.completedFuture(serviceExecutionResult);
+            };
             ServiceExecutionFactory serviceExecutionFactory = new ServiceExecutionFactory() {
                 @Override
                 public ServiceExecution getServiceExecution(String serviceName) {
@@ -72,7 +76,11 @@ public class LargeResponseBenchmark {
                 }
             };
             String nsdl = "service activity{" + schemaString + "}";
-            nadel = newNadel().dsl("activity", nsdl).serviceExecutionFactory(serviceExecutionFactory).build();
+            nadel = Nadel.newNadel()
+                    .engineFactory(kt ? NextgenEngine::new : NadelEngine::new)
+                    .dsl("activity", nsdl)
+                    .serviceExecutionFactory(serviceExecutionFactory)
+                    .build();
             query = readFromClasspath("large_response_benchmark_query.graphql");
         }
 
@@ -86,7 +94,7 @@ public class LargeResponseBenchmark {
     @Benchmark
     @Warmup(iterations = 2)
     @Measurement(iterations = 3, time = 10)
-    @Threads(8)
+    @Threads(1)
     @BenchmarkMode(Mode.AverageTime)
     @OutputTimeUnit(TimeUnit.MILLISECONDS)
     public ExecutionResult benchMarkAvgTime(NadelInstance nadelInstance) throws ExecutionException, InterruptedException {

--- a/test/src/test/kotlin/graphql/nadel/tests/hooks/ari-transforms.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/hooks/ari-transforms.kt
@@ -9,6 +9,7 @@ import graphql.nadel.enginekt.transform.NadelTransform
 import graphql.nadel.enginekt.transform.NadelTransformFieldResult
 import graphql.nadel.enginekt.transform.query.NadelQueryTransformer
 import graphql.nadel.enginekt.transform.result.NadelResultInstruction
+import graphql.nadel.enginekt.transform.result.json.JsonNodes
 import graphql.nadel.enginekt.util.getField
 import graphql.nadel.enginekt.util.makeFieldCoordinates
 import graphql.nadel.enginekt.util.strictAssociateBy
@@ -86,6 +87,7 @@ private class AriTestTransform : NadelTransform<Set<String>> {
         underlyingParentField: ExecutableNormalizedField?,
         result: ServiceExecutionResult,
         state: Set<String>,
+        nodes: JsonNodes,
     ): List<NadelResultInstruction> {
         return emptyList()
     }

--- a/test/src/test/kotlin/graphql/nadel/tests/hooks/chain-rename-transform.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/hooks/chain-rename-transform.kt
@@ -10,6 +10,7 @@ import graphql.nadel.enginekt.transform.NadelTransform
 import graphql.nadel.enginekt.transform.NadelTransformFieldResult
 import graphql.nadel.enginekt.transform.query.NadelQueryTransformer
 import graphql.nadel.enginekt.transform.result.NadelResultInstruction
+import graphql.nadel.enginekt.transform.result.json.JsonNodes
 import graphql.nadel.enginekt.util.toBuilder
 import graphql.nadel.tests.EngineTestHook
 import graphql.nadel.tests.UseHook
@@ -66,6 +67,7 @@ private class ChainRenameTransform : NadelTransform<Any> {
         underlyingParentField: ExecutableNormalizedField?,
         result: ServiceExecutionResult,
         state: Any,
+        nodes: JsonNodes,
     ): List<NadelResultInstruction> {
         return emptyList()
     }

--- a/test/src/test/kotlin/graphql/nadel/tests/hooks/transformer-on-hydration-fields.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/hooks/transformer-on-hydration-fields.kt
@@ -10,6 +10,7 @@ import graphql.nadel.enginekt.transform.NadelTransform
 import graphql.nadel.enginekt.transform.NadelTransformFieldResult
 import graphql.nadel.enginekt.transform.query.NadelQueryTransformer
 import graphql.nadel.enginekt.transform.result.NadelResultInstruction
+import graphql.nadel.enginekt.transform.result.json.JsonNodes
 import graphql.nadel.enginekt.util.toBuilder
 import graphql.nadel.tests.EngineTestHook
 import graphql.nadel.tests.NadelEngineType
@@ -81,6 +82,7 @@ abstract class `transformer-on-hydration-fields` : EngineTestHook {
                     underlyingParentField: ExecutableNormalizedField?,
                     result: ServiceExecutionResult,
                     state: Any,
+                    nodes: JsonNodes,
                 ): List<NadelResultInstruction> {
                     return emptyList()
                 }

--- a/test/src/test/kotlin/graphql/nadel/tests/hooks/transforms-can-copy-array-value.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/hooks/transforms-can-copy-array-value.kt
@@ -9,6 +9,7 @@ import graphql.nadel.enginekt.transform.NadelTransformFieldResult
 import graphql.nadel.enginekt.transform.query.NadelQueryTransformer
 import graphql.nadel.enginekt.transform.result.NadelResultInstruction
 import graphql.nadel.enginekt.transform.result.json.JsonNodeExtractor
+import graphql.nadel.enginekt.transform.result.json.JsonNodes
 import graphql.nadel.enginekt.util.queryPath
 import graphql.nadel.tests.EngineTestHook
 import graphql.nadel.tests.UseHook
@@ -48,6 +49,7 @@ class `transforms-can-copy-array-value` : EngineTestHook {
                     underlyingParentField: ExecutableNormalizedField?,
                     result: ServiceExecutionResult,
                     state: Any,
+                    nodes: JsonNodes,
                 ): List<NadelResultInstruction> {
                     val nodes = JsonNodeExtractor.getNodesAt(
                         data = result.data,

--- a/test/src/test/kotlin/graphql/nadel/tests/hooks/transforms-can-set-array-value.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/hooks/transforms-can-set-array-value.kt
@@ -9,6 +9,7 @@ import graphql.nadel.enginekt.transform.NadelTransformFieldResult
 import graphql.nadel.enginekt.transform.query.NadelQueryTransformer
 import graphql.nadel.enginekt.transform.result.NadelResultInstruction
 import graphql.nadel.enginekt.transform.result.json.JsonNodeExtractor
+import graphql.nadel.enginekt.transform.result.json.JsonNodes
 import graphql.nadel.enginekt.util.queryPath
 import graphql.nadel.tests.EngineTestHook
 import graphql.nadel.tests.UseHook
@@ -48,6 +49,7 @@ class `transforms-can-set-array-value` : EngineTestHook {
                     underlyingParentField: ExecutableNormalizedField?,
                     result: ServiceExecutionResult,
                     state: Any,
+                    nodes: JsonNodes,
                 ): List<NadelResultInstruction> {
                     val nodes = JsonNodeExtractor.getNodesAt(
                         data = result.data,

--- a/test/src/test/kotlin/graphql/nadel/tests/transforms/RemoveFieldTestTransform.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/transforms/RemoveFieldTestTransform.kt
@@ -12,6 +12,7 @@ import graphql.nadel.enginekt.transform.query.NadelQueryPath
 import graphql.nadel.enginekt.transform.query.NadelQueryTransformer
 import graphql.nadel.enginekt.transform.result.NadelResultInstruction
 import graphql.nadel.enginekt.transform.result.json.JsonNodeExtractor
+import graphql.nadel.enginekt.transform.result.json.JsonNodes
 import graphql.nadel.enginekt.util.queryPath
 import graphql.normalized.ExecutableNormalizedField
 import graphql.schema.GraphQLObjectType
@@ -71,6 +72,7 @@ class RemoveFieldTestTransform : NadelTransform<GraphQLError> {
         underlyingParentField: ExecutableNormalizedField?,
         result: ServiceExecutionResult,
         state: GraphQLError,
+        nodes: JsonNodes,
     ): List<NadelResultInstruction> {
         val parentNodes = JsonNodeExtractor.getNodesAt(
             data = result.data,


### PR DESCRIPTION
Did a dig at performance last night and got a bunch of performance improvements which brings down the execution time by a lot.

Old engine

```
Result "benchmark.LargeRenamedResponseBenchmark.benchMarkAvgTime":
  53.688 ±(99.9%) 2.307 ms/op [Average]
  (min, avg, max) = (50.883, 53.688, 57.167), stdev = 2.158
  CI (99.9%): [51.381, 55.995] (assumes normal distribution)
```

New engine without changes

```
Result "benchmark.LargeRenamedResponseBenchmark.benchMarkAvgTime":
  42.152 ±(99.9%) 1.423 ms/op [Average]
  (min, avg, max) = (40.100, 42.152, 44.873), stdev = 1.331
  CI (99.9%): [40.730, 43.575] (assumes normal distribution)
```

With caching traversals using `JsonNodes` instead of `JsonNodeExtractor`

```
Result "benchmark.LargeRenamedResponseBenchmark.benchMarkAvgTime":
  35.301 ±(99.9%) 0.846 ms/op [Average]
  (min, avg, max) = (33.777, 35.301, 36.819), stdev = 0.792
  CI (99.9%): [34.455, 36.147] (assumes normal distribution)
```

After removing `DataMutations`

```
Result "benchmark.LargeRenamedResponseBenchmark.benchMarkAvgTime":
  27.076 ±(99.9%) 0.998 ms/op [Average]
  (min, avg, max) = (25.917, 27.076, 28.899), stdev = 0.934
  CI (99.9%): [26.078, 28.074] (assumes normal distribution)
```

After updating `JsonMap.getAt` implementation

```
Result "benchmark.LargeRenamedResponseBenchmark.benchMarkAvgTime":
  20.348 ±(99.9%) 0.914 ms/op [Average]
  (min, avg, max) = (18.878, 20.348, 22.288), stdev = 1.053
  CI (99.9%): [19.434, 21.262] (assumes normal distribution)
```

I still need to change `NadelCoerceTransform` to stop running all the time. It effectively runs for every leaf node, which is a decent performance hit. I tested straight up removing the transform and got a drop of ~3 ms in performance.

There's probably still some areas where we can improve this. This is by no means done either.