### PR TITLE
handle poly hydrations from the same service

### DIFF
--- a/test/src/test/kotlin/graphql/nadel/tests/hooks/polymorphic-hydration-hook-using-alias-helper.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/hooks/polymorphic-hydration-hook-using-alias-helper.kt
@@ -34,14 +34,23 @@ private class PolymorphicHydrationHookUsingAliasHelper : NadelEngineExecutionHoo
         instruction: T,
         hydrationArgumentValue: String
     ): Boolean {
-        return instruction.actorService.name == "pets" && hydrationArgumentValue.startsWith("pet", ignoreCase = true) ||
-            instruction.actorService.name == "people" && hydrationArgumentValue.startsWith("human", ignoreCase = true)
+        return instruction.actorFieldDef.name.contains("pet") && hydrationArgumentValue.startsWith(
+            "pet", ignoreCase = true
+        ) ||
+            instruction.actorFieldDef.name.contains("human") && hydrationArgumentValue.startsWith(
+            "human", ignoreCase = true
+        )
     }
 }
 
-@UseHook
-class `batch-polymorphic-hydration` : EngineTestHook {
+open class PolymorphicHydrationWithAliasTestHook : EngineTestHook {
     override fun makeNadel(engineType: NadelEngineType, builder: Nadel.Builder): Nadel.Builder {
         return builder.serviceExecutionHooks(PolymorphicHydrationHookUsingAliasHelper())
     }
 }
+
+@UseHook
+class `batch-polymorphic-hydration` : PolymorphicHydrationWithAliasTestHook()
+
+@UseHook
+class `batch-polymorphic-hydration-actor-fields-are-in-the-same-service` : PolymorphicHydrationWithAliasTestHook()

--- a/test/src/test/kotlin/graphql/nadel/tests/hooks/polymorphic-hydration-hooks.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/hooks/polymorphic-hydration-hooks.kt
@@ -8,6 +8,7 @@ import graphql.nadel.enginekt.transform.artificial.NadelAliasHelper
 import graphql.nadel.enginekt.transform.result.json.JsonNode
 import graphql.nadel.enginekt.transform.result.json.JsonNodeExtractor
 import graphql.nadel.enginekt.transform.result.json.JsonNodePath
+import graphql.nadel.enginekt.transform.result.json.JsonNodes
 import graphql.nadel.tests.EngineTestHook
 import graphql.nadel.tests.NadelEngineType
 import graphql.nadel.tests.UseHook
@@ -63,3 +64,6 @@ class `batch-polymorphic-hydration-when-hook-returns-null-1` : PolymorphicHydrat
 
 @UseHook
 class `solitary-polymorphic-hydration-when-hook-returns-null` : PolymorphicHydrationTestHook() {}
+
+@UseHook
+class `batch-polymorphic-hydration-with-lots-of-renames` : PolymorphicHydrationTestHook() {}

--- a/test/src/test/resources/fixtures/hydration/polymorphic hydrations/batch-polymorphic-hydration-actor-fields-are-in-the-same-service.yml
+++ b/test/src/test/resources/fixtures/hydration/polymorphic hydrations/batch-polymorphic-hydration-actor-fields-are-in-the-same-service.yml
@@ -1,0 +1,251 @@
+name: batch polymorphic hydration actor fields are in the same service
+enabled:
+  current: false
+  nextgen: true
+overallSchema:
+  foo: |
+    type Query {
+      foo: [Foo]
+    }
+
+    type Foo {
+      id: ID
+      dataId: ID
+      data: Data
+      @hydrated(
+        service: "bar"
+        field: "petById"
+        arguments: [
+          {name: "ids" value: "$source.dataId"}
+        ]
+      )
+      @hydrated(
+        service: "bar"
+        field: "humanById"
+        arguments: [
+          {name: "ids" value: "$source.dataId"}
+        ]
+      )
+    }
+
+    union Data = Pet | Human
+  bar: |
+    type Query {
+      petById(ids: [ID]): [Pet]
+      humanById(ids: [ID]): [Human]
+    }
+
+    type Human {
+      id: ID
+      name: String
+    }
+    
+    type Pet {
+      id: ID
+      breed: String
+    }
+underlyingSchema:
+  foo: |
+    type Query {
+      foo: [Foo]
+    }
+
+    type Foo {
+      id: ID
+      dataId: ID
+    }
+  bar: |
+    type Query {
+      petById(ids: [ID]): [Pet]
+      humanById(ids: [ID]): [Human]
+    }
+
+    type Pet {
+      id: ID
+      breed: String
+    }
+
+    type Human {
+      id: ID
+      name: String
+    }
+
+query: |
+  query {
+    foo {
+      __typename
+      id
+      data {
+        ... on Pet {
+          __typename
+          id
+          breed
+        }
+        ... on Human {
+          __typename
+          id
+          name
+        }
+      }
+    }
+  }
+variables: { }
+serviceCalls:
+  nextgen:
+    - serviceName: foo
+      request:
+        query: |
+          query {
+            foo {
+              __typename
+              __typename__batch_hydration__data: __typename
+              batch_hydration__data__dataId: dataId
+              batch_hydration__data__dataId: dataId
+              id
+            }
+          }
+        variables: { }
+      # language=JSON
+      response: |-
+        {
+          "data": {
+            "foo": [
+              {
+                "__typename": "Foo",
+                "__typename__batch_hydration__data": "Foo",
+                "batch_hydration__data__dataId": "PET-0",
+                "batch_hydration__data__dataId": "PET-0",
+                "id": "FOO-0"
+              },
+              {
+                "__typename": "Foo",
+                "__typename__batch_hydration__data": "Foo",
+                "batch_hydration__data__dataId": "HUMAN-0",
+                "batch_hydration__data__dataId": "HUMAN-0",
+                "id": "FOO-1"
+              },
+              {
+                "__typename": "Foo",
+                "__typename__batch_hydration__data": "Foo",
+                "batch_hydration__data__dataId": "PET-1",
+                "batch_hydration__data__dataId": "PET-1",
+                "id": "FOO-2"
+              },
+              {
+                "__typename": "Foo",
+                "__typename__batch_hydration__data": "Foo",
+                "batch_hydration__data__dataId": "HUMAN-1",
+                "batch_hydration__data__dataId": "HUMAN-1",
+                "id": "FOO-3"
+              } ]
+          },
+          "extensions": {}
+        }
+    - serviceName: bar
+      request:
+        query: |
+          query {
+            petById(ids: ["PET-0", "PET-1"]) {
+              __typename
+              breed
+              id
+              batch_hydration__data__id: id
+            }
+          }
+        variables: { }
+      # language=JSON
+      response: |-
+        {
+          "data": {
+            "petById": [
+              {
+                "__typename": "Pet",
+                "breed": "Akita",
+                "id": "PET-0",
+                "batch_hydration__data__id": "PET-0"
+              },
+              {
+                "__typename": "Pet",
+                "breed": "Labrador",
+                "id": "PET-1",
+                "batch_hydration__data__id": "PET-1"
+              }]
+          },
+          "extensions": {}
+        }
+    - serviceName: bar
+      request:
+        query: |
+          query {
+            humanById(ids: ["HUMAN-0", "HUMAN-1"]) {
+              __typename
+              id
+              batch_hydration__data__id: id
+              name
+            }
+          }
+        variables: { }
+      # language=JSON
+      response: |-
+        {
+          "data": {
+            "humanById": [
+              {
+                "__typename": "Human",
+                "id": "HUMAN-0",
+                "batch_hydration__data__id": "HUMAN-0",
+                "name": "Fanny Longbottom"
+              },
+              {
+                "__typename": "Human",
+                "id": "HUMAN-1",
+                "batch_hydration__data__id": "HUMAN-1",
+                "name": "John Doe"
+              }]
+          },
+          "extensions": {}
+        }
+# language=JSON
+response: |-
+  {
+    "data": {
+      "foo": [
+        {
+          "__typename": "Foo",
+          "id": "FOO-0",
+          "data": {
+            "__typename": "Pet",
+            "id": "PET-0",
+            "breed": "Akita"
+          }
+        },
+        {
+          "__typename": "Foo",
+          "id": "FOO-1",
+          "data": {
+            "__typename": "Human",
+            "id": "HUMAN-0",
+            "name": "Fanny Longbottom"
+          }
+        },
+        {
+          "__typename": "Foo",
+          "id": "FOO-2",
+          "data": {
+            "__typename": "Pet",
+            "id": "PET-1",
+            "breed": "Labrador"
+          }
+        },
+        {
+          "__typename": "Foo",
+          "id": "FOO-3",
+          "data": {
+            "__typename": "Human",
+            "id": "HUMAN-1",
+            "name": "John Doe"
+          }
+        }]
+    },
+    "extensions": {}
+  }

--- a/test/src/test/resources/fixtures/hydration/polymorphic hydrations/batch-polymorphic-hydration-when-hook-returns-null-1.yml
+++ b/test/src/test/resources/fixtures/hydration/polymorphic hydrations/batch-polymorphic-hydration-when-hook-returns-null-1.yml
@@ -149,9 +149,6 @@ serviceCalls:
           query {
             petById(ids: ["PET-0"]) {
               __typename
-              __typename__type_filter____typename: __typename
-              __typename__type_filter__id: __typename
-              __typename__type_filter__name: __typename
               breed
               id
               batch_hydration__data__id: id
@@ -164,9 +161,6 @@ serviceCalls:
           "data": {
             "petById": [{
               "__typename": "Pet",
-              "__typename__type_filter____typename": "Pet",
-              "__typename__type_filter__id": "Pet",
-              "__typename__type_filter__name": "Pet",
               "breed": "Akita",
               "id": "PET-0",
               "batch_hydration__data__id": "PET-0"
@@ -179,10 +173,7 @@ serviceCalls:
         query: |
           query {
             humanById(ids: ["HUMAN-0", "HUMAN-1"]) {
-              __typename__type_filter____typename: __typename
               __typename
-              __typename__type_filter__id: __typename
-              __typename__type_filter__breed: __typename
               id
               batch_hydration__data__id: id
               name
@@ -194,19 +185,13 @@ serviceCalls:
         {
           "data": {
             "humanById": [{
-              "__typename__type_filter____typename": "Human",
               "__typename": "Human",
-              "__typename__type_filter__id": "Human",
-              "__typename__type_filter__breed": "Human",
               "id": "HUMAN-0",
               "batch_hydration__data__id": "HUMAN-0",
               "name": "Fanny Longbottom"
             },
             {
-              "__typename__type_filter____typename": "Human",
               "__typename": "Human",
-              "__typename__type_filter__id": "Human",
-              "__typename__type_filter__breed": "Human",
               "id": "HUMAN-1",
               "batch_hydration__data__id": "HUMAN-1",
               "name": "John Doe"

--- a/test/src/test/resources/fixtures/hydration/polymorphic hydrations/batch-polymorphic-hydration-when-hook-returns-null.yml
+++ b/test/src/test/resources/fixtures/hydration/polymorphic hydrations/batch-polymorphic-hydration-when-hook-returns-null.yml
@@ -148,10 +148,7 @@ serviceCalls:
         query: |
           query {
             humanById(ids: ["HUMAN-0", "HUMAN-1"]) {
-              __typename__type_filter____typename: __typename
               __typename
-              __typename__type_filter__id: __typename
-              __typename__type_filter__breed: __typename
               id
               batch_hydration__data__id: id
               name
@@ -163,19 +160,13 @@ serviceCalls:
         {
           "data": {
             "humanById": [{
-              "__typename__type_filter____typename": "Human",
               "__typename": "Human",
-              "__typename__type_filter__id": "Human",
-              "__typename__type_filter__breed": "Human",
               "id": "HUMAN-0",
               "batch_hydration__data__id": "HUMAN-0",
               "name": "Fanny Longbottom"
             },
             {
-              "__typename__type_filter____typename": "Human",
               "__typename": "Human",
-              "__typename__type_filter__id": "Human",
-              "__typename__type_filter__breed": "Human",
               "id": "HUMAN-1",
               "batch_hydration__data__id": "HUMAN-1",
               "name": "John Doe"

--- a/test/src/test/resources/fixtures/hydration/polymorphic hydrations/batch-polymorphic-hydration-where-only-one-type-is-queried.yml
+++ b/test/src/test/resources/fixtures/hydration/polymorphic hydrations/batch-polymorphic-hydration-where-only-one-type-is-queried.yml
@@ -190,9 +190,6 @@ serviceCalls:
         query: |
           query {
             humanById(ids: ["HUMAN-0"]) {
-              __typename__type_filter____typename: __typename
-              __typename__type_filter__id: __typename
-              __typename__type_filter__fins: __typename
               batch_hydration__data__id: id
             }
           }
@@ -202,9 +199,6 @@ serviceCalls:
         {
           "data": {
             "humanById": [{
-              "__typename__type_filter____typename": "Human",
-              "__typename__type_filter__id": "Human",
-              "__typename__type_filter__fins": "Human",
               "batch_hydration__data__id": "HUMAN-0"
             }]
           },

--- a/test/src/test/resources/fixtures/hydration/polymorphic hydrations/batch-polymorphic-hydration-with-interfaces.yml
+++ b/test/src/test/resources/fixtures/hydration/polymorphic hydrations/batch-polymorphic-hydration-with-interfaces.yml
@@ -176,18 +176,12 @@ serviceCalls:
             petById(ids: ["DOG-0", "FISH-0", "DOG-1", "FISH-1"]) {
               ... on Dog {
                 __typename
-                __typename__type_filter____typename: __typename
-                __typename__type_filter__id: __typename
-                __typename__type_filter__name: __typename
                 breed
                 id
                 batch_hydration__data__id: id
               }
               ... on Fish {
                 __typename
-                __typename__type_filter____typename: __typename
-                __typename__type_filter__id: __typename
-                __typename__type_filter__name: __typename
                 fins
                 id
                 batch_hydration__data__id: id
@@ -201,33 +195,21 @@ serviceCalls:
           "data": {
             "petById": [{
               "__typename": "Dog",
-              "__typename__type_filter____typename": "Dog",
-              "__typename__type_filter__id": "Dog",
-              "__typename__type_filter__name": "Dog",
               "breed": "Akita",
               "id": "DOG-0",
               "batch_hydration__data__id": "DOG-0"
             }, {
               "__typename": "Fish",
-              "__typename__type_filter____typename": "Fish",
-              "__typename__type_filter__id": "Fish",
-              "__typename__type_filter__name": "Fish",
               "fins": 4,
               "id": "FISH-0",
               "batch_hydration__data__id": "FISH-0"
             }, {
               "__typename": "Dog",
-              "__typename__type_filter____typename": "Dog",
-              "__typename__type_filter__id": "Dog",
-              "__typename__type_filter__name": "Dog",
               "breed": "Labrador",
               "id": "DOG-1",
               "batch_hydration__data__id": "DOG-1"
             }, {
               "__typename": "Fish",
-              "__typename__type_filter____typename": "Fish",
-              "__typename__type_filter__id": "Fish",
-              "__typename__type_filter__name": "Fish",
               "fins": 8,
               "id": "FISH-1",
               "batch_hydration__data__id": "FISH-1"
@@ -240,12 +222,7 @@ serviceCalls:
         query: |
           query {
             humanById(ids: ["HUMAN-0"]) {
-              __typename__type_filter____typename: __typename
-              __typename__type_filter____typename: __typename
               __typename
-              __typename__type_filter__id: __typename
-              __typename__type_filter__breed: __typename
-              __typename__type_filter__fins: __typename
               id
               batch_hydration__data__id: id
               name
@@ -257,13 +234,7 @@ serviceCalls:
         {
           "data": {
             "humanById": [{
-              "__typename__type_filter____typename": "Human",
-              "__typename__type_filter____typename": "Human",
               "__typename": "Human",
-              "__typename__type_filter__id": "Human",
-              "__typename__type_filter__id": "Human",
-              "__typename__type_filter__breed": "Human",
-              "__typename__type_filter__fins": "Human",
               "id": "HUMAN-0",
               "batch_hydration__data__id": "HUMAN-0",
               "name": "Fanny Longbottom"

--- a/test/src/test/resources/fixtures/hydration/polymorphic hydrations/batch-polymorphic-hydration-with-lots-of-renames.yml
+++ b/test/src/test/resources/fixtures/hydration/polymorphic hydrations/batch-polymorphic-hydration-with-lots-of-renames.yml
@@ -1,0 +1,264 @@
+name: batch polymorphic hydration with lots of renames
+enabled:
+  current: false
+  nextgen: true
+overallSchema:
+  bar: |
+    type Query {
+        animalById(ids: [ID]): [Animal] @renamed(from: "petById")
+        personById(ids: [ID]): [Person] @renamed(from: "humanById")
+    }
+
+    type Animal @renamed(from: "Pet") {
+        id: ID @renamed(from: "identifier")
+        breed: String @renamed(from: "kind")
+    }
+
+    type Person @renamed(from: "Human") {
+        id: ID @renamed(from: "identifier")
+        name: String
+    }
+  foo: |
+    type Query {
+        foo: [Foo]
+    }
+
+    type Foo {
+        id: ID
+        dataId: ID
+        data: Data
+        @hydrated(
+            service: "bar"
+            field: "petById"
+            arguments: [
+                {name: "ids" value: "$source.dataId"}
+            ]
+            identifiedBy: "hiddenId"
+        )
+        @hydrated(
+            service: "bar"
+            field: "humanById"
+            arguments: [
+                {name: "ids" value: "$source.dataId"}
+            ]
+            identifiedBy: "hiddenId"
+        )
+    }
+
+    union Data = Animal | Person
+underlyingSchema:
+  foo: |
+    type Query {
+      foo: [Foo]
+    }
+
+    type Foo {
+      id: ID
+      dataId: ID
+    }
+  bar: |
+    type Query {
+      humanById(ids: [ID]): [Human]
+      petById(ids: [ID]): [Pet]
+    }
+
+    type Human {
+      hiddenId: ID
+      identifier: ID
+      name: String
+    }
+    
+    type Pet {
+      hiddenId: ID
+      identifier: ID
+      kind: String
+    }
+
+query: |
+  query {
+    foo {
+      __typename
+      id
+      data {
+        ... on Animal {
+          __typename
+          id
+          breed
+        }
+        ... on Person {
+          __typename
+          id
+          name
+        }
+      }
+    }
+  }
+variables: { }
+serviceCalls:
+  nextgen:
+    - serviceName: foo
+      request:
+        query: |
+          query {
+            foo {
+              __typename
+              __typename__batch_hydration__data: __typename
+              batch_hydration__data__dataId: dataId
+              batch_hydration__data__dataId: dataId
+              id
+            }
+          }
+        variables: { }
+      # language=JSON
+      response: |-
+        {
+          "data": {
+            "foo": [
+              {
+                "__typename": "Foo",
+                "__typename__batch_hydration__data": "Foo",
+                "batch_hydration__data__dataId": "PET-0",
+                "batch_hydration__data__dataId": "PET-0",
+                "id": "FOO-0"
+              },
+              {
+                "__typename": "Foo",
+                "__typename__batch_hydration__data": "Foo",
+                "batch_hydration__data__dataId": "HUMAN-0",
+                "batch_hydration__data__dataId": "HUMAN-0",
+                "id": "FOO-1"
+              },
+              {
+                "__typename": "Foo",
+                "__typename__batch_hydration__data": "Foo",
+                "batch_hydration__data__dataId": "PET-1",
+                "batch_hydration__data__dataId": "PET-1",
+                "id": "FOO-2"
+              },
+              {
+                "__typename": "Foo",
+                "__typename__batch_hydration__data": "Foo",
+                "batch_hydration__data__dataId": "HUMAN-1",
+                "batch_hydration__data__dataId": "HUMAN-1",
+                "id": "FOO-3"
+              } ]
+          },
+          "extensions": {}
+        }
+    - serviceName: bar
+      request:
+        query: |
+          query {
+            humanById(ids: ["HUMAN-0", "HUMAN-1"]) {
+              __typename
+              __typename__rename__id: __typename
+              batch_hydration__data__hiddenId: hiddenId
+              rename__id__identifier: identifier
+              name
+            }
+          }
+        variables: { }
+      # language=JSON
+      response: |-
+        {
+          "data": {
+            "humanById": [
+              {
+                "__typename": "Human",
+                "__typename__rename__id": "Human",
+                "batch_hydration__data__hiddenId": "HUMAN-0",
+                "rename__id__identifier": "PERSON-0",
+                "name": "Fanny Longbottom"
+              },
+              {
+                "__typename": "Human",
+                "__typename__rename__id": "Human",
+                "batch_hydration__data__hiddenId": "HUMAN-1",
+                "rename__id__identifier": "PERSON-1",
+                "name": "John Doe"
+              }]
+          },
+          "extensions": {}
+        }
+    - serviceName: bar
+      request:
+        query: |
+          query {
+            petById(ids: ["PET-0", "PET-1"]) {
+              __typename
+              __typename__rename__id: __typename
+              __typename__rename__breed: __typename
+              batch_hydration__data__hiddenId: hiddenId
+              rename__id__identifier: identifier
+              rename__breed__kind: kind
+            }
+          }
+        variables: { }
+      # language=JSON
+      response: |-
+        {
+          "data": {
+            "petById": [
+              {
+                "__typename": "Pet",
+                "__typename__rename__id": "Pet",
+                "__typename__rename__breed": "Pet",
+                "batch_hydration__data__hiddenId": "PET-0",
+                "rename__id__identifier": "ANIMAL-0",
+                "rename__breed__kind": "Akita"
+              },
+              {
+                "__typename": "Pet",
+                "__typename__rename__id": "Pet",
+                "__typename__rename__breed": "Pet",
+                "batch_hydration__data__hiddenId": "PET-1",
+                "rename__id__identifier": "ANIMAL-1",
+                "rename__breed__kind": "Labrador"
+              }]
+          },
+          "extensions": {}
+        }
+# language=JSON
+response: |-
+  {
+    "data": {
+      "foo": [
+        {
+          "__typename": "Foo",
+          "id": "FOO-0",
+          "data": {
+            "__typename": "Animal",
+            "id": "ANIMAL-0",
+            "breed": "Akita"
+          }
+        },
+        {
+          "__typename": "Foo",
+          "id": "FOO-1",
+          "data": {
+            "__typename": "Person",
+            "id": "PERSON-0",
+            "name": "Fanny Longbottom"
+          }
+        },
+        {
+          "__typename": "Foo",
+          "id": "FOO-2",
+          "data": {
+            "__typename": "Animal",
+            "id": "ANIMAL-1",
+            "breed": "Labrador"
+          }
+        },
+        {
+          "__typename": "Foo",
+          "id": "FOO-3",
+          "data": {
+            "__typename": "Person",
+            "id": "PERSON-1",
+            "name": "John Doe"
+          }
+        }]
+    },
+    "extensions": {}
+  }

--- a/test/src/test/resources/fixtures/hydration/polymorphic hydrations/batch-polymorphic-hydration-with-rename.yml
+++ b/test/src/test/resources/fixtures/hydration/polymorphic hydrations/batch-polymorphic-hydration-with-rename.yml
@@ -149,10 +149,7 @@ serviceCalls:
           query {
             petById(ids: ["PET-0", "PET-1"]) {
               __typename
-              __typename__type_filter____typename: __typename
-              __typename__type_filter__id: __typename
               __typename__rename__breed: __typename
-              __typename__type_filter__name: __typename
               id
               batch_hydration__data__id: id
               rename__breed__kind: kind
@@ -165,20 +162,14 @@ serviceCalls:
           "data": {
             "petById": [{
               "__typename": "Pet",
-              "__typename__type_filter____typename": "Pet",
-              "__typename__type_filter__id": "Pet",
               "__typename__rename__breed": "Pet",
-              "__typename__type_filter__name": "Pet",
               "id": "PET-0",
               "batch_hydration__data__id": "PET-0",
               "rename__breed__kind": "Akita"
             },
             {
               "__typename": "Pet",
-              "__typename__type_filter____typename": "Pet",
-              "__typename__type_filter__id": "Pet",
               "__typename__rename__breed": "Pet",
-              "__typename__type_filter__name": "Pet",
               "id": "PET-1",
               "batch_hydration__data__id": "PET-1",
               "rename__breed__kind": "Labrador"
@@ -191,10 +182,7 @@ serviceCalls:
         query: |
           query {
             humanById(ids: ["HUMAN-0", "HUMAN-1"]) {
-              __typename__type_filter____typename: __typename
               __typename
-              __typename__type_filter__id: __typename
-              __typename__type_filter__breed: __typename
               id
               batch_hydration__data__id: id
               name
@@ -206,19 +194,13 @@ serviceCalls:
         {
           "data": {
             "humanById": [{
-              "__typename__type_filter____typename": "Human",
               "__typename": "Human",
-              "__typename__type_filter__id": "Human",
-              "__typename__type_filter__breed": "Human",
               "id": "HUMAN-0",
               "batch_hydration__data__id": "HUMAN-0",
               "name": "Fanny Longbottom"
             },
             {
-              "__typename__type_filter____typename": "Human",
               "__typename": "Human",
-              "__typename__type_filter__id": "Human",
-              "__typename__type_filter__breed": "Human",
               "id": "HUMAN-1",
               "batch_hydration__data__id": "HUMAN-1",
               "name": "John Doe"

--- a/test/src/test/resources/fixtures/hydration/polymorphic hydrations/batch-polymorphic-hydration-with-unions.yml
+++ b/test/src/test/resources/fixtures/hydration/polymorphic hydrations/batch-polymorphic-hydration-with-unions.yml
@@ -172,18 +172,12 @@ serviceCalls:
             petById(ids: ["DOG-0", "FISH-0", "DOG-1", "FISH-1"]) {
               ... on Dog {
                 __typename
-                __typename__type_filter____typename: __typename
-                __typename__type_filter__id: __typename
-                __typename__type_filter__name: __typename
                 breed
                 id
                 batch_hydration__data__id: id
               }
               ... on Fish {
                 __typename
-                __typename__type_filter____typename: __typename
-                __typename__type_filter__id: __typename
-                __typename__type_filter__name: __typename
                 fins
                 id
                 batch_hydration__data__id: id
@@ -197,33 +191,21 @@ serviceCalls:
           "data": {
             "petById": [{
               "__typename": "Dog",
-              "__typename__type_filter____typename": "Dog",
-              "__typename__type_filter__id": "Dog",
-              "__typename__type_filter__name": "Dog",
               "breed": "Akita",
               "id": "DOG-0",
               "batch_hydration__data__id": "DOG-0"
             }, {
               "__typename": "Fish",
-              "__typename__type_filter____typename": "Fish",
-              "__typename__type_filter__id": "Fish",
-              "__typename__type_filter__name": "Fish",
               "fins": 4,
               "id": "FISH-0",
               "batch_hydration__data__id": "FISH-0"
             }, {
               "__typename": "Dog",
-              "__typename__type_filter____typename": "Dog",
-              "__typename__type_filter__id": "Dog",
-              "__typename__type_filter__name": "Dog",
               "breed": "Labrador",
               "id": "DOG-1",
               "batch_hydration__data__id": "DOG-1"
             }, {
               "__typename": "Fish",
-              "__typename__type_filter____typename": "Fish",
-              "__typename__type_filter__id": "Fish",
-              "__typename__type_filter__name": "Fish",
               "fins": 8,
               "id": "FISH-1",
               "batch_hydration__data__id": "FISH-1"
@@ -236,13 +218,7 @@ serviceCalls:
         query: |
           query {
             humanById(ids: ["HUMAN-0"]) {
-              __typename__type_filter____typename: __typename
-              __typename__type_filter____typename: __typename
               __typename
-              __typename__type_filter__id: __typename
-              __typename__type_filter__id: __typename
-              __typename__type_filter__breed: __typename
-              __typename__type_filter__fins: __typename
               id
               batch_hydration__data__id: id
               name
@@ -254,13 +230,7 @@ serviceCalls:
         {
           "data": {
             "humanById": [{
-              "__typename__type_filter____typename": "Human",
-              "__typename__type_filter____typename": "Human",
               "__typename": "Human",
-              "__typename__type_filter__id": "Human",
-              "__typename__type_filter__id": "Human",
-              "__typename__type_filter__breed": "Human",
-              "__typename__type_filter__fins": "Human",
               "id": "HUMAN-0",
               "batch_hydration__data__id": "HUMAN-0",
               "name": "Fanny Longbottom"

--- a/test/src/test/resources/fixtures/hydration/polymorphic hydrations/batch-polymorphic-hydration.yml
+++ b/test/src/test/resources/fixtures/hydration/polymorphic hydrations/batch-polymorphic-hydration.yml
@@ -149,9 +149,6 @@ serviceCalls:
           query {
             petById(ids: ["PET-0", "PET-1"]) {
               __typename
-              __typename__type_filter____typename: __typename
-              __typename__type_filter__id: __typename
-              __typename__type_filter__name: __typename
               breed
               id
               batch_hydration__data__id: id
@@ -164,18 +161,12 @@ serviceCalls:
           "data": {
             "petById": [{
               "__typename": "Pet",
-              "__typename__type_filter____typename": "Pet",
-              "__typename__type_filter__id": "Pet",
-              "__typename__type_filter__name": "Pet",
               "breed": "Akita",
               "id": "PET-0",
               "batch_hydration__data__id": "PET-0"
             },
             {
               "__typename": "Pet",
-              "__typename__type_filter____typename": "Pet",
-              "__typename__type_filter__id": "Pet",
-              "__typename__type_filter__name": "Pet",
               "breed": "Labrador",
               "id": "PET-1",
               "batch_hydration__data__id": "PET-1"
@@ -188,10 +179,7 @@ serviceCalls:
         query: |
           query {
             humanById(ids: ["HUMAN-0", "HUMAN-1"]) {
-              __typename__type_filter____typename: __typename
               __typename
-              __typename__type_filter__id: __typename
-              __typename__type_filter__breed: __typename
               id
               batch_hydration__data__id: id
               name
@@ -203,19 +191,13 @@ serviceCalls:
         {
           "data": {
             "humanById": [{
-              "__typename__type_filter____typename": "Human",
               "__typename": "Human",
-              "__typename__type_filter__id": "Human",
-              "__typename__type_filter__breed": "Human",
               "id": "HUMAN-0",
               "batch_hydration__data__id": "HUMAN-0",
               "name": "Fanny Longbottom"
             },
             {
-              "__typename__type_filter____typename": "Human",
               "__typename": "Human",
-              "__typename__type_filter__id": "Human",
-              "__typename__type_filter__breed": "Human",
               "id": "HUMAN-1",
               "batch_hydration__data__id": "HUMAN-1",
               "name": "John Doe"


### PR DESCRIPTION
Please make sure you consider the following:

- [+] Add tests that use __typename in queries
- [+] Does this change work with all nadel transformations (rename, type rename, hydration, etc)? Add tests for this.
- [ MAYBE? ] Is it worth using hints for this change in order to be able to enable a percentage rollout?
- [+] Do we need to add integration tests for this change in the graphql gateway?
- [-] Do we need a pollinator check for this?


Not sure whether this should be behind hints or not. Happy to add one

So the bug surfaced when we started testing poly hydrations yesterday. Basically, original query looks something like this:

```graphql
query {
    foo {
      data {
        ... on Pet { # hydrated from getPet
          __typename
          id
          breed
        }
        ... on Human { # hydrated from getHuman
          __typename
          id
          name
        }
      }
    }
  }
```
When both `Pet` and `Human` are hydrated from 2 fields in the same service we would form invalid queries to them. For hydrations we get children of `data` field and send them to the actor field. The problem is that we get both fragments `... on Pet` and `... on Human` and send them to both actor fields. This is invalid, since it does not make sense to do `... on Pet` for `getHuman` because it doesn't return `Pet`
I added some filtering logic to remove the fields that cannot be served by the actor fields.
We haven't picked up on this because when the actor fields live in different services `NadelServiceTypeFilterTransform` adjusts the fields for us but when the service owns both types (like in the example above) the transform does not kick in