### PR TITLE
remove validation hint for overall hydration actor fields

### DIFF
--- a/engine-nextgen/src/main/kotlin/graphql/nadel/validation/NadelFieldValidation.kt
+++ b/engine-nextgen/src/main/kotlin/graphql/nadel/validation/NadelFieldValidation.kt
@@ -18,11 +18,9 @@ internal class NadelFieldValidation(
     private val overallSchema: GraphQLSchema,
     services: Map<String, Service>,
     private val typeValidation: NadelTypeValidation,
-    nadelValidationHints: NadelValidationHints?,
 ) {
     private val renameValidation = NadelRenameValidation(this)
-    private val hydrationValidation =
-        NadelHydrationValidation(services, typeValidation, overallSchema, nadelValidationHints)
+    private val hydrationValidation = NadelHydrationValidation(services, typeValidation, overallSchema)
 
     fun validate(
         schemaElement: NadelServiceSchemaElement,
@@ -65,7 +63,7 @@ internal class NadelFieldValidation(
     fun validate(
         parent: NadelServiceSchemaElement,
         overallField: GraphQLFieldDefinition,
-        underlyingFieldsByName: Map<String, GraphQLFieldDefinition>
+        underlyingFieldsByName: Map<String, GraphQLFieldDefinition>,
     ): List<NadelSchemaValidationError> {
         return if (hasRename(overallField)) {
             renameValidation.validate(parent, overallField)

--- a/engine-nextgen/src/main/kotlin/graphql/nadel/validation/NadelSchemaValidation.kt
+++ b/engine-nextgen/src/main/kotlin/graphql/nadel/validation/NadelSchemaValidation.kt
@@ -8,9 +8,9 @@ class NadelSchemaValidation(
     private val overallSchema: GraphQLSchema,
     private val services: Map<String, Service>,
 ) {
-    fun validate(nadelValidationHints: NadelValidationHints? = null): Set<NadelSchemaValidationError> {
+    fun validate(): Set<NadelSchemaValidationError> {
         val context = NadelValidationContext()
-        val typeValidation = NadelTypeValidation(context, overallSchema, services, nadelValidationHints)
+        val typeValidation = NadelTypeValidation(context, overallSchema, services)
         return services
             .asSequence()
             .flatMap { (_, service) ->

--- a/engine-nextgen/src/main/kotlin/graphql/nadel/validation/NadelTypeValidation.kt
+++ b/engine-nextgen/src/main/kotlin/graphql/nadel/validation/NadelTypeValidation.kt
@@ -35,9 +35,8 @@ internal class NadelTypeValidation(
     private val context: NadelValidationContext,
     private val overallSchema: GraphQLSchema,
     services: Map<String, Service>,
-    nadelValidationHints: NadelValidationHints?,
 ) {
-    private val fieldValidation = NadelFieldValidation(overallSchema, services, this, nadelValidationHints)
+    private val fieldValidation = NadelFieldValidation(overallSchema, services, this)
     private val inputValidation = NadelInputValidation()
     private val enumValidation = NadelEnumValidation()
     private val interfaceValidation = NadelInterfaceValidation()

--- a/engine-nextgen/src/main/kotlin/graphql/nadel/validation/NadelValidationHints.kt
+++ b/engine-nextgen/src/main/kotlin/graphql/nadel/validation/NadelValidationHints.kt
@@ -1,5 +1,0 @@
-package graphql.nadel.validation
-
-data class NadelValidationHints(
-    val requireHydrationActorFieldInOverallSchemaHint: RequireHydrationActorFieldInOverallSchemaHint
-)

--- a/engine-nextgen/src/main/kotlin/graphql/nadel/validation/RequireHydrationActorFieldInOverallSchemaHint.kt
+++ b/engine-nextgen/src/main/kotlin/graphql/nadel/validation/RequireHydrationActorFieldInOverallSchemaHint.kt
@@ -1,7 +1,0 @@
-package graphql.nadel.validation
-
-import graphql.nadel.Service
-
-interface RequireHydrationActorFieldInOverallSchemaHint {
-    fun getHintValue(service: Service): Boolean
-}

--- a/engine-nextgen/src/test/kotlin/graphql/nadel/validation/NadelSchemaValidationTest.kt
+++ b/engine-nextgen/src/test/kotlin/graphql/nadel/validation/NadelSchemaValidationTest.kt
@@ -1,6 +1,5 @@
 package graphql.nadel.validation
 
-import graphql.nadel.Service
 import graphql.nadel.enginekt.util.strictAssociateBy
 import io.kotest.core.spec.style.DescribeSpec
 
@@ -33,10 +32,5 @@ class NadelSchemaValidationTest : DescribeSpec({
 fun validate(fixture: NadelValidationTestFixture): Set<NadelSchemaValidationError> {
     val nadel = fixture.toNadel()
     val services = nadel.services.strictAssociateBy { it.name }
-    val hint: RequireHydrationActorFieldInOverallSchemaHint = object : RequireHydrationActorFieldInOverallSchemaHint {
-        override fun getHintValue(service: Service): Boolean {
-            return true
-        }
-    }
-    return NadelSchemaValidation(nadel.engineSchema, services).validate(NadelValidationHints(hint))
+    return NadelSchemaValidation(nadel.engineSchema, services).validate()
 }


### PR DESCRIPTION
Please make sure you consider the following:

- [ ] Add tests that use __typename in queries
- [ ] Does this change work with all nadel transformations (rename, type rename, hydration, etc)? Add tests for this.
- [ ] Is it worth using hints for this change in order to be able to enable a percentage rollout?
- [ ] Do we need to add integration tests for this change in the graphql gateway?
- [ ] Do we need a pollinator check for this?
