### PR TITLE
send json scalar arguments as variables to underlying services

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -83,6 +83,7 @@ dependencies {
     testImplementation("org.openjdk.jmh:jmh-core:1.21")
     testImplementation("org.openjdk.jmh:jmh-generator-annprocess:1.21")
     testImplementation("com.google.guava:guava:28.0-jre")
+    testImplementation("com.graphql-java:graphql-java-extended-scalars:2021-06-29T01-19-32-8e19827")
 }
 
 tasks.generateGrammarSource {

--- a/api/src/main/java/graphql/nadel/normalized/ExecutableNormalizedOperationToAstCompiler.java
+++ b/api/src/main/java/graphql/nadel/normalized/ExecutableNormalizedOperationToAstCompiler.java
@@ -1,0 +1,189 @@
+package graphql.nadel.normalized;
+
+import graphql.Internal;
+import graphql.com.google.common.collect.ImmutableList;
+import graphql.com.google.common.collect.ImmutableMap;
+import graphql.language.Argument;
+import graphql.language.ArrayValue;
+import graphql.language.Document;
+import graphql.language.Field;
+import graphql.language.InlineFragment;
+import graphql.language.NullValue;
+import graphql.language.ObjectField;
+import graphql.language.ObjectValue;
+import graphql.language.OperationDefinition;
+import graphql.language.Selection;
+import graphql.language.SelectionSet;
+import graphql.language.TypeName;
+import graphql.language.Value;
+import graphql.nadel.normalized.ValueToVariableValueCompiler.VariableValueWithDefinition;
+import graphql.normalized.ExecutableNormalizedField;
+import graphql.normalized.NormalizedInputValue;
+import graphql.schema.GraphQLSchema;
+import kotlin.Pair;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static graphql.collect.ImmutableKit.map;
+import static graphql.language.Argument.newArgument;
+import static graphql.language.Field.newField;
+import static graphql.language.InlineFragment.newInlineFragment;
+import static graphql.language.SelectionSet.newSelectionSet;
+import static graphql.language.TypeName.newTypeName;
+import static graphql.nadel.normalized.ValueToVariableValueCompiler.normalizedInputValueToVariable;
+
+@Internal
+public class ExecutableNormalizedOperationToAstCompiler {
+
+    private static final String JSON_SCALAR_TYPENAME = "JSON";
+
+    public static Pair<Document, Map<String, Object>> compileToDocument(
+            GraphQLSchema schema,
+            OperationDefinition.Operation operationKind,
+            String operationName,
+            List<ExecutableNormalizedField> topLevelFields
+    ) {
+        List<VariableValueWithDefinition> variables = new ArrayList<>();
+        List<Selection<?>> selections = selectionsForNormalizedFields(schema, topLevelFields, variables);
+        SelectionSet selectionSet = new SelectionSet(selections);
+
+        OperationDefinition.Builder definitionBuilder = OperationDefinition.newOperationDefinition()
+                .name(operationName)
+                .operation(operationKind)
+                .selectionSet(selectionSet);
+
+        definitionBuilder.variableDefinitions(map(variables, (variableWithDefinition -> variableWithDefinition.definition)));
+
+        Map<String, Object> variableValuesByNames = variables.stream()
+                .collect(Collectors.toMap(
+                        variableWithDefinition -> variableWithDefinition.definition.getName(),
+                        variableWithDefinition -> variableWithDefinition.value
+                ));
+
+        return new Pair<>(
+                Document.newDocument()
+                        .definition(definitionBuilder.build())
+                        .build(),
+                variableValuesByNames
+        );
+    }
+
+    private static List<Selection<?>> selectionsForNormalizedFields(
+            GraphQLSchema schema,
+            List<ExecutableNormalizedField> executableNormalizedFields,
+            List<VariableValueWithDefinition> variables
+    ) {
+        ImmutableList.Builder<Selection<?>> selections = ImmutableList.builder();
+
+        // All conditional fields go here instead of directly to selections so they can be grouped together
+        // in the same inline fragement in the output
+        Map<String, List<Field>> conditionalFieldsByObjectTypeName = new LinkedHashMap<>();
+
+        for (ExecutableNormalizedField nf : executableNormalizedFields) {
+            Map<String, List<Field>> groupFieldsForChild = selectionForNormalizedField(schema, nf, variables);
+            if (nf.isConditional(schema)) {
+                groupFieldsForChild.forEach((objectTypeName, fields) -> {
+                    List<Field> fieldList = conditionalFieldsByObjectTypeName.computeIfAbsent(objectTypeName, ignored -> new ArrayList<>());
+                    fieldList.addAll(fields);
+                });
+            } else {
+                List<Field> fields = groupFieldsForChild.values().iterator().next();
+                selections.addAll(fields);
+            }
+        }
+
+        conditionalFieldsByObjectTypeName.forEach((objectTypeName, fields) -> {
+            TypeName typeName = newTypeName(objectTypeName).build();
+            InlineFragment inlineFragment = newInlineFragment().
+                    typeCondition(typeName)
+                    .selectionSet(selectionSet(fields))
+                    .build();
+            selections.add(inlineFragment);
+        });
+
+        return selections.build();
+    }
+
+    private static Map<String, List<Field>> selectionForNormalizedField(
+            GraphQLSchema schema,
+            ExecutableNormalizedField executableNormalizedField,
+            List<VariableValueWithDefinition> variableAccumulator
+    ) {
+        Map<String, List<Field>> groupedFields = new LinkedHashMap<>();
+        for (String objectTypeName : executableNormalizedField.getObjectTypeNames()) {
+            List<Selection<?>> subSelections = selectionsForNormalizedFields(schema, executableNormalizedField.getChildren(), variableAccumulator);
+            SelectionSet selectionSet = null;
+            if (subSelections.size() > 0) {
+                selectionSet = newSelectionSet()
+                        .selections(subSelections)
+                        .build();
+            }
+            List<Argument> arguments = createArguments(executableNormalizedField, variableAccumulator);
+            Field field = newField()
+                    .name(executableNormalizedField.getFieldName())
+                    .alias(executableNormalizedField.getAlias())
+                    .selectionSet(selectionSet)
+                    .arguments(arguments)
+                    .build();
+
+            groupedFields.computeIfAbsent(objectTypeName, ignored -> new ArrayList<>()).add(field);
+        }
+        return groupedFields;
+    }
+
+    private static SelectionSet selectionSet(List<Field> fields) {
+        return newSelectionSet().selections(fields).build();
+    }
+
+    private static List<Argument> createArguments(ExecutableNormalizedField executableNormalizedField, List<VariableValueWithDefinition> variables) {
+        ImmutableList.Builder<Argument> result = ImmutableList.builder();
+        ImmutableMap<String, NormalizedInputValue> normalizedArguments = executableNormalizedField.getNormalizedArguments();
+        for (String argName : normalizedArguments.keySet()) {
+            NormalizedInputValue normalizedInputValue = normalizedArguments.get(argName);
+            Value<?> value = argValue(normalizedInputValue, variables);
+            Argument argument = newArgument()
+                    .name(argName)
+                    .value(value)
+                    .build();
+            result.add(argument);
+        }
+        return result.build();
+    }
+
+    private static Value<?> argValue(Object value, List<VariableValueWithDefinition> variables) {
+        if (value instanceof List) {
+            ArrayValue.Builder arrayValue = ArrayValue.newArrayValue();
+            arrayValue.values(map((List<Object>) value, val -> argValue(val, variables)));
+            return arrayValue.build();
+        }
+        if (value instanceof Map) {
+            ObjectValue.Builder objectValue = ObjectValue.newObjectValue();
+            Map<String, Object> map = (Map<String, Object>) value;
+            for (String fieldName : map.keySet()) {
+                Value<?> fieldValue = argValue((NormalizedInputValue) map.get(fieldName), variables);
+                objectValue.objectField(ObjectField.newObjectField().name(fieldName).value(fieldValue).build());
+            }
+            return objectValue.build();
+        }
+        if (value == null) {
+            return NullValue.newNullValue().build();
+        }
+        return (Value<?>) value;
+    }
+
+    @NotNull
+    private static Value<?> argValue(NormalizedInputValue normalizedInputValue, List<VariableValueWithDefinition> variableDefinitionAccumulator) {
+        if (JSON_SCALAR_TYPENAME.equals(normalizedInputValue.getUnwrappedTypeName())) {
+            VariableValueWithDefinition variableWithDefinition = normalizedInputValueToVariable(normalizedInputValue);
+            variableDefinitionAccumulator.add(variableWithDefinition);
+            return variableWithDefinition.variableReference;
+        } else {
+            return argValue(normalizedInputValue.getValue(), variableDefinitionAccumulator);
+        }
+    }
+}

--- a/api/src/main/java/graphql/nadel/normalized/ExecutableNormalizedOperationToAstCompiler.java
+++ b/api/src/main/java/graphql/nadel/normalized/ExecutableNormalizedOperationToAstCompiler.java
@@ -178,7 +178,7 @@ public class ExecutableNormalizedOperationToAstCompiler {
 
     @NotNull
     private static Value<?> argValue(NormalizedInputValue normalizedInputValue, List<VariableValueWithDefinition> variableAccumulator) {
-        if (JSON_SCALAR_TYPENAME.equals(normalizedInputValue.getUnwrappedTypeName())) {
+        if (JSON_SCALAR_TYPENAME.equals(normalizedInputValue.getUnwrappedTypeName()) && normalizedInputValue.getValue() != null) {
             int numberOfVariablesAlreadyPresent = variableAccumulator.size();
             VariableValueWithDefinition variableWithDefinition = normalizedInputValueToVariable(normalizedInputValue, numberOfVariablesAlreadyPresent);
             variableAccumulator.add(variableWithDefinition);

--- a/api/src/main/java/graphql/nadel/normalized/ValueToVariableValueCompiler.java
+++ b/api/src/main/java/graphql/nadel/normalized/ValueToVariableValueCompiler.java
@@ -26,13 +26,14 @@ import static graphql.nadel.util.FpKit.map;
 public class ValueToVariableValueCompiler {
 
     static VariableValueWithDefinition normalizedInputValueToVariable(NormalizedInputValue normalizedInputValue, int queryVariableCount) {
-        Object variableValue = null;
-        Object normalizedInputValueValue = normalizedInputValue.getValue();
-        if (normalizedInputValueValue instanceof ObjectValue) {
-            variableValue = toVariableValue((ObjectValue) normalizedInputValueValue);
-        }
-        if (normalizedInputValueValue instanceof List) {
-            variableValue = toVariableValues((List) normalizedInputValueValue);
+        Object variableValue;
+        Object inputValue = normalizedInputValue.getValue();
+        if (inputValue instanceof ObjectValue) {
+            variableValue = toVariableValue((ObjectValue) inputValue);
+        } else if (inputValue instanceof List) {
+            variableValue = toVariableValues((List) inputValue);
+        } else {
+            throw new AssertException("Should never happen. Did not expect NormalizedInputValue.getValue() of type: " + inputValue.getClass());
         }
         String varName = getVarName(queryVariableCount);
         return new VariableValueWithDefinition(
@@ -79,7 +80,7 @@ public class ValueToVariableValueCompiler {
         } else if (value instanceof NullValue) {
             return null;
         }
-        throw new AssertException("Should never happen. Cannot handle JSON node of type " + value.getClass());
+        throw new AssertException("Should never happen. Cannot handle JSON node of type: " + value.getClass());
     }
 
     private static String getVarName(int variableOrdinal) {

--- a/api/src/main/java/graphql/nadel/normalized/ValueToVariableValueCompiler.java
+++ b/api/src/main/java/graphql/nadel/normalized/ValueToVariableValueCompiler.java
@@ -1,0 +1,107 @@
+package graphql.nadel.normalized;
+
+import graphql.language.ArrayValue;
+import graphql.language.BooleanValue;
+import graphql.language.FloatValue;
+import graphql.language.IntValue;
+import graphql.language.ObjectField;
+import graphql.language.ObjectValue;
+import graphql.language.StringValue;
+import graphql.language.TypeName;
+import graphql.language.Value;
+import graphql.language.VariableDefinition;
+import graphql.language.VariableReference;
+import graphql.normalized.NormalizedInputValue;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+public class ValueToVariableValueCompiler {
+
+    static VariableValueWithDefinition normalizedInputValueToVariable(NormalizedInputValue normalizedInputValue) {
+        Object variableValue = null;
+        Object normalizedInputValueValue = normalizedInputValue.getValue();
+        if (normalizedInputValueValue instanceof ObjectValue) {
+            variableValue = toVariableValue((ObjectValue) normalizedInputValueValue);
+        }
+        if (normalizedInputValueValue instanceof ArrayValue) {
+            variableValue = toVariableValues(((ArrayValue) normalizedInputValueValue).getValues());
+        }
+        if (normalizedInputValueValue instanceof List) {
+            variableValue = toVariableValues((List) normalizedInputValueValue);
+        }
+        String varName = getVarName();
+        return new VariableValueWithDefinition(
+                variableValue,
+                VariableDefinition.newVariableDefinition()
+                        .name(varName)
+                        .type(TypeName.newTypeName(normalizedInputValue.getTypeName()).build())
+                        .build(),
+                VariableReference.newVariableReference().name(varName).build());
+    }
+
+    @NotNull
+    private static List<Object> toVariableValues(List<Value> values) {
+        ArrayList<Object> objects = new ArrayList<>();
+        for (Value value : values) {
+            objects.add(toVariableValue(value));
+        }
+        return objects;
+    }
+
+    private static Map<String, Object> toVariableValue(ObjectValue objectValue) {
+        HashMap<String, Object> map = new HashMap<>();
+        List<ObjectField> objectFields = objectValue.getObjectFields();
+        for (ObjectField objectField : objectFields) {
+            String objectFieldName = objectField.getName();
+            Value<?> objectFieldValue = objectField.getValue();
+            if (objectFieldValue instanceof ArrayValue) {
+                List<Object> objects = toVariableValues(((ArrayValue) objectFieldValue).getValues());
+                map.put(objectFieldName, objects);
+                continue;
+            }
+            map.put(objectFieldName, toVariableValue(objectFieldValue));
+        }
+        return map;
+    }
+
+    private static Object toVariableValue(Value value) {
+        if (value instanceof ObjectValue) {
+            return toVariableValue((ObjectValue) value);
+        }
+        if (value instanceof StringValue) {
+            return ((StringValue) value).getValue();
+        }
+        if (value instanceof FloatValue) {
+            return ((FloatValue) value).getValue();
+        }
+        if (value instanceof IntValue) {
+            return ((IntValue) value).getValue();
+        }
+        if (value instanceof BooleanValue) {
+            return ((BooleanValue) value).isValue();
+        }
+        return null; //todo
+    }
+
+    private static String getVarName() {
+        return "var_" + UUID.randomUUID().toString().replace("-", "_");
+    }
+
+    static class VariableValueWithDefinition {
+        final Object value;
+        final VariableDefinition definition;
+        final VariableReference variableReference;
+
+        public VariableValueWithDefinition(Object value, VariableDefinition definition, VariableReference variableReference) {
+            this.value = value;
+            this.definition = definition;
+            this.variableReference = variableReference;
+        }
+    }
+
+}

--- a/api/src/test/groovy/graphql/nadel/normalized/ExecutableNormalizedOperationToAstCompilerTest.groovy
+++ b/api/src/test/groovy/graphql/nadel/normalized/ExecutableNormalizedOperationToAstCompilerTest.groovy
@@ -676,7 +676,7 @@ class ExecutableNormalizedOperationToAstCompilerTest extends Specification {
         
         input InputWithJson {
           id: ID
-          json: JSON
+          json: [JSON!]
         }
         scalar JSON
         '''
@@ -686,12 +686,12 @@ class ExecutableNormalizedOperationToAstCompilerTest extends Specification {
         '''
         def variables = [var: [
                 id  : "ID-00",
-                json: [name    : "Zlatan",
-                       lastName: "Ibrahimoviç",
-                       clubs   : ["MU", "Barsa", "Inter", "Milan", null],
-                       "48x48" : "Zlatan_48x48.jpg",
-                       "96x96" : null
-                ]
+                json: [[name    : "Zlatan",
+                        lastName: "Ibrahimoviç",
+                        clubs   : ["MU", "Barsa", "Inter", "Milan", null],
+                        "48x48" : "Zlatan_48x48.jpg",
+                        "96x96" : null
+                       ]]
         ]]
         GraphQLSchema schema = TestUtil.schema(sdl)
         def fields = createNormalizedFields(schema, query, variables)
@@ -702,17 +702,16 @@ class ExecutableNormalizedOperationToAstCompilerTest extends Specification {
         def vars = variablesAndDocument.second
         then:
         vars.size() == 1
-        vars['var_0'] == [name    : "Zlatan",
-                          lastName: "Ibrahimoviç",
-                          clubs   : ["MU", "Barsa", "Inter", "Milan", null],
-                          "48x48" : "Zlatan_48x48.jpg",
-                          "96x96" : null
-        ]
-        def variableName = vars.keySet().first()
-        AstPrinter.printAst(document) == """mutation (\$$variableName: JSON) {
-  foo1(arg: {id : "ID-00", json : \$$variableName})
+        vars['var_0'] == [[name    : "Zlatan",
+                           lastName: "Ibrahimoviç",
+                           clubs   : ["MU", "Barsa", "Inter", "Milan", null],
+                           "48x48" : "Zlatan_48x48.jpg",
+                           "96x96" : null
+                          ]]
+        AstPrinter.printAst(document) == '''mutation ($var_0: [JSON!]) {
+  foo1(arg: {id : "ID-00", json : $var_0})
 }
-"""
+'''
     }
 
 

--- a/api/src/test/groovy/graphql/nadel/normalized/ExecutableNormalizedOperationToAstCompilerTest.groovy
+++ b/api/src/test/groovy/graphql/nadel/normalized/ExecutableNormalizedOperationToAstCompilerTest.groovy
@@ -1,0 +1,696 @@
+package graphql.nadel.normalized
+
+import graphql.GraphQL
+import graphql.language.AstPrinter
+import graphql.language.Document
+import graphql.nadel.testutils.TestUtil
+import graphql.normalized.ExecutableNormalizedField
+import graphql.normalized.ExecutableNormalizedOperationFactory
+import graphql.schema.GraphQLSchema
+import spock.lang.Specification
+
+import static graphql.language.OperationDefinition.Operation.MUTATION
+import static graphql.language.OperationDefinition.Operation.QUERY
+import static graphql.language.OperationDefinition.Operation.SUBSCRIPTION
+import static graphql.nadel.normalized.ExecutableNormalizedOperationToAstCompiler.compileToDocument
+
+class ExecutableNormalizedOperationToAstCompilerTest extends Specification {
+
+    def "test pet interfaces"() {
+        String sdl = """
+        type Query { 
+            animal: Animal
+        }
+        interface Animal {
+            name: String
+            friends: [Friend]
+        }
+
+        union Pet = Dog | Cat
+
+        type Friend {
+            name: String
+            isBirdOwner: Boolean
+            isCatOwner: Boolean
+            pets: [Pet] 
+        }
+
+        type Bird implements Animal {
+           name: String 
+           friends: [Friend]
+        }
+
+        type Cat implements Animal {
+           name: String 
+           friends: [Friend]
+           breed: String 
+           mood: String 
+        }
+
+        type Dog implements Animal {
+           name: String 
+           breed: String
+           friends: [Friend]
+        }
+        """
+
+        String query = """
+        {
+            animal {
+                name
+                otherName: name
+                ... on Animal {
+                    name
+                }
+                ... on Cat {
+                    name
+                    mood
+                    friends {
+                        ... on Friend {
+                            isCatOwner
+                            pets {
+                                ... on Dog {
+                                    name
+                                }
+                            }
+                        }
+                    }
+                }
+                ... on Bird {
+                    friends {
+                        isBirdOwner
+                    }
+                    friends {
+                        name
+                        pets {
+                            ... on Cat {
+                                breed
+                            }
+                        }
+                    }
+                }
+                ... on Dog {
+                    name
+                    breed
+                }
+            }
+        }
+        """
+        GraphQLSchema schema = TestUtil.schema(sdl)
+        def fields = createNormalizedFields(schema, query)
+        when:
+        def document = compileToDocument(schema, QUERY, null, fields).first
+        def printed = AstPrinter.printAst(document)
+        then:
+        printed == '''query {
+  animal {
+    ... on Bird {
+      name
+      otherName: name
+      friends {
+        isBirdOwner
+        name
+        pets {
+          ... on Cat {
+            breed
+          }
+        }
+      }
+    }
+    ... on Cat {
+      name
+      otherName: name
+      mood
+      friends {
+        isCatOwner
+        pets {
+          ... on Dog {
+            name
+          }
+        }
+      }
+    }
+    ... on Dog {
+      name
+      otherName: name
+      breed
+    }
+  }
+}
+'''
+    }
+
+    def "test a combination of plain objects and interfaces"() {
+        def sdl = '''
+        type Query {
+            foo(arg: I): Foo
+        }
+        type Foo {
+            bar(arg: I): Bar
+        }
+        type Bar {
+            baz : Baz
+        }
+        interface Baz {
+            boo : String
+        }
+        type ABaz implements Baz {
+            boo : String
+            a : String
+        }
+        type BBaz implements Baz {
+            boo : String
+            b : String
+        }
+        input I {
+            arg1: String
+        }
+        '''
+        def query = '''query {
+    foo(arg: {arg1 : "fooArg"}) {
+        bar(arg: {arg1 : "barArg"}) {
+            baz {
+                ... on ABaz {
+                    boo
+                    a
+                }
+            }
+        }
+    }
+}
+        '''
+        GraphQLSchema schema = TestUtil.schema(sdl)
+        def fields = createNormalizedFields(schema, query)
+        when:
+        def document = compileToDocument(schema, QUERY, null, fields).first
+        then:
+        AstPrinter.printAst(document) == '''query {
+  foo(arg: {arg1 : "fooArg"}) {
+    bar(arg: {arg1 : "barArg"}) {
+      baz {
+        ... on ABaz {
+          boo
+          a
+        }
+      }
+    }
+  }
+}
+'''
+    }
+
+    def "test arguments"() {
+        def sdl = '''
+        type Query {
+            foo1(arg: String): String
+            foo2(a: Int, b: Boolean, c: Float): String
+        }
+        '''
+        def query = ''' {
+            foo1(arg: "hello")
+            foo2(a: 123, b: true, c: 123.45)
+        }
+        '''
+        GraphQLSchema schema = TestUtil.schema(sdl)
+        def fields = createNormalizedFields(schema, query)
+        when:
+        def document = compileToDocument(schema, QUERY, null, fields).first
+        then:
+        AstPrinter.printAst(document) == '''query {
+  foo1(arg: "hello")
+  foo2(a: 123, b: true, c: 123.45)
+}
+'''
+    }
+
+    def "sets operation name"() {
+        def sdl = '''
+        type Query {
+            foo1(arg: String): String
+            foo2(a: Int,b: Boolean, c: Float): String
+        }
+        '''
+        def query = ''' {
+            foo1(arg: "hello")
+            foo2(a: 123, b: true, c: 123.45)
+        }
+        '''
+        GraphQLSchema schema = TestUtil.schema(sdl)
+        def fields = createNormalizedFields(schema, query)
+        when:
+        def document = compileToDocument(schema, QUERY, "My_Op23", fields).first
+        then:
+        AstPrinter.printAst(document) == '''query My_Op23 {
+  foo1(arg: "hello")
+  foo2(a: 123, b: true, c: 123.45)
+}
+'''
+    }
+
+    def "test input object arguments"() {
+        def sdl = '''
+        type Query {
+            foo1(arg: I): String
+        }
+        input I {
+            arg1: String
+            arg2: Int
+            arg3: ID
+            arg4: Boolean
+            arg5: Float
+            nested: I
+        }
+        '''
+        def query = '''{
+            foo1(arg: {
+             arg1: "Hello"
+             arg2: 123
+             arg3: "IDID"
+             arg4: false
+             arg5: 123.123
+             nested: {
+                 arg1: "Hello2"
+                 arg2: 1234
+                 arg3: "IDID1"
+                 arg4: null
+                 arg5: null
+             }
+            })
+        }
+        '''
+        GraphQLSchema schema = TestUtil.schema(sdl)
+        def fields = createNormalizedFields(schema, query)
+        when:
+        def document = compileToDocument(schema, QUERY, null, fields).first
+        then:
+        AstPrinter.printAst(document) == '''query {
+  foo1(arg: {arg1 : "Hello", arg2 : 123, arg3 : "IDID", arg4 : false, arg5 : 123.123, nested : {arg1 : "Hello2", arg2 : 1234, arg3 : "IDID1", arg4 : null, arg5 : null}})
+}
+'''
+    }
+
+    def "test mutations"() {
+        def sdl = '''
+        type Query {
+            foo1(arg: I): String
+        }
+        type Mutation {
+            foo1(arg: I): String
+        }
+        input I {
+            arg1: String
+        }
+        '''
+        def query = '''mutation {
+            foo1(arg: {
+             arg1: "Mutation"
+            })
+        }
+        '''
+        GraphQLSchema schema = TestUtil.schema(sdl)
+        def fields = createNormalizedFields(schema, query)
+        when:
+        def document = compileToDocument(schema, MUTATION, null, fields).first
+        then:
+        AstPrinter.printAst(document) == '''mutation {
+  foo1(arg: {arg1 : "Mutation"})
+}
+'''
+    }
+
+    def "test JSON when input is a variable"() {
+        def sdl = '''
+        type Query {
+            foo: String
+        }
+        type Mutation {
+            foo1(arg: JSON!): String
+        }
+        
+        scalar JSON
+        '''
+        def query = '''mutation hello($var: JSON!) {
+            foo1(arg: $var)
+        }
+        '''
+        GraphQLSchema schema = TestUtil.schema(sdl)
+
+        def vars = [var: ["48x48": "hello"]]
+        def fields = createNormalizedFields(schema, query, vars)
+
+        def pair = compileToDocument(schema, MUTATION, null, fields)
+        when:
+        def document = pair.first
+        def variables = pair.second
+        then:
+        variables.size() == 1
+        variables.values().first() == ["48x48": "hello"]
+        def varName = variables.keySet().first()
+        AstPrinter.printAst(document) == """mutation (\$$varName: JSON!) {
+  foo1(arg: \$$varName)
+}
+"""
+    }
+
+    def "test JSON scalar when input is inlined"() {
+        def sdl = '''
+        type Query {
+            foo: String
+        }
+        type Mutation {
+            foo1(arg: JSON!): String
+        }
+        
+        scalar JSON
+        '''
+        def query = '''mutation {
+            foo1(arg: {one: "two", three: ["four", "five"]})
+        }
+        '''
+        def variables = [var: ["48x48": "hello"]]
+        GraphQLSchema schema = TestUtil.schema(sdl)
+        def fields = createNormalizedFields(schema, query, variables)
+
+        def pair = compileToDocument(schema, MUTATION, null, fields)
+        when:
+        def document = pair.first
+        def vars = pair.second
+        then:
+        vars.size() == 1
+        vars.values().first() == [one: "two", three: ["four", "five"]]
+        def varName = vars.keySet().first()
+        AstPrinter.printAst(document) == """mutation (\$$varName: JSON!) {
+  foo1(arg: \$$varName)
+}
+"""
+    }
+
+    def "test JSON scalar inside an input type"() {
+        def sdl = '''
+        type Query {
+            foo: String
+        }
+        type Mutation {
+            foo1(arg: InputWithJson): String
+        }
+        
+        input InputWithJson {
+          id: ID
+          json: JSON
+        }
+        scalar JSON
+        '''
+        def query = '''mutation {
+            foo1(arg: {id: "ID-00", json: {name: "Zlatan", lastName: "Ibrahimoviç", clubs: ["MU", "Barsa", "Inter", "Milan"]}})
+        }
+        '''
+
+        GraphQLSchema schema = TestUtil.schema(sdl)
+        def fields = createNormalizedFields(schema, query)
+
+        def variablesAndDocument = compileToDocument(schema, MUTATION, null, fields)
+        when:
+        def document = variablesAndDocument.first
+        def vars = variablesAndDocument.second
+        then:
+        vars.size() == 1
+        vars.values().first() == [lastName: "Ibrahimoviç", name: "Zlatan", clubs: ["MU", "Barsa", "Inter", "Milan"]]
+        def variableName = vars.keySet().first()
+        AstPrinter.printAst(document) == """mutation (\$$variableName: JSON) {
+  foo1(arg: {id : "ID-00", json : \$$variableName})
+}
+"""
+    }
+
+    def "test JSON scalar inside an input type, json key is illegal graphql input name"() {
+        def sdl = '''
+        type Query {
+            foo: String
+        }
+        type Mutation {
+            foo1(arg: InputWithJson): String
+        }
+        
+        input InputWithJson {
+          id: ID
+          json: JSON
+        }
+        scalar JSON
+        '''
+        def query = '''mutation test($var: InputWithJson) {
+            foo1(arg: $var)
+        }
+        '''
+        def variables = [var: [
+                id  : "ID-00",
+                json: [name    : "Zlatan",
+                       lastName: "Ibrahimoviç",
+                       clubs   : ["MU", "Barsa", "Inter", "Milan"],
+                       "48x48" : "Zlatan_48x48.jpg"
+                ]
+        ]]
+        GraphQLSchema schema = TestUtil.schema(sdl)
+        def fields = createNormalizedFields(schema, query, variables)
+
+        def variablesAndDocument = compileToDocument(schema, MUTATION, null, fields)
+        when:
+        def document = variablesAndDocument.first
+        def vars = variablesAndDocument.second
+        then:
+        vars.size() == 1
+        vars.values().first() == ["48x48": "Zlatan_48x48.jpg", lastName: "Ibrahimoviç", name: "Zlatan", clubs: ["MU", "Barsa", "Inter", "Milan"]]
+        def variableName = vars.keySet().first()
+        AstPrinter.printAst(document) == """mutation (\$$variableName: JSON) {
+  foo1(arg: {id : "ID-00", json : \$$variableName})
+}
+"""
+    }
+
+    def "test subscriptions"() {
+        def sdl = '''
+        type Query {
+            foo1(arg: I): String
+        }
+        type Subscription {
+            foo1(arg: I): String
+        }
+        input I {
+            arg1: String
+        }
+        '''
+        def query = '''subscription {
+            foo1(arg: {
+             arg1: "Subscription"
+            })
+        }
+        '''
+        GraphQLSchema schema = TestUtil.schema(sdl)
+        def fields = createNormalizedFields(schema, query)
+        when:
+        def document = compileToDocument(schema, SUBSCRIPTION, null, fields).first
+        then:
+        AstPrinter.printAst(document) == '''subscription {
+  foo1(arg: {arg1 : "Subscription"})
+}
+'''
+    }
+
+    def "test redundant inline fragments specified in original query"() {
+        def sdl = '''
+        type Query {
+            foo1(arg: I): Foo 
+        }
+        type Mutation {
+            foo1(arg: I): Foo 
+        }
+        type Foo {
+            test: String
+        }
+        input I {
+            arg1: String
+        }
+        '''
+        def query = '''mutation {
+            ... on Mutation {
+                foo1(arg: {
+                    arg1: "Mutation"
+                }) {
+                    ... on Foo {
+                        test
+                    }
+                }
+            }
+        }
+        '''
+        GraphQLSchema schema = TestUtil.schema(sdl)
+        def fields = createNormalizedFields(schema, query)
+        when:
+        def document = compileToDocument(schema, MUTATION, null, fields).first
+        then:
+        AstPrinter.printAst(document) == '''mutation {
+  foo1(arg: {arg1 : "Mutation"}) {
+    test
+  }
+}
+'''
+    }
+
+    def "inserts inline fragment on interface types"() {
+        def sdl = '''
+        type Query {
+            foo1(arg: I): Foo 
+        }
+        type Mutation {
+            foo1(arg: I): Foo 
+        }
+        interface Foo {
+            test: String
+        }
+        type AFoo implements Foo {
+            test: String
+        }
+        input I {
+            arg1: String
+        }
+        '''
+        def query = '''query {
+            ... on Query {
+                foo1(arg: {
+                    arg1: "Query"
+                }) {
+                    ... on Foo {
+                        test
+                    }
+                }
+            }
+        }
+        '''
+        GraphQLSchema schema = TestUtil.schema(sdl)
+        def fields = createNormalizedFields(schema, query)
+        when:
+        def document = compileToDocument(schema, QUERY, null, fields).first
+        then:
+        AstPrinter.printAst(document) == '''query {
+  foo1(arg: {arg1 : "Query"}) {
+    ... on AFoo {
+      test
+    }
+  }
+}
+'''
+    }
+
+    def "handles concrete and abstract fields"() {
+        def sdl = '''
+        type Query {
+            foo1(arg: I): Foo 
+        }
+        type Mutation {
+            foo1(arg: I): Foo 
+        }
+        interface Foo {
+            test: String
+        }
+        type AFoo implements Foo {
+            test: String
+            afoo: String
+        }
+        input I {
+            arg1: String
+        }
+        '''
+        def query = '''query {
+            ... on Query {
+                foo1(arg: {
+                    arg1: "Query"
+                }) {
+                    test
+                    ... on AFoo {
+                        afoo
+                    }
+                    ... on AFoo {
+                        __typename
+                    }
+                }
+            }
+        }
+        '''
+        GraphQLSchema schema = TestUtil.schema(sdl)
+        def fields = createNormalizedFields(schema, query)
+        when:
+        def document = compileToDocument(schema, QUERY, null, fields).first
+        then:
+        AstPrinter.printAst(document) == '''query {
+  foo1(arg: {arg1 : "Query"}) {
+    ... on AFoo {
+      test
+      afoo
+      __typename
+    }
+  }
+}
+'''
+    }
+
+    def "handles typename outside fragment and inside fragment"() {
+        def sdl = '''
+        type Query {
+            foo1(arg: I): Foo 
+        }
+        type Mutation {
+            foo1(arg: I): Foo 
+        }
+        interface Foo {
+            test: String
+        }
+        type AFoo implements Foo {
+            test: String
+        }
+        input I {
+            arg1: String
+        }
+        '''
+        def query = '''query {
+            ... on Query {
+                foo1(arg: {
+                    arg1: "Query"
+                }) {
+                    __typename
+                    test
+                    ... on AFoo {
+                        __typename
+                    }
+                }
+            }
+        }
+        '''
+        GraphQLSchema schema = TestUtil.schema(sdl)
+        def fields = createNormalizedFields(schema, query)
+        when:
+        def document = compileToDocument(schema, QUERY, null, fields).first
+        then:
+        AstPrinter.printAst(document) == '''query {
+  foo1(arg: {arg1 : "Query"}) {
+    ... on AFoo {
+      __typename
+      test
+    }
+  }
+}
+'''
+    }
+
+    private List<ExecutableNormalizedField> createNormalizedFields(GraphQLSchema schema, String query, Map<String, Object> variables = [:]) {
+        assertValidQuery(schema, query, variables)
+        Document originalDocument = TestUtil.parseQuery(query)
+
+        ExecutableNormalizedOperationFactory dependencyGraph = new ExecutableNormalizedOperationFactory()
+        def tree = dependencyGraph.createExecutableNormalizedOperationWithRawVariables(schema, originalDocument, null, variables)
+        return tree.getTopLevelFields()
+    }
+
+    private void assertValidQuery(GraphQLSchema graphQLSchema, String query, Map variables = [:]) {
+        GraphQL graphQL = GraphQL.newGraphQL(graphQLSchema).build()
+        assert graphQL.execute(query, null, variables).errors.size() == 0
+    }
+}

--- a/api/src/test/groovy/graphql/nadel/normalized/ExecutableNormalizedOperationToAstCompilerTest.groovy
+++ b/api/src/test/groovy/graphql/nadel/normalized/ExecutableNormalizedOperationToAstCompilerTest.groovy
@@ -567,6 +567,66 @@ class ExecutableNormalizedOperationToAstCompilerTest extends Specification {
 '''
     }
 
+    def "test JSON scalar when JSON arg is null"() {
+        def sdl = '''
+        type Query {
+            foo: String
+        }
+        type Mutation {
+            foo1(arg: JSON): String
+        }
+        
+        scalar JSON
+        '''
+        def query = '''mutation {
+            foo1
+        }
+        '''
+        GraphQLSchema schema = TestUtil.schema(sdl)
+        def fields = createNormalizedFields(schema, query)
+
+        def pair = compileToDocument(schema, MUTATION, null, fields)
+        when:
+        def document = pair.first
+        def variables = pair.second
+        then:
+        variables == [:]
+        AstPrinter.printAst(document) == '''mutation {
+  foo1
+}
+'''
+    }
+
+    def "test JSON scalar when JSON arg is explicitly null"() {
+        def sdl = '''
+        type Query {
+            foo: String
+        }
+        type Mutation {
+            foo1(arg: JSON): String
+        }
+        
+        scalar JSON
+        '''
+        def query = '''mutation {
+            foo1(arg: null)
+        }
+        '''
+        GraphQLSchema schema = TestUtil.schema(sdl)
+        def fields = createNormalizedFields(schema, query)
+
+        def pair = compileToDocument(schema, MUTATION, null, fields)
+        when:
+        def document = pair.first
+        def variables = pair.second
+        then:
+        variables == [:]
+        AstPrinter.printAst(document) == '''mutation {
+  foo1(arg: null)
+}
+'''
+    }
+
     def "test JSON scalar when input is inlined"() {
         def sdl = '''
         type Query {
@@ -661,6 +721,76 @@ class ExecutableNormalizedOperationToAstCompilerTest extends Specification {
         vars['var_0'] == [lastName: "Ibrahimoviç", name: "Zlatan", clubs: ["MU", "Barsa", "Inter", "Milan"]]
         AstPrinter.printAst(document) == '''mutation ($var_0: JSON) {
   foo1(arg: {id : "ID-00", json : $var_0})
+}
+'''
+    }
+
+    def "test JSON scalar inside an input type, json value is explicitly null"() {
+        def sdl = '''
+        type Query {
+            foo: String
+        }
+        type Mutation {
+            foo1(arg: InputWithJson): String
+        }
+        
+        input InputWithJson {
+          id: ID
+          json: JSON
+        }
+        scalar JSON
+        '''
+        def query = '''mutation {
+            foo1(arg: {id: "ID-00", json: null})
+        }
+        '''
+
+        GraphQLSchema schema = TestUtil.schema(sdl)
+        def fields = createNormalizedFields(schema, query)
+
+        def variablesAndDocument = compileToDocument(schema, MUTATION, null, fields)
+        when:
+        def document = variablesAndDocument.first
+        def vars = variablesAndDocument.second
+        then:
+        vars == [:]
+        AstPrinter.printAst(document) == '''mutation {
+  foo1(arg: {id : "ID-00", json : null})
+}
+'''
+    }
+
+    def "test JSON scalar inside an input type, json value is null"() {
+        def sdl = '''
+        type Query {
+            foo: String
+        }
+        type Mutation {
+            foo1(arg: InputWithJson): String
+        }
+        
+        input InputWithJson {
+          id: ID
+          json: JSON
+        }
+        scalar JSON
+        '''
+        def query = '''mutation {
+            foo1(arg: {id: "ID-00"})
+        }
+        '''
+
+        GraphQLSchema schema = TestUtil.schema(sdl)
+        def fields = createNormalizedFields(schema, query)
+
+        def variablesAndDocument = compileToDocument(schema, MUTATION, null, fields)
+        when:
+        def document = variablesAndDocument.first
+        def vars = variablesAndDocument.second
+        then:
+        vars == [:]
+        AstPrinter.printAst(document) == '''mutation {
+  foo1(arg: {id : "ID-00"})
 }
 '''
     }

--- a/api/src/test/groovy/graphql/nadel/testutils/MockWiringFactory.groovy
+++ b/api/src/test/groovy/graphql/nadel/testutils/MockWiringFactory.groovy
@@ -1,16 +1,44 @@
 package graphql.nadel.testutils
 
+import com.google.common.collect.ImmutableMap
 import graphql.TypeResolutionEnvironment
+import graphql.scalars.ExtendedScalars
 import graphql.schema.DataFetcher
 import graphql.schema.GraphQLObjectType
+import graphql.schema.GraphQLScalarType
 import graphql.schema.PropertyDataFetcher
 import graphql.schema.TypeResolver
 import graphql.schema.idl.FieldWiringEnvironment
 import graphql.schema.idl.InterfaceWiringEnvironment
+import graphql.schema.idl.ScalarInfo
+import graphql.schema.idl.ScalarWiringEnvironment
 import graphql.schema.idl.UnionWiringEnvironment
 import graphql.schema.idl.WiringFactory
 
 class MockedWiringFactory implements WiringFactory {
+
+    private static final ImmutableMap<String, GraphQLScalarType> SCALARS = ImmutableMap.of(
+            ExtendedScalars.Json.getName(), ExtendedScalars.Json
+    )
+
+    @Override
+    boolean providesScalar(ScalarWiringEnvironment env) {
+        String scalarName = env.getScalarTypeDefinition().getName()
+        if (SCALARS.containsKey(scalarName)) {
+            return true
+        }
+        return !(ScalarInfo.isGraphqlSpecifiedScalar(scalarName))
+    }
+
+    @Override
+    GraphQLScalarType getScalar(ScalarWiringEnvironment env) {
+        String scalarName = env.getScalarTypeDefinition().getName()
+        GraphQLScalarType scalarType = SCALARS.get(scalarName)
+        if (scalarType != null) {
+            return scalarType
+        }
+        return null
+    }
 
     @Override
     boolean providesTypeResolver(InterfaceWiringEnvironment environment) {

--- a/engine-nextgen/src/main/kotlin/graphql/nadel/NextgenEngine.kt
+++ b/engine-nextgen/src/main/kotlin/graphql/nadel/NextgenEngine.kt
@@ -7,6 +7,7 @@ import graphql.ExecutionResultImpl.newExecutionResult
 import graphql.GraphQLError
 import graphql.execution.instrumentation.InstrumentationState
 import graphql.language.Document
+import graphql.nadel.normalized.ExecutableNormalizedOperationToAstCompiler.compileToDocument
 import graphql.nadel.ServiceExecutionParameters.newServiceExecutionParameters
 import graphql.nadel.enginekt.NadelExecutionContext
 import graphql.nadel.enginekt.blueprint.NadelDefaultIntrospectionRunner
@@ -40,7 +41,6 @@ import graphql.nadel.util.ErrorUtil
 import graphql.nadel.util.OperationNameUtil
 import graphql.normalized.ExecutableNormalizedField
 import graphql.normalized.ExecutableNormalizedOperationFactory.createExecutableNormalizedOperationWithRawVariables
-import graphql.normalized.ExecutableNormalizedOperationToAstCompiler.compileToDocument
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -265,7 +265,7 @@ class NextgenEngine @JvmOverloads constructor(
         executionHydrationDetails: ServiceExecutionHydrationDetails? = null,
     ): ServiceExecutionResult {
         val executionInput = executionContext.executionInput
-        val document: Document = compileToDocument(
+        val (document, variables) = compileToDocument(
             service.underlyingSchema,
             transformedQuery.getOperationKind(overallSchema),
             getOperationName(service, executionContext),
@@ -277,7 +277,7 @@ class NextgenEngine @JvmOverloads constructor(
             .context(executionInput.context)
             .executionId(executionInput.executionId ?: executionIdProvider.provide(executionInput))
             .cacheControl(executionInput.cacheControl)
-            .variables(emptyMap())
+            .variables(variables)
             .fragments(emptyMap())
             .operationDefinition(document.definitions.singleOfType())
             .serviceContext(executionContext.getContextForService(service).await())

--- a/test/build.gradle.kts
+++ b/test/build.gradle.kts
@@ -14,6 +14,7 @@ dependencies {
     testImplementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.9.6")
     testImplementation("io.kotest:kotest-runner-junit5:4.6.0")
     testImplementation("io.strikt:strikt-jvm:0.31.0")
+    testImplementation("com.graphql-java:graphql-java-extended-scalars:2021-06-29T01-19-32-8e19827")
 }
 
 tasks.withType<Test> {

--- a/test/src/test/kotlin/graphql/nadel/tests/EngineTestHook.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/EngineTestHook.kt
@@ -4,9 +4,11 @@ import graphql.ExecutionResult
 import graphql.nadel.Nadel
 import graphql.nadel.NadelExecutionInput
 import graphql.nadel.enginekt.transform.NadelTransform
+import graphql.nadel.schema.NeverWiringFactory
 import graphql.nadel.schema.SchemaTransformationHook
 import graphql.nadel.tests.util.join
 import graphql.nadel.tests.util.toSlug
+import graphql.schema.idl.WiringFactory
 import org.reflections.Reflections
 import java.io.File
 
@@ -27,6 +29,9 @@ interface EngineTestHook {
 
     val schemaTransformationHook: SchemaTransformationHook
         get() = SchemaTransformationHook.IDENTITY
+
+    val wiringFactory: WiringFactory
+        get() = NeverWiringFactory()
 
     fun makeNadel(engineType: NadelEngineType, builder: Nadel.Builder): Nadel.Builder {
         return builder

--- a/test/src/test/kotlin/graphql/nadel/tests/EngineTests.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/EngineTests.kt
@@ -142,6 +142,8 @@ private suspend fun execute(
                 engineFactory.make(nadel, testHooks)
             }
             .dsl(fixture.overallSchema)
+            .overallWiringFactory(testHooks.wiringFactory)
+            .underlyingWiringFactory(testHooks.wiringFactory)
             .serviceExecutionFactory(object : ServiceExecutionFactory {
                 private val astSorter = AstSorter()
                 private val serviceCalls = fixture.serviceCalls[engineType].toMutableList()
@@ -161,6 +163,7 @@ private suspend fun execute(
                                         it.serviceName == serviceName
                                             && AstPrinter.printAst(it.request.document) == incomingQueryPrinted
                                             && it.request.operationName == params.operationDefinition.name
+                                            && it.request.variables == params.variables
                                     }
                                     .takeIf { it != -1 }
 

--- a/test/src/test/kotlin/graphql/nadel/tests/hooks/json-handling.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/hooks/json-handling.kt
@@ -1,0 +1,33 @@
+package graphql.nadel.tests.hooks
+
+import graphql.nadel.schema.NeverWiringFactory
+import graphql.nadel.tests.EngineTestHook
+import graphql.nadel.tests.UseHook
+import graphql.scalars.ExtendedScalars
+import graphql.schema.GraphQLScalarType
+import graphql.schema.idl.ScalarWiringEnvironment
+
+class NeverWiringFactoryWithExtendedJsonScalar : NeverWiringFactory() {
+
+    override fun providesScalar(environment: ScalarWiringEnvironment): Boolean {
+        val scalarName: String? = environment.scalarTypeDefinition?.name
+        return scalarName == ExtendedScalars.Json.name
+    }
+
+    override fun getScalar(environment: ScalarWiringEnvironment): GraphQLScalarType? {
+        return when (environment.scalarTypeDefinition?.name) {
+            ExtendedScalars.Json.name -> ExtendedScalars.Json
+            else -> null
+        }
+    }
+}
+
+@UseHook
+class `inlined-json-arguments` : EngineTestHook {
+    override val wiringFactory = NeverWiringFactoryWithExtendedJsonScalar()
+}
+
+@UseHook
+class `input-object-with-json-field` : EngineTestHook {
+    override val wiringFactory = NeverWiringFactoryWithExtendedJsonScalar()
+}

--- a/test/src/test/resources/fixtures/hydration/hydration-within-hydration-with-variables.yml
+++ b/test/src/test/resources/fixtures/hydration/hydration-within-hydration-with-variables.yml
@@ -89,7 +89,7 @@ serviceCalls:
               issueId
             }
           }
-        variables: {}
+        variables: { }
         operationName: nadel_2_boards
       # language=JSON
       response: |-
@@ -109,7 +109,7 @@ serviceCalls:
               cloudId
             }
           }
-        variables: {}
+        variables: { }
         operationName: nadel_2_issues
       # language=JSON
       response: |-
@@ -129,7 +129,7 @@ serviceCalls:
               totalCount
             }
           }
-        variables: {}
+        variables: { first: 10 }
         operationName: nadel_2_comments
       # language=JSON
       response: |-
@@ -151,7 +151,7 @@ serviceCalls:
               hydration__issue__issueId: issueId
             }
           }
-        variables: {}
+        variables: { }
       # language=JSON
       response: |-
         {
@@ -172,7 +172,7 @@ serviceCalls:
               hydration__comments__cloudId: cloudId
             }
           }
-        variables: {}
+        variables: { }
       # language=JSON
       response: |-
         {
@@ -192,7 +192,7 @@ serviceCalls:
               totalCount
             }
           }
-        variables: {}
+        variables: { }
       # language=JSON
       response: |-
         {
@@ -207,14 +207,14 @@ serviceCalls:
 response: |-
   {
     "data":
-      {
-        "board": {
-          "issue": {
-            "comments": {
-              "totalCount":10
-            }
+    {
+      "board": {
+        "issue": {
+          "comments": {
+            "totalCount":10
           }
         }
-      },
-  "extensions": {}
+      }
+    },
+    "extensions": {}
   }

--- a/test/src/test/resources/fixtures/hydration/query-with-hydrated-interfaces-work-as-expected-on-nextgen.yml
+++ b/test/src/test/resources/fixtures/hydration/query-with-hydrated-interfaces-work-as-expected-on-nextgen.yml
@@ -145,101 +145,6 @@ query: |
 variables:
   isLoyal: true
 serviceCalls:
-  current:
-    - serviceName: PetService
-      request:
-        query: |
-          query nadel_2_PetService_petQ($isLoyal: Boolean) {
-            pets(isLoyal: $isLoyal) {
-              name
-              ownerIds
-              type_hint_typename__UUID: __typename
-            }
-          }
-        variables:
-          isLoyal: true
-        operationName: nadel_2_PetService_petQ
-      # language=JSON
-      response: |-
-        {
-          "data": {
-            "pets": [
-              {
-                "name": "Sparky",
-                "ownerIds": [
-                  "dearly"
-                ],
-                "type_hint_typename__UUID": "Dog"
-              },
-              {
-                "name": "Whiskers",
-                "ownerIds": [
-                  "cruella"
-                ],
-                "type_hint_typename__UUID": "Cat"
-              }
-            ]
-          },
-          "extensions": {}
-        }
-    - serviceName: OwnerService
-      request:
-        query: |
-          query nadel_2_OwnerService_petQ {
-            ownerById(id: "dearly") {
-              name
-              ... on CaringOwner {
-                givesPats
-              }
-              ... on CruelOwner {
-                givesSmacks
-              }
-              type_hint_typename__UUID: __typename
-            }
-          }
-        variables: {}
-        operationName: nadel_2_OwnerService_petQ
-      # language=JSON
-      response: |-
-        {
-          "data": {
-            "ownerById": {
-              "name": "Mr Dearly",
-              "givesPats": true,
-              "type_hint_typename__UUID": "CaringOwner"
-            }
-          },
-          "extensions": {}
-        }
-    - serviceName: OwnerService
-      request:
-        query: |
-          query nadel_2_OwnerService_petQ {
-            ownerById(id: "cruella") {
-              name
-              ... on CaringOwner {
-                givesPats
-              }
-              ... on CruelOwner {
-                givesSmacks
-              }
-              type_hint_typename__UUID: __typename
-            }
-          }
-        variables: {}
-        operationName: nadel_2_OwnerService_petQ
-      # language=JSON
-      response: |-
-        {
-          "data": {
-            "ownerById": {
-              "name": "Cruella De Vil",
-              "givesSmacks": true,
-              "type_hint_typename__UUID": "CruelOwner"
-            }
-          },
-          "extensions": {}
-        }
   nextgen:
     - serviceName: PetService
       request:
@@ -258,8 +163,7 @@ serviceCalls:
               }
             }
           }
-        variables:
-          isLoyal: true
+        variables: { }
         operationName: petQ
       # language=JSON
       response: |-
@@ -299,7 +203,7 @@ serviceCalls:
               }
             }
           }
-        variables: {}
+        variables: { }
         operationName: petQ
       # language=JSON
       response: |-
@@ -327,7 +231,7 @@ serviceCalls:
               }
             }
           }
-        variables: {}
+        variables: { }
         operationName: petQ
       # language=JSON
       response: |-

--- a/test/src/test/resources/fixtures/json scalar handling/inlined-json-arguments.yml
+++ b/test/src/test/resources/fixtures/json scalar handling/inlined-json-arguments.yml
@@ -1,0 +1,76 @@
+name: inlined json arguments
+enabled:
+  current: true
+  nextgen: true
+overallSchema:
+  MyService: |
+    type Query {
+      hello(arg: InputWithJson, arg1: JSON!): String
+    }
+    
+    input InputWithJson {
+      payload: JSON 
+    }
+    
+    scalar JSON
+underlyingSchema:
+  MyService: |-
+    type Query {
+      hello(arg: InputWithJson, arg1: JSON!): String
+    }
+    
+    input InputWithJson {
+      payload: JSON 
+    }
+    
+    scalar JSON
+query: |
+  query myQuery {
+    hello(arg: {payload: {name: "Bobert", age: "23"}}, arg1: {interests: ["photography", "basketball"]})
+  }
+variables: { }
+serviceCalls:
+  current:
+    - serviceName: MyService
+      request:
+        query: |
+          query nadel_2_MyService_myQuery {
+              hello(arg: {payload: {name: "Bobert", age: "23"}}, arg1: {interests: ["photography", "basketball"]})
+          }
+        variables: { }
+        operationName: nadel_2_MyService_myQuery
+      # language=JSON
+      response: |-
+        {
+          "data": {
+            "hello": "world"
+          },
+          "extensions": {}
+        }
+  nextgen:
+    - serviceName: MyService
+      request:
+        query: |
+          query myQuery($var_0: JSON, $var_1: JSON!) {
+            hello(arg: {payload : $var_0}, arg1: $var_1)
+          }
+        variables:
+          var_0: { "name": "Bobert", age: "23" }
+          var_1: { interests: [ "photography", "basketball" ] }
+        operationName: myQuery
+      # language=JSON
+      response: |-
+        {
+          "data": {
+            "hello": "world"
+          },
+          "extensions": {}
+        }
+# language=JSON
+response: |-
+  {
+    "data": {
+      "hello": "world"
+    },
+    "extensions": {}
+  }

--- a/test/src/test/resources/fixtures/json scalar handling/input-object-with-json-field.yml
+++ b/test/src/test/resources/fixtures/json scalar handling/input-object-with-json-field.yml
@@ -1,0 +1,80 @@
+name: input object with json field
+enabled:
+  current: true
+  nextgen: true
+overallSchema:
+  MyService: |
+    type Query {
+      hello(arg: InputWithJson): String
+    }
+    
+    input InputWithJson {
+      payload: JSON 
+    }
+    
+    scalar JSON
+underlyingSchema:
+  MyService: |-
+    type Query {
+      hello(arg: InputWithJson): String
+    }
+    
+    input InputWithJson {
+      payload: JSON 
+    }
+    
+    scalar JSON
+query: |
+  query myQuery($var: JSON!) {
+    hello(arg: {payload: $var})
+  }
+variables:
+  var:
+    "48x48": "file.jpeg"
+serviceCalls:
+  current:
+    - serviceName: MyService
+      request:
+        query: |
+          query nadel_2_MyService_myQuery($var: JSON!) {
+              hello(arg: {payload: $var})
+          }
+        variables:
+          var:
+            "48x48": "file.jpeg"
+        operationName: nadel_2_MyService_myQuery
+      # language=JSON
+      response: |-
+        {
+          "data": {
+            "hello": "world"
+          },
+          "extensions": {}
+        }
+  nextgen:
+    - serviceName: MyService
+      request:
+        query: |
+          query myQuery($var_0: JSON) {
+            hello(arg: {payload : $var_0})
+          }
+        variables:
+          var_0:
+            "48x48": "file.jpeg"
+        operationName: myQuery
+      # language=JSON
+      response: |-
+        {
+          "data": {
+            "hello": "world"
+          },
+          "extensions": {}
+        }
+# language=JSON
+response: |-
+  {
+    "data": {
+      "hello": "world"
+    },
+    "extensions": {}
+  }


### PR DESCRIPTION
Please make sure you consider the following:

- [x] Add tests that use __typename in queries
- [x] Does this change work with all nadel transformations (rename, type rename, hydration, etc)? Add tests for this.
- [x] Is it worth using hints for this change in order to be able to enable a percentage rollout?
- [x] Do we need to add integration tests for this change in the graphql gateway?
- [x] Do we need a pollinator check for this?
