### PR TITLE
handle primitive JSON args

### DIFF
--- a/api/src/main/java/graphql/nadel/normalized/ValueToVariableValueCompiler.java
+++ b/api/src/main/java/graphql/nadel/normalized/ValueToVariableValueCompiler.java
@@ -28,8 +28,8 @@ public class ValueToVariableValueCompiler {
     static VariableValueWithDefinition normalizedInputValueToVariable(NormalizedInputValue normalizedInputValue, int queryVariableCount) {
         Object variableValue;
         Object inputValue = normalizedInputValue.getValue();
-        if (inputValue instanceof ObjectValue) {
-            variableValue = toVariableValue((ObjectValue) inputValue);
+        if (inputValue instanceof Value) {
+            variableValue = toVariableValue((Value) inputValue);
         } else if (inputValue instanceof List) {
             variableValue = toVariableValues((List) inputValue);
         } else {
@@ -66,8 +66,7 @@ public class ValueToVariableValueCompiler {
     private static Object toVariableValue(Value<?> value) {
         if (value instanceof ObjectValue) {
             return toVariableValue((ObjectValue) value);
-        }
-        if (value instanceof ArrayValue) {
+        } else if (value instanceof ArrayValue) {
             return toVariableValues(((ArrayValue) value).getValues());
         } else if (value instanceof StringValue) {
             return ((StringValue) value).getValue();

--- a/api/src/test/groovy/graphql/nadel/normalized/ExecutableNormalizedOperationToAstCompilerTest.groovy
+++ b/api/src/test/groovy/graphql/nadel/normalized/ExecutableNormalizedOperationToAstCompilerTest.groovy
@@ -567,6 +567,70 @@ class ExecutableNormalizedOperationToAstCompilerTest extends Specification {
 '''
     }
 
+    def "test JSON when input is a string variable"() {
+        def sdl = '''
+        type Query {
+            foo: String
+        }
+        type Mutation {
+            foo1(arg: JSON!): String
+        }
+        
+        scalar JSON
+        '''
+        def query = '''mutation hello($var: JSON!) {
+            foo1(arg: $var)
+        }
+        '''
+        GraphQLSchema schema = TestUtil.schema(sdl)
+
+        def vars = [var: "hello there"]
+        def fields = createNormalizedFields(schema, query, vars)
+
+        def pair = compileToDocument(schema, MUTATION, null, fields)
+        when:
+        def document = pair.first
+        def variables = pair.second
+        then:
+        variables == [var_0: "hello there"]
+        AstPrinter.printAst(document) == '''mutation ($var_0: JSON!) {
+  foo1(arg: $var_0)
+}
+'''
+    }
+
+    def "test JSON when input is an int variable"() {
+        def sdl = '''
+        type Query {
+            foo: String
+        }
+        type Mutation {
+            foo1(arg: JSON!): String
+        }
+        
+        scalar JSON
+        '''
+        def query = '''mutation hello($var: JSON!) {
+            foo1(arg: $var)
+        }
+        '''
+        GraphQLSchema schema = TestUtil.schema(sdl)
+
+        def vars = [var: 1]
+        def fields = createNormalizedFields(schema, query, vars)
+
+        def pair = compileToDocument(schema, MUTATION, null, fields)
+        when:
+        def document = pair.first
+        def variables = pair.second
+        then:
+        variables == [var_0: 1]
+        AstPrinter.printAst(document) == '''mutation ($var_0: JSON!) {
+  foo1(arg: $var_0)
+}
+'''
+    }
+
     def "test JSON scalar when JSON arg is null"() {
         def sdl = '''
         type Query {

--- a/test/src/test/kotlin/graphql/nadel/tests/EngineTests.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/EngineTests.kt
@@ -30,7 +30,7 @@ import java.util.concurrent.CompletableFuture
  * 2. Test name e.g. hydration inside a renamed field
  * 3. Copy paste output from selecting a test in the IntelliJ e.g. java:test://graphql.nadel.tests.EngineTests.current hydration inside a renamed field
  */
-private val singleTestToRun = (System.getenv("TEST_NAME") ?: "")
+private val singleTestToRun = (System.getenv("TEST_NAME") ?: "primitive json arguments")
     .removePrefix("java:test://graphql.nadel.tests.EngineTests.current")
     .removePrefix("java:test://graphql.nadel.tests.EngineTests.nextgen")
     .removeSuffix(".yml")

--- a/test/src/test/kotlin/graphql/nadel/tests/EngineTests.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/EngineTests.kt
@@ -30,7 +30,7 @@ import java.util.concurrent.CompletableFuture
  * 2. Test name e.g. hydration inside a renamed field
  * 3. Copy paste output from selecting a test in the IntelliJ e.g. java:test://graphql.nadel.tests.EngineTests.current hydration inside a renamed field
  */
-private val singleTestToRun = (System.getenv("TEST_NAME") ?: "primitive json arguments")
+private val singleTestToRun = (System.getenv("TEST_NAME") ?: "")
     .removePrefix("java:test://graphql.nadel.tests.EngineTests.current")
     .removePrefix("java:test://graphql.nadel.tests.EngineTests.nextgen")
     .removeSuffix(".yml")

--- a/test/src/test/kotlin/graphql/nadel/tests/hooks/json-handling.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/hooks/json-handling.kt
@@ -31,3 +31,13 @@ class `inlined-json-arguments` : EngineTestHook {
 class `input-object-with-json-field` : EngineTestHook {
     override val wiringFactory = NeverWiringFactoryWithExtendedJsonScalar()
 }
+
+@UseHook
+class `primitive-json-arguments` : EngineTestHook {
+    override val wiringFactory = NeverWiringFactoryWithExtendedJsonScalar()
+}
+
+@UseHook
+class `primitive-json-arguments-variables` : EngineTestHook {
+    override val wiringFactory = NeverWiringFactoryWithExtendedJsonScalar()
+}

--- a/test/src/test/resources/fixtures/json scalar handling/primitive-json-arguments-variables.yml
+++ b/test/src/test/resources/fixtures/json scalar handling/primitive-json-arguments-variables.yml
@@ -1,0 +1,74 @@
+name: primitive json arguments variables
+enabled:
+  current: true
+  nextgen: true
+overallSchema:
+  MyService: |
+    type Query {
+      hello(arg: InputWithJson, arg1: JSON!): String
+    }
+    
+    input InputWithJson {
+      payload: JSON 
+    }
+    
+    scalar JSON
+underlyingSchema:
+  MyService: |-
+    type Query {
+      hello(arg: InputWithJson, arg1: JSON!): String
+    }
+    
+    input InputWithJson {
+      payload: JSON 
+    }
+    
+    scalar JSON
+query: |
+  query myQuery($var1: JSON!, $var2: JSON!) {
+    hello(arg: {payload: $var1}, arg1: $var2)
+  }
+variables: { var1: "String JSON input", var2: false }
+serviceCalls:
+  current:
+    - serviceName: MyService
+      request:
+        query: |
+          query nadel_2_MyService_myQuery($var1: JSON!, $var2: JSON!) {
+            hello(arg: {payload : $var1}, arg1: $var2)
+          }
+        variables: { var1: "String JSON input", var2: false }
+        operationName: nadel_2_MyService_myQuery
+      # language=JSON
+      response: |-
+        {
+          "data": {
+            "hello": "world"
+          },
+          "extensions": {}
+        }
+  nextgen:
+    - serviceName: MyService
+      request:
+        query: |
+          query myQuery($var_0: JSON, $var_1: JSON!) {
+            hello(arg: {payload : $var_0}, arg1: $var_1)
+          }
+        variables: { var_0: "String JSON input", var_1: false }
+        operationName: myQuery
+      # language=JSON
+      response: |-
+        {
+          "data": {
+            "hello": "world"
+          },
+          "extensions": {}
+        }
+# language=JSON
+response: |-
+  {
+    "data": {
+      "hello": "world"
+    },
+    "extensions": {}
+  }

--- a/test/src/test/resources/fixtures/json scalar handling/primitive-json-arguments.yml
+++ b/test/src/test/resources/fixtures/json scalar handling/primitive-json-arguments.yml
@@ -1,0 +1,74 @@
+name: primitive json arguments
+enabled:
+  current: true
+  nextgen: true
+overallSchema:
+  MyService: |
+    type Query {
+      hello(arg: InputWithJson, arg1: JSON!): String
+    }
+    
+    input InputWithJson {
+      payload: JSON 
+    }
+    
+    scalar JSON
+underlyingSchema:
+  MyService: |-
+    type Query {
+      hello(arg: InputWithJson, arg1: JSON!): String
+    }
+    
+    input InputWithJson {
+      payload: JSON 
+    }
+    
+    scalar JSON
+query: |
+  query myQuery {
+    hello(arg: {payload: "String JSON input"}, arg1: false)
+  }
+variables: { }
+serviceCalls:
+  current:
+    - serviceName: MyService
+      request:
+        query: |
+          query nadel_2_MyService_myQuery {
+            hello(arg: {payload : "String JSON input"}, arg1: false)
+          }
+        variables: { }
+        operationName: nadel_2_MyService_myQuery
+      # language=JSON
+      response: |-
+        {
+          "data": {
+            "hello": "world"
+          },
+          "extensions": {}
+        }
+  nextgen:
+    - serviceName: MyService
+      request:
+        query: |
+          query myQuery($var_0: JSON, $var_1: JSON!) {
+            hello(arg: {payload : $var_0}, arg1: $var_1)
+          }
+        variables: { var_0: "String JSON input", var_1: false }
+        operationName: myQuery
+      # language=JSON
+      response: |-
+        {
+          "data": {
+            "hello": "world"
+          },
+          "extensions": {}
+        }
+# language=JSON
+response: |-
+  {
+    "data": {
+      "hello": "world"
+    },
+    "extensions": {}
+  }


### PR DESCRIPTION
Please make sure you consider the following:

- [n/a] Add tests that use __typename in queries
- [n/a] Does this change work with all nadel transformations (rename, type rename, hydration, etc)? Add tests for this.
- [n/a] Is it worth using hints for this change in order to be able to enable a percentage rollout?
- [y] Do we need to add integration tests for this change in the graphql gateway?
- [no] Do we need a pollinator check for this?
