### PR TITLE
READY handle NPE in GraphQLUtil.kt

### DIFF
--- a/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/util/GraphQLUtil.kt
+++ b/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/util/GraphQLUtil.kt
@@ -141,8 +141,7 @@ private fun GraphQLFieldsContainer.getFieldAt(
     pathToField: List<String>,
     pathIndex: Int,
 ): GraphQLFieldDefinition? {
-    val field = getField(pathToField[pathIndex])
-
+    val field = getField(pathToField[pathIndex]) ?: return null
     return if (pathIndex == pathToField.lastIndex) {
         field
     } else {

--- a/engine-nextgen/src/test/kotlin/graphql/nadel/validation/NadelHydrationValidationTest.kt
+++ b/engine-nextgen/src/test/kotlin/graphql/nadel/validation/NadelHydrationValidationTest.kt
@@ -68,6 +68,62 @@ class NadelHydrationValidationTest : DescribeSpec({
             assert(errors.map { it.message }.isEmpty())
         }
 
+        it("fails if non-existent hydration reference field") {
+            val fixture = NadelValidationTestFixture(
+                overallSchema = mapOf(
+                    "issues" to """
+                        type Query {
+                            issue: Issue
+                        }
+                        type Issue {
+                            id: ID!
+                            creator: User @hydrated(
+                                service: "users"
+                                field: "fakeField.user"
+                                arguments: [
+                                    {name: "id", value: "$source.creator"}
+                                ]
+                            )
+                        }
+                    """.trimIndent(),
+                    "users" to """
+                        type Query {
+                            user(id: ID!): User
+                        }
+                        type User {
+                            id: ID!
+                            name: String!
+                        }
+                    """.trimIndent(),
+                    ),
+                underlyingSchema = mapOf(
+                    "issues" to """
+                        type Query {
+                            issue: Issue
+                        }
+                        type Issue {
+                            id: ID!
+                            creator: ID!
+                        }
+                    """.trimIndent(),
+                    "users" to """
+                        type Query {
+                            user(id: ID!): User
+                        }
+                        type User {
+                            id: ID!
+                            name: String!
+                        }
+                    """.trimIndent(),
+                    ),
+            )
+
+            val errors = validate(fixture)
+
+            assert(errors.map { it.message }.isNotEmpty())
+            errors.assertSingleOfType<MissingHydrationActorField>()
+        }
+
         it("fails if hydrated field has rename") {
             val fixture = NadelValidationTestFixture(
                 overallSchema = mapOf(


### PR DESCRIPTION
There were NPE's found in splunk on this line, since type is never null I assume field was the cause. I will raise a follow up ticket as not all calling contexts handle the null value properly which could lead to more NPE's in the future