### PR TITLE
remove exemption for scalar output type mismatch

### DIFF
--- a/engine-nextgen/src/main/kotlin/graphql/nadel/validation/NadelTypeValidation.kt
+++ b/engine-nextgen/src/main/kotlin/graphql/nadel/validation/NadelTypeValidation.kt
@@ -147,11 +147,6 @@ internal class NadelTypeValidation(
             return true
         }
 
-        // Ignore what the name is for scalars
-        if (overallType is GraphQLScalarType && underlyingType is GraphQLScalarType) {
-            return true
-        }
-
         return false
     }
 


### PR DESCRIPTION
Removing this exemption, we will then filter through any errors for this in the gateway and act accordingly
