### PR TITLE
fix validation for polymorphic hydrations

### DIFF
--- a/engine-nextgen/src/main/kotlin/graphql/nadel/validation/NadelSchemaValidationError.kt
+++ b/engine-nextgen/src/main/kotlin/graphql/nadel/validation/NadelSchemaValidationError.kt
@@ -237,7 +237,6 @@ sealed interface NadelSchemaValidationError {
         val service: Service get() = parentType.service
 
         override val message = run {
-            actorField
             val of = makeFieldCoordinates(parentType.overall.name, overallField.name)
             "Field $of declares a polymorphic hydration with incorrect return type. One of the hydrations' actor fields" +
                 " ${actorField.name} in the service ${actorService.name} returns the type " +

--- a/engine-nextgen/src/main/kotlin/graphql/nadel/validation/NadelSchemaValidationError.kt
+++ b/engine-nextgen/src/main/kotlin/graphql/nadel/validation/NadelSchemaValidationError.kt
@@ -214,6 +214,40 @@ sealed interface NadelSchemaValidationError {
         override val subject = overallField
     }
 
+    data class FieldWithPolymorphicHydrationMustReturnAUnion(
+        val parentType: NadelServiceSchemaElement,
+        val overallField: GraphQLFieldDefinition,
+    ) : NadelSchemaValidationError {
+        val service: Service get() = parentType.service
+
+        override val message = run {
+            val of = makeFieldCoordinates(parentType.overall.name, overallField.name)
+            "Field $of declares a polymorphic hydration so its output type MUST be a union"
+        }
+
+        override val subject = overallField
+    }
+
+    data class PolymorphicHydrationReturnTypeMismatch(
+        val actorField: GraphQLFieldDefinition,
+        val actorService: Service,
+        val parentType: NadelServiceSchemaElement,
+        val overallField: GraphQLFieldDefinition,
+    ) : NadelSchemaValidationError {
+        val service: Service get() = parentType.service
+
+        override val message = run {
+            actorField
+            val of = makeFieldCoordinates(parentType.overall.name, overallField.name)
+            "Field $of declares a polymorphic hydration with incorrect return type. One of the hydrations' actor fields" +
+                " ${actorField.name} in the service ${actorService.name} returns the type " +
+                "${(actorField.type as GraphQLNamedType).name} which is not present in the polymorphic hydration return " +
+                "type ${(overallField.type as GraphQLNamedType).name}"
+        }
+
+        override val subject = overallField
+    }
+
     data class MissingHydrationFieldValueSource(
         val parentType: NadelServiceSchemaElement,
         val overallField: GraphQLFieldDefinition,

--- a/engine-nextgen/src/main/kotlin/graphql/nadel/validation/NadelSchemaValidationError.kt
+++ b/engine-nextgen/src/main/kotlin/graphql/nadel/validation/NadelSchemaValidationError.kt
@@ -11,6 +11,7 @@ import graphql.nadel.dsl.RemoteArgumentSource
 import graphql.nadel.dsl.UnderlyingServiceHydration
 import graphql.nadel.enginekt.util.makeFieldCoordinates
 import graphql.nadel.enginekt.util.pathToActorField
+import graphql.nadel.enginekt.util.unwrapAll
 import graphql.schema.GraphQLArgument
 import graphql.schema.GraphQLDirective
 import graphql.schema.GraphQLEnumValueDefinition
@@ -240,8 +241,8 @@ sealed interface NadelSchemaValidationError {
             val of = makeFieldCoordinates(parentType.overall.name, overallField.name)
             "Field $of declares a polymorphic hydration with incorrect return type. One of the hydrations' actor fields" +
                 " ${actorField.name} in the service ${actorService.name} returns the type " +
-                "${(actorField.type as GraphQLNamedType).name} which is not present in the polymorphic hydration return " +
-                "type ${(overallField.type as GraphQLNamedType).name}"
+                "${(actorField.type.unwrapAll() as GraphQLNamedType).name} which is not present in the polymorphic hydration return " +
+                "type ${(overallField.type.unwrapAll() as GraphQLNamedType).name}"
         }
 
         override val subject = overallField

--- a/engine-nextgen/src/main/kotlin/graphql/nadel/validation/NadelTypeValidation.kt
+++ b/engine-nextgen/src/main/kotlin/graphql/nadel/validation/NadelTypeValidation.kt
@@ -159,7 +159,7 @@ internal class NadelTypeValidation(
     ): Pair<List<NadelServiceSchemaElement>, List<NadelSchemaValidationError>> {
         val errors = mutableListOf<NadelSchemaValidationError>()
         val nameNamesUsed = getTypeNamesUsed(service)
-        val polymorphicHydrationUnions = getPolymophicHydrationUnions(service)
+        val polymorphicHydrationUnions = getPolymorphicHydrationUnions(service)
         val objectTypeNamesReferencedInPolymorphicHydrationUnions = polymorphicHydrationUnions
             .flatMap { it.types }
             .map { it.name }
@@ -182,7 +182,7 @@ internal class NadelTypeValidation(
                 name in objectTypeNamesReferencedInPolymorphicHydrationUnions || overallType in polymorphicHydrationUnions
             }
             .mapNotNull { (_, overallType) ->
-                val underlyingType = getUnderlyingType(overallType, service) as GraphQLNamedType?
+                val underlyingType = getUnderlyingType(overallType, service)
 
                 if (underlyingType == null) {
                     addMissingUnderlyingTypeError(overallType).let { null }
@@ -209,7 +209,7 @@ internal class NadelTypeValidation(
             } to errors
     }
 
-    private fun getPolymophicHydrationUnions(service: Service): Set<GraphQLUnionType> {
+    private fun getPolymorphicHydrationUnions(service: Service): Set<GraphQLUnionType> {
         return service.definitionRegistry
             .definitions
             .asSequence()

--- a/engine-nextgen/src/main/kotlin/graphql/nadel/validation/NadelTypeValidation.kt
+++ b/engine-nextgen/src/main/kotlin/graphql/nadel/validation/NadelTypeValidation.kt
@@ -159,8 +159,8 @@ internal class NadelTypeValidation(
     ): Pair<List<NadelServiceSchemaElement>, List<NadelSchemaValidationError>> {
         val errors = mutableListOf<NadelSchemaValidationError>()
         val nameNamesUsed = getTypeNamesUsed(service)
-        val syntheticUnions = getSyntheticUnions(service)
-        val objectTypeNamesReferencedInSyntheticUnions = syntheticUnions
+        val polymorphicHydrationUnions = getPolymophicHydrationUnions(service)
+        val objectTypeNamesReferencedInPolymorphicHydrationUnions = polymorphicHydrationUnions
             .flatMap { it.types }
             .map { it.name }
             .toSet()
@@ -178,8 +178,8 @@ internal class NadelTypeValidation(
             .filterNot { (key) ->
                 key in allNadelBuiltInTypeNames
             }
-            .filterNot { (key, value) ->
-                key in objectTypeNamesReferencedInSyntheticUnions || value in syntheticUnions
+            .filterNot { (name, overallType) ->
+                name in objectTypeNamesReferencedInPolymorphicHydrationUnions || overallType in polymorphicHydrationUnions
             }
             .mapNotNull { (_, overallType) ->
                 val underlyingType = getUnderlyingType(overallType, service) as GraphQLNamedType?
@@ -209,7 +209,7 @@ internal class NadelTypeValidation(
             } to errors
     }
 
-    private fun getSyntheticUnions(service: Service): Set<GraphQLUnionType> {
+    private fun getPolymophicHydrationUnions(service: Service): Set<GraphQLUnionType> {
         return service.definitionRegistry
             .definitions
             .asSequence()

--- a/engine-nextgen/src/main/kotlin/graphql/nadel/validation/util/NadelSchemaUtil.kt
+++ b/engine-nextgen/src/main/kotlin/graphql/nadel/validation/util/NadelSchemaUtil.kt
@@ -11,11 +11,10 @@ import graphql.nadel.util.Util
 import graphql.schema.GraphQLFieldDefinition
 import graphql.schema.GraphQLNamedType
 import graphql.schema.GraphQLSchema
-import graphql.schema.GraphQLType
 
 object NadelSchemaUtil {
-    fun getUnderlyingType(overallType: GraphQLNamedType, service: Service): GraphQLType? {
-        return service.underlyingSchema.getType(getRenamedFrom(overallType) ?: overallType.name)
+    fun getUnderlyingType(overallType: GraphQLNamedType, service: Service): GraphQLNamedType? {
+        return service.underlyingSchema.getType(getRenamedFrom(overallType) ?: overallType.name) as GraphQLNamedType?
     }
 
     fun getHydrations(field: GraphQLFieldDefinition, overallSchema: GraphQLSchema): List<UnderlyingServiceHydration> {

--- a/engine-nextgen/src/test/kotlin/graphql/nadel/validation/NadelPolymorphicHydrationValidationTest.kt
+++ b/engine-nextgen/src/test/kotlin/graphql/nadel/validation/NadelPolymorphicHydrationValidationTest.kt
@@ -1,6 +1,9 @@
 package graphql.nadel.validation
 
+import graphql.nadel.enginekt.util.singleOfType
 import graphql.nadel.validation.NadelSchemaValidationError.FieldWithPolymorphicHydrationMustReturnAUnion
+import graphql.nadel.validation.NadelSchemaValidationError.PolymorphicHydrationReturnTypeMismatch
+import graphql.schema.GraphQLNamedType
 import io.kotest.core.spec.style.DescribeSpec
 
 private const val source = "$" + "source"
@@ -36,6 +39,76 @@ class NadelPolymorphicHydrationValidationTest : DescribeSpec({
                     """.trimIndent(),
                     "users" to """
                         type User {
+                            id: ID!
+                            name: String!
+                        }
+                        
+                        type ExternalUser {
+                            id: ID!
+                            name: String!
+                        }
+                    """.trimIndent(),
+                ),
+                underlyingSchema = mapOf(
+                    "issues" to """
+                        type Query {
+                            issue: Issue
+                        }
+                        type Issue {
+                            id: ID!
+                            creatorId: ID!
+                        }
+                    """.trimIndent(),
+                    "users" to """
+                        type Query {
+                            user(id: ID!): User
+                            externalUser(id: ID!): ExternalUser
+                        }
+                        type User {
+                            id: ID!
+                            name: String!
+                        }
+                        type ExternalUser {
+                            id: ID!
+                            name: String!
+                        }
+                    """.trimIndent(),
+                ),
+            )
+
+            val errors = validate(fixture)
+            assert(errors.map { it.message }.isEmpty())
+        }
+
+        it("passes if polymorphic hydration is valid when actor field returns a renamed type") {
+            val fixture = NadelValidationTestFixture(
+                overallSchema = mapOf(
+                    "issues" to """
+                        type Query {
+                            issue: Issue
+                        }
+                        type Issue {
+                            id: ID!
+                            creator: AbstractUser
+                            @hydrated(
+                                service: "users"
+                                field: "user"
+                                arguments: [
+                                    {name: "id", value: "$source.creatorId"}
+                                ]
+                            )
+                            @hydrated(
+                                service: "users"
+                                field: "externalUser"
+                                arguments: [
+                                    {name: "id", value: "$source.creatorId"}
+                                ]
+                            )    
+                        }
+                        union AbstractUser = InternalUser | ExternalUser
+                    """.trimIndent(),
+                    "users" to """
+                        type InternalUser @renamed(from: "User") {
                             id: ID!
                             name: String!
                         }
@@ -146,7 +219,8 @@ class NadelPolymorphicHydrationValidationTest : DescribeSpec({
             val errors = validate(fixture)
             assert(errors.map { it.message }.isNotEmpty())
             val error = errors.filterIsInstance<FieldWithPolymorphicHydrationMustReturnAUnion>().single()
-            assert(error.message == "Field Issue.creator declares a polymorphic hydration so its output type MUST be a union")
+            assert(error.parentType.overall.name == "Issue")
+            assert(error.overallField.name == "creator")
         }
 
         it("fails if one of the hydrations' return types is not in the union") {
@@ -217,12 +291,11 @@ class NadelPolymorphicHydrationValidationTest : DescribeSpec({
 
             val errors = validate(fixture)
             assert(errors.map { it.message }.isNotEmpty())
-            val error = errors.single()
-            assert(
-                error.message == "Field Issue.creator declares a polymorphic hydration with incorrect return type. " +
-                    "One of the hydrations' actor fields externalUser in the service users returns the type ExternalUser " +
-                    "which is not present in the polymorphic hydration return type AbstractUser"
-            )
+            val error = errors.singleOfType<PolymorphicHydrationReturnTypeMismatch>()
+            assert(error.parentType.overall.name == "Issue")
+            assert(error.actorField.name == "externalUser")
+            assert(error.actorService.name == "users")
+            assert((error.actorField.type as GraphQLNamedType).name == "ExternalUser")
         }
     }
 })

--- a/engine-nextgen/src/test/kotlin/graphql/nadel/validation/NadelPolymorphicHydrationValidationTest.kt
+++ b/engine-nextgen/src/test/kotlin/graphql/nadel/validation/NadelPolymorphicHydrationValidationTest.kt
@@ -1,0 +1,229 @@
+package graphql.nadel.validation
+
+import graphql.nadel.validation.NadelSchemaValidationError.FieldWithPolymorphicHydrationMustReturnAUnion
+import io.kotest.core.spec.style.DescribeSpec
+
+private const val source = "$" + "source"
+
+class NadelPolymorphicHydrationValidationTest : DescribeSpec({
+    describe("validate") {
+        it("passes if polymorphic hydration is valid") {
+            val fixture = NadelValidationTestFixture(
+                overallSchema = mapOf(
+                    "issues" to """
+                        type Query {
+                            issue: Issue
+                        }
+                        type Issue {
+                            id: ID!
+                            creator: AbstractUser
+                            @hydrated(
+                                service: "users"
+                                field: "user"
+                                arguments: [
+                                    {name: "id", value: "$source.creatorId"}
+                                ]
+                            )
+                            @hydrated(
+                                service: "users"
+                                field: "externalUser"
+                                arguments: [
+                                    {name: "id", value: "$source.creatorId"}
+                                ]
+                            )    
+                        }
+                        union AbstractUser = User | ExternalUser
+                    """.trimIndent(),
+                    "users" to """
+                        type User {
+                            id: ID!
+                            name: String!
+                        }
+                        
+                        type ExternalUser {
+                            id: ID!
+                            name: String!
+                        }
+                    """.trimIndent(),
+                ),
+                underlyingSchema = mapOf(
+                    "issues" to """
+                        type Query {
+                            issue: Issue
+                        }
+                        type Issue {
+                            id: ID!
+                            creatorId: ID!
+                        }
+                    """.trimIndent(),
+                    "users" to """
+                        type Query {
+                            user(id: ID!): User
+                            externalUser(id: ID!): ExternalUser
+                        }
+                        type User {
+                            id: ID!
+                            name: String!
+                        }
+                        type ExternalUser {
+                            id: ID!
+                            name: String!
+                        }
+                    """.trimIndent(),
+                ),
+            )
+
+            val errors = validate(fixture)
+            assert(errors.map { it.message }.isEmpty())
+        }
+
+        it("fails if return type is not a union") {
+            val fixture = NadelValidationTestFixture(
+                overallSchema = mapOf(
+                    "issues" to """
+                        type Query {
+                            issue: Issue
+                        }
+                        type Issue {
+                            id: ID!
+                            creator: User
+                            @hydrated(
+                                service: "users"
+                                field: "user"
+                                arguments: [
+                                    {name: "id", value: "$source.creatorId"}
+                                ]
+                            )
+                            @hydrated(
+                                service: "users"
+                                field: "externalUser"
+                                arguments: [
+                                    {name: "id", value: "$source.creatorId"}
+                                ]
+                            )
+                        }
+                        union AbstractUser = User | ExternalUser
+                    """.trimIndent(),
+                    "users" to """
+                        type User {
+                            id: ID!
+                            name: String!
+                        }
+
+                        type ExternalUser {
+                            id: ID!
+                            name: String!
+                        }
+                    """.trimIndent(),
+                ),
+                underlyingSchema = mapOf(
+                    "issues" to """
+                        type Query {
+                            issue: Issue
+                        }
+                        type Issue {
+                            id: ID!
+                            creatorId: ID!
+                        }
+                    """.trimIndent(),
+                    "users" to """
+                        type Query {
+                            user(id: ID!): User
+                            externalUser(id: ID!): ExternalUser
+                        }
+                        type User {
+                            id: ID!
+                            name: String!
+                        }
+                        type ExternalUser {
+                            id: ID!
+                            name: String!
+                        }
+                    """.trimIndent(),
+                ),
+            )
+
+            val errors = validate(fixture)
+            assert(errors.map { it.message }.isNotEmpty())
+            val error = errors.filterIsInstance<FieldWithPolymorphicHydrationMustReturnAUnion>().single()
+            assert(error.message == "Field Issue.creator declares a polymorphic hydration so its output type MUST be a union")
+        }
+
+        it("fails if one of the hydrations' return types is not in the union") {
+            val fixture = NadelValidationTestFixture(
+                overallSchema = mapOf(
+                    "issues" to """
+                        type Query {
+                            issue: Issue
+                        }
+                        type Issue {
+                            id: ID!
+                            creator: AbstractUser
+                            @hydrated(
+                                service: "users"
+                                field: "user"
+                                arguments: [
+                                    {name: "id", value: "$source.creatorId"}
+                                ]
+                            )
+                            @hydrated(
+                                service: "users"
+                                field: "externalUser"
+                                arguments: [
+                                    {name: "id", value: "$source.creatorId"}
+                                ]
+                            )
+                        }
+                        union AbstractUser = User
+                    """.trimIndent(),
+                    "users" to """
+                        type User {
+                            id: ID!
+                            name: String!
+                        }
+
+                        type ExternalUser {
+                            id: ID!
+                            name: String!
+                        }
+                    """.trimIndent(),
+                ),
+                underlyingSchema = mapOf(
+                    "issues" to """
+                        type Query {
+                            issue: Issue
+                        }
+                        type Issue {
+                            id: ID!
+                            creatorId: ID!
+                        }
+                    """.trimIndent(),
+                    "users" to """
+                        type Query {
+                            user(id: ID!): User
+                            externalUser(id: ID!): ExternalUser
+                        }
+                        type User {
+                            id: ID!
+                            name: String!
+                        }
+                        type ExternalUser {
+                            id: ID!
+                            name: String!
+                        }
+                    """.trimIndent(),
+                ),
+            )
+
+            val errors = validate(fixture)
+            assert(errors.map { it.message }.isNotEmpty())
+            val error = errors.single()
+            assert(
+                error.message == "Field Issue.creator declares a polymorphic hydration with incorrect return type. " +
+                    "One of the hydrations' actor fields externalUser in the service users returns the type ExternalUser " +
+                    "which is not present in the polymorphic hydration return type AbstractUser"
+            )
+        }
+    }
+})
+

--- a/engine-nextgen/src/test/kotlin/graphql/nadel/validation/NadelPolymorphicHydrationValidationTest.kt
+++ b/engine-nextgen/src/test/kotlin/graphql/nadel/validation/NadelPolymorphicHydrationValidationTest.kt
@@ -2,7 +2,9 @@ package graphql.nadel.validation
 
 import graphql.nadel.enginekt.util.singleOfType
 import graphql.nadel.validation.NadelSchemaValidationError.FieldWithPolymorphicHydrationMustReturnAUnion
+import graphql.nadel.validation.NadelSchemaValidationError.MissingUnderlyingType
 import graphql.nadel.validation.NadelSchemaValidationError.PolymorphicHydrationReturnTypeMismatch
+import graphql.nadel.validation.util.assertSingleOfType
 import graphql.schema.GraphQLNamedType
 import io.kotest.core.spec.style.DescribeSpec
 
@@ -88,6 +90,133 @@ class NadelPolymorphicHydrationValidationTest : DescribeSpec({
 
             val errors = validate(fixture)
             assert(errors.map { it.message }.isEmpty())
+        }
+
+        it("can detect if polymorphic hydration from the same service returns a type that does not exist in the underlying schema") {
+            val fixture = NadelValidationTestFixture(
+                overallSchema = mapOf(
+                    "issues" to """
+                        type Query {
+                            hello: String
+                        }
+                        type Issue {
+                            id: ID!
+                            reference: ReferenceObject
+                            @hydrated(
+                                service: "issues"
+                                field: "issue"
+                                arguments: [
+                                    {name: "id", value: "$source.referenceId"}
+                                ]
+                            )
+                            @hydrated(
+                                service: "pages"
+                                field: "page"
+                                arguments: [
+                                    {name: "id", value: "$source.referenceId"}
+                                ]
+                            )    
+                        }
+                        union ReferenceObject = Issue | Page
+                    """.trimIndent(),
+                    "pages" to """
+                        type Page {
+                            id: ID!
+                            name: String!
+                        }
+                    """.trimIndent(),
+                ),
+                underlyingSchema = mapOf(
+                    "issues" to """
+                        type Query {
+                            hello: String
+                            issue(id: ID!): String
+                        }
+                    """.trimIndent(),
+                    "pages" to """
+                        type Query {
+                            page(id: ID!): Page
+                        }
+                        type Page {
+                            id: ID!
+                            name: String!
+                        }
+                    """.trimIndent(),
+                ),
+            )
+
+            val errors = validate(fixture)
+            val error = errors.assertSingleOfType<MissingUnderlyingType>()
+            assert(error.overallType.name == "Issue")
+            assert(error.service.name == "issues")
+        }
+
+        it("can detect if polymorphic hydration from the same service references a type that does not exist in the underlying schema") {
+            val fixture = NadelValidationTestFixture(
+                overallSchema = mapOf(
+                    "issues" to """
+                        type Query {
+                            hello: String
+                        }
+                        type Comment {
+                            id: ID
+                            text: String
+                        }
+                        type Issue {
+                            id: ID!
+                            comment: Comment
+                            reference: ReferenceObject
+                            @hydrated(
+                                service: "issues"
+                                field: "issue"
+                                arguments: [
+                                    {name: "id", value: "$source.referenceId"}
+                                ]
+                            )
+                            @hydrated(
+                                service: "pages"
+                                field: "page"
+                                arguments: [
+                                    {name: "id", value: "$source.referenceId"}
+                                ]
+                            )    
+                        }
+                        union ReferenceObject = Issue | Page
+                    """.trimIndent(),
+                    "pages" to """
+                        type Page {
+                            id: ID!
+                            name: String!
+                        }
+                    """.trimIndent(),
+                ),
+                underlyingSchema = mapOf(
+                    "issues" to """
+                        type Query {
+                            hello: String
+                            issue(id: ID!): Issue
+                        }
+                        type Issue {
+                            id: ID!
+                            referenceId: ID
+                        }
+                    """.trimIndent(),
+                    "pages" to """
+                        type Query {
+                            page(id: ID!): Page
+                        }
+                        type Page {
+                            id: ID!
+                            name: String!
+                        }
+                    """.trimIndent(),
+                ),
+            )
+
+            val errors = validate(fixture)
+            val error = errors.assertSingleOfType<MissingUnderlyingType>()
+            assert(error.overallType.name == "Comment")
+            assert(error.service.name == "issues")
         }
 
         it("passes if polymorphic hydration is valid when actor field returns a renamed type") {

--- a/engine-nextgen/src/test/kotlin/graphql/nadel/validation/NadelPolymorphicHydrationValidationTest.kt
+++ b/engine-nextgen/src/test/kotlin/graphql/nadel/validation/NadelPolymorphicHydrationValidationTest.kt
@@ -46,6 +46,11 @@ class NadelPolymorphicHydrationValidationTest : DescribeSpec({
                         type ExternalUser {
                             id: ID!
                             name: String!
+                            metadata: UserMetadata
+                        }
+                        
+                        type UserMetadata {
+                            payload: String
                         }
                     """.trimIndent(),
                 ),
@@ -71,6 +76,11 @@ class NadelPolymorphicHydrationValidationTest : DescribeSpec({
                         type ExternalUser {
                             id: ID!
                             name: String!
+                            metadata: UserMetadata
+                        }
+                        
+                        type UserMetadata {
+                            payload: String
                         }
                     """.trimIndent(),
                 ),

--- a/engine-nextgen/src/test/kotlin/graphql/nadel/validation/NadelTypeValidationTest.kt
+++ b/engine-nextgen/src/test/kotlin/graphql/nadel/validation/NadelTypeValidationTest.kt
@@ -48,6 +48,41 @@ class NadelTypeValidationTest : DescribeSpec({
             assert(errors.map { it.message }.isEmpty())
         }
 
+        it("cannot have a synthetic union") {
+            val fixture = NadelValidationTestFixture(
+                overallSchema = mapOf(
+                    "test" to """
+                        type Query {
+                            echo: Echo
+                        }
+                        type Echo {
+                            world: World
+                        }
+                        type World {
+                            hello: String
+                        }
+                        union Something = Echo | World
+                    """.trimIndent(),
+                ),
+                underlyingSchema = mapOf(
+                    "test" to """
+                        type Query {
+                            echo: Echo
+                        }
+                        type Echo {
+                            world: World
+                        }
+                        type World {
+                            hello: String
+                        }
+                    """.trimIndent(),
+                ),
+            )
+
+            val errors = validate(fixture)
+            assert(errors.map { it.message }.isNotEmpty())
+        }
+
         it("tracks visited types to avoid stack overflow").config(timeout = Duration.seconds(1)) {
             val fixture = NadelValidationTestFixture(
                 overallSchema = mapOf(


### PR DESCRIPTION
Please make sure you consider the following:

- [n/a] Add tests that use __typename in queries
- [n/a] Does this change work with all nadel transformations (rename, type rename, hydration, etc)? Add tests for this.
- [-] Is it worth using hints for this change in order to be able to enable a percentage rollout?
- [+] Do we need to add integration tests for this change in the graphql gateway?
- [-] Do we need a pollinator check for this?
