### PR TITLE
pass hydration info to NadelTransform isApplicable

### DIFF
--- a/engine-nextgen/src/main/kotlin/graphql/nadel/NextgenEngine.kt
+++ b/engine-nextgen/src/main/kotlin/graphql/nadel/NextgenEngine.kt
@@ -212,7 +212,7 @@ class NextgenEngine @JvmOverloads constructor(
             it.children.single()
         }
 
-        val (transformResult, executionPlan) = transformHydrationQuery(service, executionContext, actorField)
+        val (transformResult, executionPlan) = transformHydrationQuery(service, executionContext, actorField, serviceHydrationDetails)
 
         // Get to the top level field again using .parent N times on the new actor field
         val transformedQuery: ExecutableNormalizedField = fold(
@@ -243,8 +243,15 @@ class NextgenEngine @JvmOverloads constructor(
         service: Service,
         executionContext: NadelExecutionContext,
         actorField: ExecutableNormalizedField,
+        serviceHydrationDetails: ServiceExecutionHydrationDetails,
     ): Pair<NadelQueryTransformer.TransformResult, NadelExecutionPlan> {
-        val executionPlan = executionPlanner.create(executionContext, services, service, rootField = actorField)
+        val executionPlan = executionPlanner.create(
+            executionContext,
+            services,
+            service,
+            rootField = actorField,
+            serviceHydrationDetails,
+        )
 
         val queryTransform = transformQuery(service, executionContext, executionPlan, actorField)
 

--- a/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/plan/NadelExecutionPlanFactory.kt
+++ b/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/plan/NadelExecutionPlanFactory.kt
@@ -2,6 +2,7 @@ package graphql.nadel.enginekt.plan
 
 import graphql.nadel.NextgenEngine
 import graphql.nadel.Service
+import graphql.nadel.ServiceExecutionHydrationDetails
 import graphql.nadel.enginekt.NadelExecutionContext
 import graphql.nadel.enginekt.blueprint.NadelOverallExecutionBlueprint
 import graphql.nadel.enginekt.transform.NadelCoerceTransform
@@ -28,6 +29,7 @@ internal class NadelExecutionPlanFactory(
         services: Map<String, Service>,
         service: Service,
         rootField: ExecutableNormalizedField,
+        serviceHydrationDetails: ServiceExecutionHydrationDetails? = null,
     ): NadelExecutionPlan {
         val executionSteps = mutableListOf<AnyNadelExecutionPlanStep>()
 
@@ -39,6 +41,7 @@ internal class NadelExecutionPlanFactory(
                     services,
                     service,
                     field,
+                    serviceHydrationDetails,
                 )
                 if (state != null) {
                     executionSteps.add(

--- a/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/transform/NadelCoerceTransform.kt
+++ b/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/transform/NadelCoerceTransform.kt
@@ -1,6 +1,7 @@
 package graphql.nadel.enginekt.transform
 
 import graphql.nadel.Service
+import graphql.nadel.ServiceExecutionHydrationDetails
 import graphql.nadel.ServiceExecutionResult
 import graphql.nadel.enginekt.NadelExecutionContext
 import graphql.nadel.enginekt.blueprint.NadelOverallExecutionBlueprint
@@ -73,6 +74,7 @@ internal class NadelCoerceTransform : NadelTransform<State> {
         services: Map<String, Service>,
         service: Service,
         overallField: ExecutableNormalizedField,
+        hydrationDetails: ServiceExecutionHydrationDetails?,
     ): State? {
         val schema = executionBlueprint.schema
 

--- a/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/transform/NadelDeepRenameTransform.kt
+++ b/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/transform/NadelDeepRenameTransform.kt
@@ -1,6 +1,7 @@
 package graphql.nadel.enginekt.transform
 
 import graphql.nadel.Service
+import graphql.nadel.ServiceExecutionHydrationDetails
 import graphql.nadel.ServiceExecutionResult
 import graphql.nadel.enginekt.NadelExecutionContext
 import graphql.nadel.enginekt.blueprint.NadelDeepRenameFieldInstruction
@@ -84,6 +85,7 @@ internal class NadelDeepRenameTransform : NadelTransform<NadelDeepRenameTransfor
         services: Map<String, Service>,
         service: Service,
         overallField: ExecutableNormalizedField,
+        hydrationDetails: ServiceExecutionHydrationDetails?,
     ): State? {
         val deepRenameInstructions = executionBlueprint.fieldInstructions
             .getTypeNameToInstructionMap<NadelDeepRenameFieldInstruction>(overallField)

--- a/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/transform/NadelRenameTransform.kt
+++ b/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/transform/NadelRenameTransform.kt
@@ -1,6 +1,7 @@
 package graphql.nadel.enginekt.transform
 
 import graphql.nadel.Service
+import graphql.nadel.ServiceExecutionHydrationDetails
 import graphql.nadel.ServiceExecutionResult
 import graphql.nadel.enginekt.NadelExecutionContext
 import graphql.nadel.enginekt.blueprint.NadelOverallExecutionBlueprint
@@ -40,6 +41,7 @@ internal class NadelRenameTransform : NadelTransform<State> {
         services: Map<String, Service>,
         service: Service,
         overallField: ExecutableNormalizedField,
+        hydrationDetails: ServiceExecutionHydrationDetails?,
     ): State? {
         val renameInstructions = executionBlueprint.fieldInstructions
             .getTypeNameToInstructionMap<NadelRenameFieldInstruction>(overallField)

--- a/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/transform/NadelServiceTypeFilterTransform.kt
+++ b/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/transform/NadelServiceTypeFilterTransform.kt
@@ -2,6 +2,7 @@ package graphql.nadel.enginekt.transform
 
 import graphql.introspection.Introspection
 import graphql.nadel.Service
+import graphql.nadel.ServiceExecutionHydrationDetails
 import graphql.nadel.ServiceExecutionResult
 import graphql.nadel.enginekt.NadelExecutionContext
 import graphql.nadel.enginekt.blueprint.IntrospectionService
@@ -74,6 +75,7 @@ class NadelServiceTypeFilterTransform : NadelTransform<State> {
         services: Map<String, Service>,
         service: Service,
         overallField: ExecutableNormalizedField,
+        hydrationDetails: ServiceExecutionHydrationDetails?,
     ): State? {
         when {
             // Ignore top level fields, they won't belong to multiple services

--- a/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/transform/NadelTransform.kt
+++ b/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/transform/NadelTransform.kt
@@ -2,6 +2,7 @@ package graphql.nadel.enginekt.transform
 
 import graphql.language.Directive
 import graphql.nadel.Service
+import graphql.nadel.ServiceExecutionHydrationDetails
 import graphql.nadel.ServiceExecutionResult
 import graphql.nadel.enginekt.NadelExecutionContext
 import graphql.nadel.enginekt.blueprint.NadelOverallExecutionBlueprint
@@ -26,6 +27,8 @@ interface NadelTransform<State : Any> {
      * @param executionBlueprint the [NadelOverallExecutionBlueprint] of the Nadel instance being operated on
      * @param service the [Service] the [overallField] belongs to
      * @param overallField the [ExecutableNormalizedField] in question, we are asking whether it [isApplicable] for transforms
+     * @param hydrationDetails the [ServiceExecutionHydrationDetails] when the [NadelTransform] is applied to fields inside
+     * hydrations, `null` otherwise
      *
      * @return null if the [NadelTransform] should not run, non-null [State] otherwise
      */
@@ -35,6 +38,7 @@ interface NadelTransform<State : Any> {
         services: Map<String, Service>,
         service: Service,
         overallField: ExecutableNormalizedField,
+        hydrationDetails: ServiceExecutionHydrationDetails? = null,
     ): State?
 
     /**

--- a/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/transform/NadelTransformJavaCompat.kt
+++ b/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/transform/NadelTransformJavaCompat.kt
@@ -1,6 +1,7 @@
 package graphql.nadel.enginekt.transform
 
 import graphql.nadel.Service
+import graphql.nadel.ServiceExecutionHydrationDetails
 import graphql.nadel.ServiceExecutionResult
 import graphql.nadel.enginekt.NadelExecutionContext
 import graphql.nadel.enginekt.blueprint.NadelOverallExecutionBlueprint
@@ -26,6 +27,7 @@ interface NadelTransformJavaCompat<State : Any> {
         services: Map<String, Service>,
         service: Service,
         overallField: ExecutableNormalizedField,
+        hydrationDetails: ServiceExecutionHydrationDetails?,
     ): CompletableFuture<State?>
 
     /**
@@ -63,13 +65,15 @@ interface NadelTransformJavaCompat<State : Any> {
                     services: Map<String, Service>,
                     service: Service,
                     overallField: ExecutableNormalizedField,
+                    hydrationDetails: ServiceExecutionHydrationDetails?,
                 ): State? {
                     return compat.isApplicable(
                         executionContext = executionContext,
                         executionBlueprint = executionBlueprint,
                         services = services,
                         service = service,
-                        overallField = overallField
+                        overallField = overallField,
+                        hydrationDetails = hydrationDetails,
                     ).asDeferred().await()
                 }
 

--- a/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/transform/NadelTypeRenameResultTransform.kt
+++ b/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/transform/NadelTypeRenameResultTransform.kt
@@ -2,6 +2,7 @@ package graphql.nadel.enginekt.transform
 
 import graphql.introspection.Introspection
 import graphql.nadel.Service
+import graphql.nadel.ServiceExecutionHydrationDetails
 import graphql.nadel.ServiceExecutionResult
 import graphql.nadel.enginekt.NadelExecutionContext
 import graphql.nadel.enginekt.blueprint.NadelOverallExecutionBlueprint
@@ -24,6 +25,7 @@ internal class NadelTypeRenameResultTransform : NadelTransform<State> {
         services: Map<String, Service>,
         service: Service,
         overallField: ExecutableNormalizedField,
+        hydrationDetails: ServiceExecutionHydrationDetails?,
     ): State? {
         return if (overallField.fieldName == Introspection.TypeNameMetaFieldDef.name) {
             State(

--- a/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/transform/hydration/NadelHydrationTransform.kt
+++ b/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/transform/hydration/NadelHydrationTransform.kt
@@ -62,6 +62,7 @@ internal class NadelHydrationTransform(
         services: Map<String, Service>,
         service: Service,
         overallField: ExecutableNormalizedField,
+        hydrationDetails: ServiceExecutionHydrationDetails?,
     ): State? {
         val hydrationInstructionsByTypeNames = executionBlueprint.fieldInstructions
             .getTypeNameToInstructionsMap<NadelHydrationFieldInstruction>(overallField)

--- a/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/transform/hydration/batch/NadelBatchHydrationTransform.kt
+++ b/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/transform/hydration/batch/NadelBatchHydrationTransform.kt
@@ -2,6 +2,7 @@ package graphql.nadel.enginekt.transform.hydration.batch
 
 import graphql.nadel.NextgenEngine
 import graphql.nadel.Service
+import graphql.nadel.ServiceExecutionHydrationDetails
 import graphql.nadel.ServiceExecutionResult
 import graphql.nadel.enginekt.NadelExecutionContext
 import graphql.nadel.enginekt.blueprint.NadelBatchHydrationFieldInstruction
@@ -42,6 +43,7 @@ internal class NadelBatchHydrationTransform(
         services: Map<String, Service>,
         service: Service,
         overallField: ExecutableNormalizedField,
+        hydrationDetails: ServiceExecutionHydrationDetails?,
     ): State? {
         val instructionsByObjectTypeName = executionBlueprint.fieldInstructions
             .getTypeNameToInstructionsMap<NadelBatchHydrationFieldInstruction>(overallField)

--- a/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/transform/skipInclude/SkipIncludeTransform.kt
+++ b/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/transform/skipInclude/SkipIncludeTransform.kt
@@ -4,6 +4,7 @@ import graphql.execution.MergedField
 import graphql.introspection.Introspection
 import graphql.language.Field
 import graphql.nadel.Service
+import graphql.nadel.ServiceExecutionHydrationDetails
 import graphql.nadel.ServiceExecutionResult
 import graphql.nadel.enginekt.NadelExecutionContext
 import graphql.nadel.enginekt.blueprint.NadelOverallExecutionBlueprint
@@ -47,6 +48,7 @@ internal class SkipIncludeTransform : NadelTransform<State> {
         services: Map<String, Service>,
         service: Service,
         overallField: ExecutableNormalizedField,
+        hydrationDetails: ServiceExecutionHydrationDetails?,
     ): State? {
         // This hacks together a child that will pass through here
         if (overallField.children.isEmpty()) {

--- a/test/src/test/java/graphql/nadel/tests/hooks/JavaAriTransform.java
+++ b/test/src/test/java/graphql/nadel/tests/hooks/JavaAriTransform.java
@@ -2,6 +2,7 @@ package graphql.nadel.tests.hooks;
 
 import graphql.language.StringValue;
 import graphql.nadel.Service;
+import graphql.nadel.ServiceExecutionHydrationDetails;
 import graphql.nadel.ServiceExecutionResult;
 import graphql.nadel.enginekt.NadelExecutionContext;
 import graphql.nadel.enginekt.blueprint.NadelOverallExecutionBlueprint;
@@ -49,7 +50,8 @@ public class JavaAriTransform implements NadelTransformJavaCompat<Set<String>> {
                                                        @NotNull NadelOverallExecutionBlueprint executionBlueprint,
                                                        @NotNull Map<String, ? extends Service> services,
                                                        @NotNull Service service,
-                                                       @NotNull ExecutableNormalizedField overallField) {
+                                                       @NotNull ExecutableNormalizedField overallField,
+                                                       @Nullable ServiceExecutionHydrationDetails hydrationDetails) {
 
         String singleObjectTypeName = getSingleObjectTypeName(overallField);
         FieldCoordinates fieldCoordinates = makeFieldCoordinates(singleObjectTypeName, overallField.getName());

--- a/test/src/test/kotlin/graphql/nadel/tests/hooks/ari-transforms.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/hooks/ari-transforms.kt
@@ -2,6 +2,7 @@ package graphql.nadel.tests.hooks
 
 import graphql.language.StringValue
 import graphql.nadel.Service
+import graphql.nadel.ServiceExecutionHydrationDetails
 import graphql.nadel.ServiceExecutionResult
 import graphql.nadel.enginekt.NadelExecutionContext
 import graphql.nadel.enginekt.blueprint.NadelOverallExecutionBlueprint
@@ -27,6 +28,7 @@ private class AriTestTransform : NadelTransform<Set<String>> {
         services: Map<String, Service>,
         service: Service,
         overallField: ExecutableNormalizedField,
+        hydrationDetails: ServiceExecutionHydrationDetails?,
     ): Set<String>? {
         // Let's not bother with abstract types in a test
         val fieldCoords = makeFieldCoordinates(overallField.objectTypeNames.single(), overallField.name)

--- a/test/src/test/kotlin/graphql/nadel/tests/hooks/chain-rename-transform.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/hooks/chain-rename-transform.kt
@@ -3,6 +3,7 @@ package graphql.nadel.tests.hooks
 import graphql.language.EnumValue
 import graphql.language.StringValue
 import graphql.nadel.Service
+import graphql.nadel.ServiceExecutionHydrationDetails
 import graphql.nadel.ServiceExecutionResult
 import graphql.nadel.enginekt.NadelExecutionContext
 import graphql.nadel.enginekt.blueprint.NadelOverallExecutionBlueprint
@@ -24,6 +25,7 @@ private class ChainRenameTransform : NadelTransform<Any> {
         services: Map<String, Service>,
         service: Service,
         overallField: ExecutableNormalizedField,
+        hydrationDetails: ServiceExecutionHydrationDetails?,
     ): Any? {
         return overallField.takeIf { it.name == "test" || it.name == "cities" }
     }

--- a/test/src/test/kotlin/graphql/nadel/tests/hooks/transforms-can-copy-array-value.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/hooks/transforms-can-copy-array-value.kt
@@ -1,6 +1,7 @@
 package graphql.nadel.tests.hooks
 
 import graphql.nadel.Service
+import graphql.nadel.ServiceExecutionHydrationDetails
 import graphql.nadel.ServiceExecutionResult
 import graphql.nadel.enginekt.NadelExecutionContext
 import graphql.nadel.enginekt.blueprint.NadelOverallExecutionBlueprint
@@ -26,6 +27,7 @@ class `transforms-can-copy-array-value` : EngineTestHook {
                     services: Map<String, Service>,
                     service: Service,
                     overallField: ExecutableNormalizedField,
+                    hydrationDetails: ServiceExecutionHydrationDetails?,
                 ): Any? {
                     return overallField.name.takeIf { it == "ids" }
                 }

--- a/test/src/test/kotlin/graphql/nadel/tests/hooks/transforms-can-set-array-value.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/hooks/transforms-can-set-array-value.kt
@@ -1,6 +1,7 @@
 package graphql.nadel.tests.hooks
 
 import graphql.nadel.Service
+import graphql.nadel.ServiceExecutionHydrationDetails
 import graphql.nadel.ServiceExecutionResult
 import graphql.nadel.enginekt.NadelExecutionContext
 import graphql.nadel.enginekt.blueprint.NadelOverallExecutionBlueprint
@@ -26,6 +27,7 @@ class `transforms-can-set-array-value` : EngineTestHook {
                     services: Map<String, Service>,
                     service: Service,
                     overallField: ExecutableNormalizedField,
+                    hydrationDetails: ServiceExecutionHydrationDetails?,
                 ): Any? {
                     return overallField.name.takeIf { it == "ids" }
                 }

--- a/test/src/test/kotlin/graphql/nadel/tests/transforms/RemoveFieldTestTransform.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/transforms/RemoveFieldTestTransform.kt
@@ -3,6 +3,7 @@ package graphql.nadel.tests.transforms
 import graphql.GraphQLError
 import graphql.introspection.Introspection
 import graphql.nadel.Service
+import graphql.nadel.ServiceExecutionHydrationDetails
 import graphql.nadel.ServiceExecutionResult
 import graphql.nadel.enginekt.NadelExecutionContext
 import graphql.nadel.enginekt.blueprint.NadelOverallExecutionBlueprint
@@ -26,6 +27,7 @@ class RemoveFieldTestTransform : NadelTransform<GraphQLError> {
         services: Map<String, Service>,
         service: Service,
         overallField: ExecutableNormalizedField,
+        hydrationDetails: ServiceExecutionHydrationDetails?,
     ): GraphQLError? {
         val objectType = overallField.objectTypeNames.asSequence()
             .map {


### PR DESCRIPTION
Please make sure you consider the following:

- [ ] Add tests that use __typename in queries
- [ ] Does this change work with all nadel transformations (rename, type rename, hydration, etc)? Add tests for this.
- [ ] Is it worth using hints for this change in order to be able to enable a percentage rollout?
- [ ] Do we need to add integration tests for this change in the graphql gateway?
- [ ] Do we need a pollinator check for this?
