### PR TITLE
make hydration instruction overall actor field non null

### DIFF
--- a/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/blueprint/NadelExecutionBlueprintFactory.kt
+++ b/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/blueprint/NadelExecutionBlueprintFactory.kt
@@ -50,7 +50,7 @@ import graphql.schema.GraphQLType
 internal object NadelExecutionBlueprintFactory {
     fun create(
         engineSchema: GraphQLSchema,
-        services: List<Service>
+        services: List<Service>,
     ): NadelOverallExecutionBlueprint {
         return Factory(engineSchema, services).make()
     }
@@ -112,7 +112,7 @@ private class Factory(
      */
     private fun makeUnderlyingTypeNamesToOverallNameByService(
         services: List<Service>,
-        underlyingBlueprints: Map<String, NadelUnderlyingExecutionBlueprint>
+        underlyingBlueprints: Map<String, NadelUnderlyingExecutionBlueprint>,
     ): Map<Service, Map<String, String>> {
         val serviceMap = LinkedHashMap<Service, Map<String, String>>()
         for (service in services) {
@@ -129,7 +129,7 @@ private class Factory(
     private fun makeOverAllTypeNameToUnderlyingNameByService(
         services: List<Service>,
         underlyingBlueprints: Map<String, NadelUnderlyingExecutionBlueprint>,
-        underlyingTypeNameToOverallNameByService: Map<Service, Map<String, String>>
+        underlyingTypeNameToOverallNameByService: Map<Service, Map<String, String>>,
     ): Map<Service, Map<String, String>> {
         val serviceMap = LinkedHashMap<Service, Map<String, String>>()
         for (service in services) {
@@ -148,7 +148,7 @@ private class Factory(
     private fun overAllTypeNameFromUnderlyingType(
         service: Service,
         underlyingBlueprints: Map<String, NadelUnderlyingExecutionBlueprint>,
-        underlyingTypeName: String
+        underlyingTypeName: String,
     ): String {
         // TODO: THIS SHOULD NOT BE HAPPENING, INTROSPECTIONS ARE DUMB AND DON'T NEED TRANSFORMING
         if (service.name == IntrospectionService.name) {
@@ -162,7 +162,7 @@ private class Factory(
     private fun underlyingTypeNameFromOverallType(
         service: Service,
         underlyingBlueprints: Map<String, NadelUnderlyingExecutionBlueprint>,
-        overallTypeName: String
+        overallTypeName: String,
     ): String {
         // TODO: THIS SHOULD NOT BE HAPPENING, INTROSPECTIONS ARE DUMB AND DON'T NEED TRANSFORMING
         if (service.name == IntrospectionService.name) {
@@ -175,7 +175,7 @@ private class Factory(
 
     private fun underlyingExecutionBlueprint(
         underlyingBlueprints: Map<String, NadelUnderlyingExecutionBlueprint>,
-        service: Service
+        service: Service,
     ) = (underlyingBlueprints[service.name] ?: error("Could not find service: $service.name"))
 
     private fun makeFieldInstructions(): List<NadelFieldInstruction> {
@@ -225,7 +225,7 @@ private class Factory(
 
         val queryPathToActorField = listOfNotNull(hydration.syntheticField, hydration.topLevelField)
         val actorFieldDef = actorFieldSchema.queryType.getFieldAt(queryPathToActorField)!!
-        val overallActorFieldDef = engineSchema.queryType.getFieldAt(queryPathToActorField)
+        val overallActorFieldDef = engineSchema.queryType.getFieldAt(queryPathToActorField)!!
 
         if (hydration.isBatched || /*deprecated*/ actorFieldDef.type.unwrapNonNull().isList) {
             require(actorFieldDef.type.unwrapNonNull().isList) { "Batched hydration at '$queryPathToActorField' requires a list output type" }
@@ -310,7 +310,7 @@ private class Factory(
         actorFieldDef: GraphQLFieldDefinition,
         hydration: UnderlyingServiceHydration,
         actorService: Service,
-        overallActorFieldDef: GraphQLFieldDefinition?,
+        overallActorFieldDef: GraphQLFieldDefinition,
     ): NadelFieldInstruction {
         val location = makeFieldCoordinates(parentType, hydratedFieldDef)
 

--- a/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/blueprint/NadelFieldInstruction.kt
+++ b/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/blueprint/NadelFieldInstruction.kt
@@ -80,9 +80,8 @@ interface NadelGenericHydrationInstruction {
 
     /**
      * The field definition in the overall schema referenced by [queryPathToActorField].
-     * should be non-null in the future
      */
-    val overallActorFieldDef: GraphQLFieldDefinition?
+    val overallActorFieldDef: GraphQLFieldDefinition
 }
 
 data class NadelHydrationFieldInstruction(
@@ -95,7 +94,7 @@ data class NadelHydrationFieldInstruction(
     override val actorInputValueDefs: List<NadelHydrationActorInputDef>,
     override val timeout: Int,
     override val sourceFields: List<NadelQueryPath>,
-    override val overallActorFieldDef: GraphQLFieldDefinition?,
+    override val overallActorFieldDef: GraphQLFieldDefinition,
     val hydrationStrategy: NadelHydrationStrategy,
 ) : NadelFieldInstruction(), NadelGenericHydrationInstruction
 
@@ -109,7 +108,7 @@ data class NadelBatchHydrationFieldInstruction(
     override val actorInputValueDefs: List<NadelHydrationActorInputDef>,
     override val timeout: Int,
     override val sourceFields: List<NadelQueryPath>,
-    override val overallActorFieldDef: GraphQLFieldDefinition?,
+    override val overallActorFieldDef: GraphQLFieldDefinition,
     val batchSize: Int,
     val batchHydrationMatchStrategy: NadelBatchHydrationMatchStrategy,
 ) : NadelFieldInstruction(), NadelGenericHydrationInstruction

--- a/test/src/test/resources/fixtures/errors/exceptions-in-hydration-call-that-fail-with-errors-are-reflected-in-the-result.yml
+++ b/test/src/test/resources/fixtures/errors/exceptions-in-hydration-call-that-fail-with-errors-are-reflected-in-the-result.yml
@@ -4,6 +4,7 @@ overallSchema:
   Bar: |
     type Query {
       bar: Bar
+      barById(id: ID): Bar
     }
     type Bar {
       name: String

--- a/test/src/test/resources/fixtures/extend type/extending-types-from-another-service-is-possible-with-synthetic-fields.yml
+++ b/test/src/test/resources/fixtures/extend type/extending-types-from-another-service-is-possible-with-synthetic-fields.yml
@@ -2,6 +2,12 @@ name: extending types from another service is possible with synthetic fields
 enabled: true
 overallSchema:
   Service2: |
+    type Query {
+      lookUpQuery: LookUpQuery
+    }
+    type LookUpQuery {
+      lookup(id: ID): Extension
+    }
     extend type Root {
       extension: Extension @hydrated(service: "Service2" field: "lookUpQuery.lookup" arguments: [{name: "id" value: "$source.id"}] identifiedBy: "id")
     }

--- a/test/src/test/resources/fixtures/extend type/extending-types-from-another-service-is-possible.yml
+++ b/test/src/test/resources/fixtures/extend type/extending-types-from-another-service-is-possible.yml
@@ -2,6 +2,9 @@ name: extending types from another service is possible
 enabled: true
 overallSchema:
   Service2: |
+    type Query {
+      lookup(id: ID): Extension
+    }
     extend type Root {
       extension: Extension @hydrated(service: "Service2" field: "lookup" arguments: [{name: "id" value: "$source.id"}] identifiedBy: "id")
     }

--- a/test/src/test/resources/fixtures/extend type/extending-types-via-hydration-returning-a-connection.yml
+++ b/test/src/test/resources/fixtures/extend type/extending-types-via-hydration-returning-a-connection.yml
@@ -14,6 +14,10 @@ overallSchema:
   Association: |
     type Query {
       association(id: ID, filter: Filter): AssociationConnection
+      pages: Pages
+    }
+    type Pages {
+      page(id: ID): Page
     }
     type AssociationConnection {
       nodes: [Association]

--- a/test/src/test/resources/fixtures/hydration/able-to-ask-for-field-and-use-same-field-as-hydration-source.yml
+++ b/test/src/test/resources/fixtures/hydration/able-to-ask-for-field-and-use-same-field-as-hydration-source.yml
@@ -4,6 +4,7 @@ overallSchema:
   Bar: |-
     type Query {
       bar: Bar
+      barById(id: ID): Bar
     }
     type Bar {
       barId: ID

--- a/test/src/test/resources/fixtures/hydration/complex identified by/complex-identified-by-uses-same-source-for-2-hydrations-and-a-deep-rename.yml
+++ b/test/src/test/resources/fixtures/hydration/complex identified by/complex-identified-by-uses-same-source-for-2-hydrations-and-a-deep-rename.yml
@@ -4,6 +4,8 @@ overallSchema:
   Foo: |
     type Query {
       foos: [Foo]
+      details(detailIds: [ID]): [Detail]
+      issues(issueIds: [ID]): [Issue]
     }
     type Foo {
       renamedField: String @renamed(from: "issue.field")

--- a/test/src/test/resources/fixtures/hydration/complex identified by/complex-identified-by-uses-same-source-for-2-hydrations.yml
+++ b/test/src/test/resources/fixtures/hydration/complex identified by/complex-identified-by-uses-same-source-for-2-hydrations.yml
@@ -4,6 +4,8 @@ overallSchema:
   Foo: |
     type Query {
       foos: [Foo]
+      details(detailIds: [ID]): [Detail]
+      issues(issueIds: [ID]): [Issue]
     }
     type Foo {
       issue: Issue @hydrated(

--- a/test/src/test/resources/fixtures/hydration/complex identified by/complex-identified-by-with-list-source-id.yml
+++ b/test/src/test/resources/fixtures/hydration/complex identified by/complex-identified-by-with-list-source-id.yml
@@ -2,6 +2,15 @@ name: complex identified by with list source id
 enabled: true
 overallSchema:
   UserService: |
+    type Query {
+      users(id: [UserInput]): [User]
+    }
+    
+    input UserInput {
+      userId: ID
+      site: String
+    }
+    
     type User {
       id: ID
       name: String

--- a/test/src/test/resources/fixtures/hydration/complex identified by/complex-identified-by-with-some-null-source-ids.yml
+++ b/test/src/test/resources/fixtures/hydration/complex identified by/complex-identified-by-with-some-null-source-ids.yml
@@ -2,6 +2,13 @@ name: complex identified by with some null source ids
 enabled: true
 overallSchema:
   UserService: |
+    type Query {
+      users(id: [UserInput]): [User]
+    }
+    input UserInput {
+      userId: ID
+      site: String
+    }
     type User {
       id: ID
       name: String

--- a/test/src/test/resources/fixtures/hydration/complex identified by/complex-identified-by.yml
+++ b/test/src/test/resources/fixtures/hydration/complex identified by/complex-identified-by.yml
@@ -2,6 +2,13 @@ name: complex identified by
 enabled: true
 overallSchema:
   UserService: |
+    type Query {
+      users(id: [UserInput]): [User]
+    }
+    input UserInput {
+      userId: ID
+      site: String
+    }
     type User {
       id: ID
       name: String

--- a/test/src/test/resources/fixtures/hydration/hydration-call-over-itself-with-renamed-types.yml
+++ b/test/src/test/resources/fixtures/hydration/hydration-call-over-itself-with-renamed-types.yml
@@ -4,6 +4,7 @@ overallSchema:
   testing: |
     type Query {
       testing: Testing
+      characters(ids: [ID!]!): [TestingCharacter]
     }
     type Testing {
       movies: [TestingMovie]

--- a/test/src/test/resources/fixtures/hydration/hydration-with-interfaces-asking-typename.yml
+++ b/test/src/test/resources/fixtures/hydration/hydration-with-interfaces-asking-typename.yml
@@ -4,6 +4,7 @@ overallSchema:
   Issues: |
     type Query {
       nodes: [Node]
+      ariById(id: ID!): ID
     }
     type JiraIssue implements Node @renamed(from: "Issue") {
       id: ID! 

--- a/test/src/test/resources/fixtures/hydration/hydration-with-interfaces-no-source-id.yml
+++ b/test/src/test/resources/fixtures/hydration/hydration-with-interfaces-no-source-id.yml
@@ -4,6 +4,7 @@ overallSchema:
   Issues: |
     type Query {
       nodes: [Node]
+      idByAri(id: ID!): ID
     }
     type JiraIssue implements Node @renamed(from: "Issue") {
       id: ID! 

--- a/test/src/test/resources/fixtures/hydration/hydration-with-interfaces.yml
+++ b/test/src/test/resources/fixtures/hydration/hydration-with-interfaces.yml
@@ -4,6 +4,7 @@ overallSchema:
   Issues: |
     type Query {
       nodes: [Node]
+      idByAri(id: ID!): ID
     }
     type JiraIssue implements Node @renamed(from: "Issue") {
       id: ID! 

--- a/test/src/test/resources/fixtures/hydration/hydration-with-more-interfaces.yml
+++ b/test/src/test/resources/fixtures/hydration/hydration-with-more-interfaces.yml
@@ -4,6 +4,8 @@ overallSchema:
   Issues: |
     type Query {
       nodes: [Node]
+      trollName(id: ID!): String
+      ariById(id: ID!): ID
     }
     type JiraIssue implements Node @renamed(from: "Issue") {
       id: ID!

--- a/test/src/test/resources/fixtures/hydration/hydration-works-when-an-ancestor-field-has-been-renamed.yml
+++ b/test/src/test/resources/fixtures/hydration/hydration-works-when-an-ancestor-field-has-been-renamed.yml
@@ -14,6 +14,7 @@ overallSchema:
     type Query {
       devOpsRelationships: DevOpsRelationshipConnection @renamed(from: "relationships")
       devOpsIssue(id: ID): DevOpsIssue @renamed(from: "issue")
+      issue(id: ID): DevOpsIssue @hidden
     }
 underlyingSchema:
   IssueService: |

--- a/test/src/test/resources/fixtures/hydration/index/hydration-matching-using-index-with-lists-with-hydration-field-not-exposed.yml
+++ b/test/src/test/resources/fixtures/hydration/index/hydration-matching-using-index-with-lists-with-hydration-field-not-exposed.yml
@@ -4,6 +4,7 @@ overallSchema:
   UserService: |
     type Query {
       echo: String
+      usersByIssueIds(issueIds: [ID]): [[User]]
     }
     type User {
       id: ID

--- a/test/src/test/resources/fixtures/hydration/nested-list-hydration-under-a-renamed-top-level-field.yml
+++ b/test/src/test/resources/fixtures/hydration/nested-list-hydration-under-a-renamed-top-level-field.yml
@@ -4,6 +4,10 @@ overallSchema:
   Foo: |
     type Query {
       fooService: FooService @renamed(from: "service")
+
+      connection(id: ID): Connection
+      node(id: ID): Node
+      space(id: ID): Space
     }
     type FooService @renamed(from: "Service") {
       otherServices: Connection @hydrated(service: "Foo" field: "connection" arguments: [{name: "id" value: "$source.id"}])

--- a/test/src/test/resources/fixtures/hydration/polymorphic hydrations/batch-polymorphic-hydration-with-lots-of-renames.yml
+++ b/test/src/test/resources/fixtures/hydration/polymorphic hydrations/batch-polymorphic-hydration-with-lots-of-renames.yml
@@ -4,7 +4,9 @@ overallSchema:
   bar: |
     type Query {
         animalById(ids: [ID]): [Animal] @renamed(from: "petById")
+        petById(ids: [ID]): [Animal]
         personById(ids: [ID]): [Person] @renamed(from: "humanById")
+        humanById(ids: [ID]): [Person]
     }
 
     type Animal @renamed(from: "Pet") {

--- a/test/src/test/resources/fixtures/hydration/query-with-hydrated-interfaces-work-as-expected.yml
+++ b/test/src/test/resources/fixtures/hydration/query-with-hydrated-interfaces-work-as-expected.yml
@@ -41,7 +41,7 @@ overallSchema:
     }
   OwnerService: |
     type Query {
-      owner(id: String): Owner
+      ownerById(id: String): Owner
     }
     interface Owner {
       name: String

--- a/test/src/test/resources/fixtures/hydration/query-with-hydration-that-fail-with-errors-are-reflected-in-the-result.yml
+++ b/test/src/test/resources/fixtures/hydration/query-with-hydration-that-fail-with-errors-are-reflected-in-the-result.yml
@@ -4,6 +4,7 @@ overallSchema:
   Bar: |
     type Query {
       bar: Bar
+      barById(id: ID): Bar
     }
     type Bar {
       name: String

--- a/test/src/test/resources/fixtures/hydration/query-with-three-nested-hydrations-and-simple-data-and-lots-of-renames.yml
+++ b/test/src/test/resources/fixtures/hydration/query-with-three-nested-hydrations-and-simple-data-and-lots-of-renames.yml
@@ -4,6 +4,7 @@ overallSchema:
   Bar: |
     type Query {
       ibar: Bar @renamed(from: "bar")
+      barsById(id: [ID]): [Bar]
     }
     type Bar {
       barId: ID

--- a/test/src/test/resources/fixtures/hydration/query-with-three-nested-hydrations-and-simple-data.yml
+++ b/test/src/test/resources/fixtures/hydration/query-with-three-nested-hydrations-and-simple-data.yml
@@ -4,6 +4,7 @@ overallSchema:
   Bar: |
     type Query {
       bar: Bar
+      barsById(id: [ID]): [Bar]
     }
     type Bar {
       barId: ID

--- a/test/src/test/resources/fixtures/hydration/query-with-three-nested-hydrations.yml
+++ b/test/src/test/resources/fixtures/hydration/query-with-three-nested-hydrations.yml
@@ -4,6 +4,7 @@ overallSchema:
   Bar: |
     type Query {
       bar: Bar
+      barsById(id: [ID]): [Bar]
     }
     type Bar {
       barId: ID

--- a/test/src/test/resources/fixtures/hydration/renamed-and-hydrated-query-using-same-underlying-source.yml
+++ b/test/src/test/resources/fixtures/hydration/renamed-and-hydrated-query-using-same-underlying-source.yml
@@ -3,6 +3,7 @@ enabled: true
 overallSchema:
   Foo: |
     type Query {
+      detail(detailId: ID): Detail
       foo: Foo
     }
     type Foo {

--- a/test/src/test/resources/fixtures/hydration/repeated-hydrated-fields-on-the-same-level-overlapping-fields-in-the-query.yml
+++ b/test/src/test/resources/fixtures/hydration/repeated-hydrated-fields-on-the-same-level-overlapping-fields-in-the-query.yml
@@ -5,6 +5,7 @@ overallSchema:
     service Foo {
       type Query {
         foo: Foo
+        issue(issueId: ID): Issue
       }
       type Foo {
         issue: Issue => hydrated from Foo.issue(issueId: $source.issueId)

--- a/test/src/test/resources/fixtures/hydration/repeated-hydrated-fields-on-the-same-level-when-using-batch-hydration.yml
+++ b/test/src/test/resources/fixtures/hydration/repeated-hydrated-fields-on-the-same-level-when-using-batch-hydration.yml
@@ -5,6 +5,7 @@ overallSchema:
     service Foo {
       type Query {
         foo: Foo
+        issues(issueIds: [ID!]): [Issue!]
       }
       type Foo {
         issue: Issue => hydrated from Foo.issues(issueIds: $source.issueId)

--- a/test/src/test/resources/fixtures/hydration/repeated-hydrated-fields-on-the-same-level.yml
+++ b/test/src/test/resources/fixtures/hydration/repeated-hydrated-fields-on-the-same-level.yml
@@ -5,6 +5,7 @@ overallSchema:
     service Foo {
       type Query {
         foo: Foo
+        issue(issueId: ID): Issue
       }
       type Foo {
         issue: Issue => hydrated from Foo.issue(issueId: $source.issueId)

--- a/test/src/test/resources/fixtures/hydration/same-source-for-2-hydrations.yml
+++ b/test/src/test/resources/fixtures/hydration/same-source-for-2-hydrations.yml
@@ -4,6 +4,8 @@ overallSchema:
   Foo: |
     type Query {
       foo: Foo
+      detail(detailId: ID): Detail
+      issue(issueId: ID): Issue
     }
     type Foo {
       issue: Issue @hydrated(service: "Foo" field: "issue" arguments: [{name: "issueId" value: "$source.fooId"}])

--- a/test/src/test/resources/fixtures/hydration/same-source-for-2-nested-hydrations-and-a-rename.yml
+++ b/test/src/test/resources/fixtures/hydration/same-source-for-2-nested-hydrations-and-a-rename.yml
@@ -4,6 +4,8 @@ overallSchema:
   Foo: |
     type Query {
       foo: Foo
+      detail(detailId: ID): Detail
+      issue(issueId: ID): Issue
     }
     type Foo {
       renamedField: String @renamed(from: "issue.field")

--- a/test/src/test/resources/fixtures/hydration/simple-synthetic-hydration-with-one-service-and-type-renaming.yml
+++ b/test/src/test/resources/fixtures/hydration/simple-synthetic-hydration-with-one-service-and-type-renaming.yml
@@ -7,6 +7,7 @@ overallSchema:
     }
     type TestQuery {
       testing: Testing
+      character(id: ID): TestingCharacter
     }
     type Testing {
       movie: Movie

--- a/test/src/test/resources/fixtures/hydration/synthetic-hydration-call-over-itself-within-renamed-types.yml
+++ b/test/src/test/resources/fixtures/hydration/synthetic-hydration-call-over-itself-within-renamed-types.yml
@@ -7,6 +7,7 @@ overallSchema:
     }
     type TestQuery {
       testing: Testing
+      characters(ids: [ID!]!): [TestingCharacter]
     }
     type Testing {
       movies: [TestingMovie]

--- a/test/src/test/resources/fixtures/hydration/synthetic-hydration-works-when-an-ancestor-field-has-been-renamed.yml
+++ b/test/src/test/resources/fixtures/hydration/synthetic-hydration-works-when-an-ancestor-field-has-been-renamed.yml
@@ -13,9 +13,11 @@ overallSchema:
     }
     type SyntheticIssue {
       devOpsIssue(id: ID): DevOpsIssue @renamed(from: "issue")
+      issue(id: ID): DevOpsIssue
     }
     type Query {
       devOpsRelationships: DevOpsRelationshipConnection @renamed(from: "relationships")
+      syntheticIssue: SyntheticIssue
     }
 underlyingSchema:
   IssueService: |

--- a/test/src/test/resources/fixtures/skip-include-fields/hydration/handles-include-directive-field-with-hydrated-parent.yml
+++ b/test/src/test/resources/fixtures/skip-include-fields/hydration/handles-include-directive-field-with-hydrated-parent.yml
@@ -4,6 +4,7 @@ overallSchema:
   service: |
     type Query {
       foo: Foo @renamed(from: "bar")
+      fooById(id: ID): Foo
     }
     type Foo {
       id: String

--- a/test/src/test/resources/fixtures/skip-include-fields/hydration/handles-include-directive-on-batch-hydrated-field.yml
+++ b/test/src/test/resources/fixtures/skip-include-fields/hydration/handles-include-directive-on-batch-hydrated-field.yml
@@ -4,6 +4,7 @@ overallSchema:
   service: |
     type Query {
       foos: [Foo]
+      tests(ids: [ID]): [Test]
     }
     type Foo {
       test: Test @hydrated(

--- a/test/src/test/resources/fixtures/skip-include-fields/hydration/handles-include-directive-on-field-with-batch-hydrated-parent.yml
+++ b/test/src/test/resources/fixtures/skip-include-fields/hydration/handles-include-directive-on-field-with-batch-hydrated-parent.yml
@@ -4,6 +4,7 @@ overallSchema:
   service: |
     type Query {
       foos: [Foo]
+      tests(ids: [ID]): [Test]
     }
     type Foo {
       test: Test @hydrated(


### PR DESCRIPTION
Please make sure you consider the following:

- [ ] Add tests that use __typename in queries
- [ ] Does this change work with all nadel transformations (rename, type rename, hydration, etc)? Add tests for this.
- [ ] Is it worth using hints for this change in order to be able to enable a percentage rollout?
- [ ] Do we need to add integration tests for this change in the graphql gateway?
- [ ] Do we need a pollinator check for this?
