### PR TITLE
add ENF to service execution parameters

### DIFF
--- a/api/src/main/java/graphql/nadel/ServiceExecutionParameters.java
+++ b/api/src/main/java/graphql/nadel/ServiceExecutionParameters.java
@@ -6,6 +6,7 @@ import graphql.execution.ExecutionId;
 import graphql.language.Document;
 import graphql.language.FragmentDefinition;
 import graphql.language.OperationDefinition;
+import graphql.normalized.ExecutableNormalizedField;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -25,6 +26,7 @@ public class ServiceExecutionParameters {
     private final CacheControl cacheControl;
     private final Object serviceContext;
     private final ServiceExecutionHydrationDetails hydrationDetails;
+    private final ExecutableNormalizedField executableNormalizedField;
 
     private ServiceExecutionParameters(Builder builder) {
         this.query = assertNotNull(builder.query);
@@ -36,6 +38,7 @@ public class ServiceExecutionParameters {
         this.cacheControl = builder.cacheControl;
         this.serviceContext = builder.serviceContext;
         this.hydrationDetails = builder.hydrationDetails;
+        this.executableNormalizedField = builder.executableNormalizedField;
     }
 
     public Document getQuery() {
@@ -85,6 +88,10 @@ public class ServiceExecutionParameters {
         return hydrationDetails;
     }
 
+    public ExecutableNormalizedField getExecutableNormalizedField() {
+        return executableNormalizedField;
+    }
+
     public static Builder newServiceExecutionParameters() {
         return new Builder();
     }
@@ -99,6 +106,7 @@ public class ServiceExecutionParameters {
         private CacheControl cacheControl;
         private Object serviceContext;
         private ServiceExecutionHydrationDetails hydrationDetails;
+        private ExecutableNormalizedField executableNormalizedField;
 
         private Builder() {
         }
@@ -145,6 +153,11 @@ public class ServiceExecutionParameters {
 
         public Builder executionHydrationDetails(ServiceExecutionHydrationDetails hydrationDetails) {
             this.hydrationDetails = hydrationDetails;
+            return this;
+        }
+
+        public Builder executableNormalizedField(ExecutableNormalizedField executableNormalizedField) {
+            this.executableNormalizedField = executableNormalizedField;
             return this;
         }
 

--- a/engine-nextgen/src/main/kotlin/graphql/nadel/NextgenEngine.kt
+++ b/engine-nextgen/src/main/kotlin/graphql/nadel/NextgenEngine.kt
@@ -301,6 +301,7 @@ class NextgenEngine @JvmOverloads constructor(
             .operationDefinition(compileResult.document.definitions.singleOfType())
             .serviceContext(executionContext.getContextForService(service).await())
             .executionHydrationDetails(executionHydrationDetails)
+            .executableNormalizedField(transformedQuery)
             .build()
 
         val serviceExecResult = try {

--- a/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/blueprint/NadelExecutionBlueprintFactory.kt
+++ b/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/blueprint/NadelExecutionBlueprintFactory.kt
@@ -251,6 +251,7 @@ private class Factory(
             actorService = hydrationActorService,
             queryPathToActorField = NadelQueryPath(queryPathToActorField),
             actorFieldDef = actorFieldDef,
+            overallActorFieldDef = overallActorFieldDef,
             actorInputValueDefs = hydrationArgs,
             timeout = hydration.timeout,
             hydrationStrategy = getHydrationStrategy(

--- a/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/blueprint/NadelFieldInstruction.kt
+++ b/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/blueprint/NadelFieldInstruction.kt
@@ -48,6 +48,7 @@ interface NadelGenericHydrationInstruction {
     /**
      * The field definition referenced by [queryPathToActorField].
      */
+    @Deprecated("Start moving to overall field overallActorFieldDef")
     val actorFieldDef: GraphQLFieldDefinition
 
     /**
@@ -76,6 +77,12 @@ interface NadelGenericHydrationInstruction {
      * or [NadelBatchHydrationMatchStrategy.MatchObjectIdentifier.sourceId].
      */
     val sourceFields: List<NadelQueryPath>
+
+    /**
+     * The field definition in the overall schema referenced by [queryPathToActorField].
+     * should be non-null in the future
+     */
+    val overallActorFieldDef: GraphQLFieldDefinition?
 }
 
 data class NadelHydrationFieldInstruction(
@@ -88,6 +95,7 @@ data class NadelHydrationFieldInstruction(
     override val actorInputValueDefs: List<NadelHydrationActorInputDef>,
     override val timeout: Int,
     override val sourceFields: List<NadelQueryPath>,
+    override val overallActorFieldDef: GraphQLFieldDefinition?,
     val hydrationStrategy: NadelHydrationStrategy,
 ) : NadelFieldInstruction(), NadelGenericHydrationInstruction
 
@@ -97,15 +105,13 @@ data class NadelBatchHydrationFieldInstruction(
     override val hydratedFieldDef: GraphQLFieldDefinition,
     override val actorService: Service,
     override val queryPathToActorField: NadelQueryPath,
-    @Deprecated("Start moving to overall field overallActorFieldDef")
     override val actorFieldDef: GraphQLFieldDefinition,
     override val actorInputValueDefs: List<NadelHydrationActorInputDef>,
     override val timeout: Int,
     override val sourceFields: List<NadelQueryPath>,
+    override val overallActorFieldDef: GraphQLFieldDefinition?,
     val batchSize: Int,
     val batchHydrationMatchStrategy: NadelBatchHydrationMatchStrategy,
-    //overallActorFieldDef should be non-null in the future
-    val overallActorFieldDef: GraphQLFieldDefinition?,
 ) : NadelFieldInstruction(), NadelGenericHydrationInstruction
 
 data class NadelDeepRenameFieldInstruction(


### PR DESCRIPTION
Please make sure you consider the following:

- [ ] Add tests that use __typename in queries
- [ ] Does this change work with all nadel transformations (rename, type rename, hydration, etc)? Add tests for this.
- [ ] Is it worth using hints for this change in order to be able to enable a percentage rollout?
- [ ] Do we need to add integration tests for this change in the graphql gateway?
- [ ] Do we need a pollinator check for this?
