### PR TITLE
fix objectTypeName filtering for polymorphic hydrations

### DIFF
--- a/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/transform/hydration/NadelHydrationFieldsBuilder.kt
+++ b/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/transform/hydration/NadelHydrationFieldsBuilder.kt
@@ -66,10 +66,9 @@ internal object NadelHydrationFieldsBuilder {
                 if (objectTypesAreNotReturnedByActorField) {
                     null
                 } else {
-                    val originalTypeNames = HashSet(childField.objectTypeNames)
                     childField.toBuilder()
                         .clearObjectTypesNames()
-                        .objectTypeNames(originalTypeNames.filter { it in actorFieldOverallObjectTypeNames })
+                        .objectTypeNames(childField.objectTypeNames.filter { it in actorFieldOverallObjectTypeNames })
                         .build()
                 }
             }

--- a/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/transform/hydration/NadelHydrationFieldsBuilder.kt
+++ b/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/transform/hydration/NadelHydrationFieldsBuilder.kt
@@ -14,7 +14,6 @@ import graphql.nadel.enginekt.transform.query.NFUtil
 import graphql.nadel.enginekt.transform.result.json.JsonNode
 import graphql.nadel.enginekt.util.deepClone
 import graphql.nadel.enginekt.util.resolveObjectTypes
-import graphql.nadel.enginekt.util.toBuilder
 import graphql.nadel.enginekt.util.unwrapAll
 import graphql.nadel.hooks.ServiceExecutionHooks
 import graphql.normalized.ExecutableNormalizedField
@@ -66,9 +65,8 @@ internal object NadelHydrationFieldsBuilder {
                 if (objectTypesAreNotReturnedByActorField) {
                     null
                 } else {
-                    childField.toBuilder()
-                        .objectTypeNames(childField.objectTypeNames.filter { it in actorFieldOverallObjectTypeNames })
-                        .build()
+                    childField.objectTypeNames.removeIf { it !in actorFieldOverallObjectTypeNames }
+                    childField
                 }
             }
             .let { children ->

--- a/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/transform/hydration/NadelHydrationFieldsBuilder.kt
+++ b/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/transform/hydration/NadelHydrationFieldsBuilder.kt
@@ -14,6 +14,7 @@ import graphql.nadel.enginekt.transform.query.NFUtil
 import graphql.nadel.enginekt.transform.result.json.JsonNode
 import graphql.nadel.enginekt.util.deepClone
 import graphql.nadel.enginekt.util.resolveObjectTypes
+import graphql.nadel.enginekt.util.toBuilder
 import graphql.nadel.enginekt.util.unwrapAll
 import graphql.nadel.hooks.ServiceExecutionHooks
 import graphql.normalized.ExecutableNormalizedField
@@ -65,8 +66,11 @@ internal object NadelHydrationFieldsBuilder {
                 if (objectTypesAreNotReturnedByActorField) {
                     null
                 } else {
-                    childField.objectTypeNames.removeIf { it !in actorFieldOverallObjectTypeNames }
-                    childField
+                    val originalTypeNames = HashSet(childField.objectTypeNames)
+                    childField.toBuilder()
+                        .clearObjectTypesNames()
+                        .objectTypeNames(originalTypeNames.filter { it in actorFieldOverallObjectTypeNames })
+                        .build()
                 }
             }
             .let { children ->

--- a/test/src/test/kotlin/graphql/nadel/tests/hooks/polymorphic-hydration-hook-using-alias-helper.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/hooks/polymorphic-hydration-hook-using-alias-helper.kt
@@ -54,3 +54,7 @@ class `batch-polymorphic-hydration` : PolymorphicHydrationWithAliasTestHook()
 
 @UseHook
 class `batch-polymorphic-hydration-actor-fields-are-in-the-same-service` : PolymorphicHydrationWithAliasTestHook()
+
+@UseHook
+class `batch-polymorphic-hydration-actor-fields-are-in-the-same-service-return-types-implement-same-interface` :
+    PolymorphicHydrationWithAliasTestHook()

--- a/test/src/test/resources/fixtures/hydration/polymorphic hydrations/batch-polymorphic-hydration-actor-fields-are-in-the-same-service-return-types-implement-same-interface.yml
+++ b/test/src/test/resources/fixtures/hydration/polymorphic hydrations/batch-polymorphic-hydration-actor-fields-are-in-the-same-service-return-types-implement-same-interface.yml
@@ -1,0 +1,259 @@
+name: batch polymorphic hydration actor fields are in the same service return types implement same interface
+enabled:
+  current: false
+  nextgen: true
+overallSchema:
+  foo: |
+    type Query {
+      foo: [Foo]
+    }
+
+    type Foo {
+      id: ID
+      dataId: ID
+      data: Data
+      @hydrated(
+        service: "bar"
+        field: "petById"
+        arguments: [
+          {name: "ids" value: "$source.dataId"}
+        ]
+      )
+      @hydrated(
+        service: "bar"
+        field: "humanById"
+        arguments: [
+          {name: "ids" value: "$source.dataId"}
+        ]
+      )
+    }
+
+    union Data = Pet | Human
+  bar: |
+    type Query {
+      petById(ids: [ID]): [Pet]
+      humanById(ids: [ID]): [Human]
+    }
+    
+    interface Node {
+      id: ID
+    }
+    
+    type Human implements Node {
+      id: ID
+      name: String
+    }
+    
+    type Pet implements Node {
+      id: ID
+      breed: String
+    }
+underlyingSchema:
+  foo: |
+    type Query {
+      foo: [Foo]
+    }
+
+    type Foo {
+      id: ID
+      dataId: ID
+    }
+  bar: |
+    type Query {
+      petById(ids: [ID]): [Pet]
+      humanById(ids: [ID]): [Human]
+    }
+    
+    interface Node {
+      id: ID
+    }
+    
+    type Human implements Node {
+      id: ID
+      name: String
+    }
+    
+    type Pet implements Node {
+      id: ID
+      breed: String
+    }
+
+query: |
+  query {
+    foo {
+      __typename
+      id
+      data {
+        ... on Pet {
+          __typename
+          id
+          breed
+        }
+        ... on Human {
+          __typename
+          id
+          name
+        }
+      }
+    }
+  }
+variables: { }
+serviceCalls:
+  nextgen:
+    - serviceName: foo
+      request:
+        query: |
+          query {
+            foo {
+              __typename
+              __typename__batch_hydration__data: __typename
+              batch_hydration__data__dataId: dataId
+              batch_hydration__data__dataId: dataId
+              id
+            }
+          }
+        variables: { }
+      # language=JSON
+      response: |-
+        {
+          "data": {
+            "foo": [
+              {
+                "__typename": "Foo",
+                "__typename__batch_hydration__data": "Foo",
+                "batch_hydration__data__dataId": "PET-0",
+                "batch_hydration__data__dataId": "PET-0",
+                "id": "FOO-0"
+              },
+              {
+                "__typename": "Foo",
+                "__typename__batch_hydration__data": "Foo",
+                "batch_hydration__data__dataId": "HUMAN-0",
+                "batch_hydration__data__dataId": "HUMAN-0",
+                "id": "FOO-1"
+              },
+              {
+                "__typename": "Foo",
+                "__typename__batch_hydration__data": "Foo",
+                "batch_hydration__data__dataId": "PET-1",
+                "batch_hydration__data__dataId": "PET-1",
+                "id": "FOO-2"
+              },
+              {
+                "__typename": "Foo",
+                "__typename__batch_hydration__data": "Foo",
+                "batch_hydration__data__dataId": "HUMAN-1",
+                "batch_hydration__data__dataId": "HUMAN-1",
+                "id": "FOO-3"
+              } ]
+          },
+          "extensions": {}
+        }
+    - serviceName: bar
+      request:
+        query: |
+          query {
+            petById(ids: ["PET-0", "PET-1"]) {
+              __typename
+              breed
+              id
+              batch_hydration__data__id: id
+            }
+          }
+        variables: { }
+      # language=JSON
+      response: |-
+        {
+          "data": {
+            "petById": [
+              {
+                "__typename": "Pet",
+                "breed": "Akita",
+                "id": "PET-0",
+                "batch_hydration__data__id": "PET-0"
+              },
+              {
+                "__typename": "Pet",
+                "breed": "Labrador",
+                "id": "PET-1",
+                "batch_hydration__data__id": "PET-1"
+              }]
+          },
+          "extensions": {}
+        }
+    - serviceName: bar
+      request:
+        query: |
+          query {
+            humanById(ids: ["HUMAN-0", "HUMAN-1"]) {
+              __typename
+              id
+              batch_hydration__data__id: id
+              name
+            }
+          }
+        variables: { }
+      # language=JSON
+      response: |-
+        {
+          "data": {
+            "humanById": [
+              {
+                "__typename": "Human",
+                "id": "HUMAN-0",
+                "batch_hydration__data__id": "HUMAN-0",
+                "name": "Fanny Longbottom"
+              },
+              {
+                "__typename": "Human",
+                "id": "HUMAN-1",
+                "batch_hydration__data__id": "HUMAN-1",
+                "name": "John Doe"
+              }]
+          },
+          "extensions": {}
+        }
+# language=JSON
+response: |-
+  {
+    "data": {
+      "foo": [
+        {
+          "__typename": "Foo",
+          "id": "FOO-0",
+          "data": {
+            "__typename": "Pet",
+            "id": "PET-0",
+            "breed": "Akita"
+          }
+        },
+        {
+          "__typename": "Foo",
+          "id": "FOO-1",
+          "data": {
+            "__typename": "Human",
+            "id": "HUMAN-0",
+            "name": "Fanny Longbottom"
+          }
+        },
+        {
+          "__typename": "Foo",
+          "id": "FOO-2",
+          "data": {
+            "__typename": "Pet",
+            "id": "PET-1",
+            "breed": "Labrador"
+          }
+        },
+        {
+          "__typename": "Foo",
+          "id": "FOO-3",
+          "data": {
+            "__typename": "Human",
+            "id": "HUMAN-1",
+            "name": "John Doe"
+          }
+        }]
+    },
+    "extensions": {}
+  }


### PR DESCRIPTION
Please make sure you consider the following:

- [✓] Add tests that use __typename in queries
- [✓] Does this change work with all nadel transformations (rename, type rename, hydration, etc)? Add tests for this.
- [ ] Is it worth using hints for this change in order to be able to enable a percentage rollout?
- [ ] Do we need to add integration tests for this change in the graphql gateway?
- [ ] Do we need a pollinator check for this?
