### PR TITLE
GQLGW-1609 - this renames input types names when used as field arguments

### DIFF
--- a/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/plan/NadelExecutionPlanFactory.kt
+++ b/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/plan/NadelExecutionPlanFactory.kt
@@ -89,8 +89,8 @@ internal class NadelExecutionPlanFactory(
                     NadelTypeRenameResultTransform(),
                     NadelHydrationTransform(engine),
                     NadelBatchHydrationTransform(engine),
-                    NadelRenameTransform(),
                     NadelRenameArgumentInputTypesTransform(),
+                    NadelRenameTransform(),
                 ),
             )
         }

--- a/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/plan/NadelExecutionPlanFactory.kt
+++ b/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/plan/NadelExecutionPlanFactory.kt
@@ -7,6 +7,7 @@ import graphql.nadel.enginekt.NadelExecutionContext
 import graphql.nadel.enginekt.blueprint.NadelOverallExecutionBlueprint
 import graphql.nadel.enginekt.transform.NadelCoerceTransform
 import graphql.nadel.enginekt.transform.NadelDeepRenameTransform
+import graphql.nadel.enginekt.transform.NadelRenameArgumentInputTypesTransform
 import graphql.nadel.enginekt.transform.NadelRenameTransform
 import graphql.nadel.enginekt.transform.NadelServiceTypeFilterTransform
 import graphql.nadel.enginekt.transform.NadelTransform
@@ -89,6 +90,7 @@ internal class NadelExecutionPlanFactory(
                     NadelHydrationTransform(engine),
                     NadelBatchHydrationTransform(engine),
                     NadelRenameTransform(),
+                    NadelRenameArgumentInputTypesTransform(),
                 ),
             )
         }

--- a/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/transform/NadelRenameArgumentInputTypesTransform.kt
+++ b/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/transform/NadelRenameArgumentInputTypesTransform.kt
@@ -1,0 +1,94 @@
+package graphql.nadel.enginekt.transform
+
+import graphql.nadel.Service
+import graphql.nadel.ServiceExecutionHydrationDetails
+import graphql.nadel.ServiceExecutionResult
+import graphql.nadel.enginekt.NadelExecutionContext
+import graphql.nadel.enginekt.blueprint.NadelOverallExecutionBlueprint
+import graphql.nadel.enginekt.transform.NadelRenameArgumentInputTypesTransform.State
+import graphql.nadel.enginekt.transform.query.NadelQueryTransformer
+import graphql.nadel.enginekt.transform.result.NadelResultInstruction
+import graphql.nadel.enginekt.transform.result.json.JsonNodes
+import graphql.nadel.enginekt.util.toBuilder
+import graphql.normalized.ExecutableNormalizedField
+import graphql.normalized.NormalizedInputValue
+
+/**
+ * This will rename a fields input arguments types.  This is especially important
+ * when we use _$variable_ printing syntax and the printed document needs
+ * to be in the underlying type names since the variable declarations
+ * end up referencing the type names
+ * ```
+ * query x($var : UnderlyingTypeName!) { ... }
+ * ```
+ */
+internal class NadelRenameArgumentInputTypesTransform : NadelTransform<State> {
+    data class State(
+        val newFieldArgs: Map<String, NormalizedInputValue>,
+    )
+
+    override suspend fun isApplicable(
+        executionContext: NadelExecutionContext,
+        executionBlueprint: NadelOverallExecutionBlueprint,
+        services: Map<String, Service>,
+        service: Service,
+        overallField: ExecutableNormalizedField,
+        hydrationDetails: ServiceExecutionHydrationDetails?,
+    ): State? {
+
+        var changeCount = 0
+        val newFieldArgs: Map<String, NormalizedInputValue> = overallField.normalizedArguments
+            .mapValues { (_, inputValue) ->
+                val newInputValue = renameInputValueType(inputValue, executionBlueprint, service)
+                if (newInputValue != inputValue) {
+                    changeCount++
+                }
+                newInputValue
+            }
+        return if (changeCount == 0) {
+            null
+        } else {
+            State(newFieldArgs)
+        }
+    }
+
+    override suspend fun transformField(
+        executionContext: NadelExecutionContext,
+        transformer: NadelQueryTransformer,
+        executionBlueprint: NadelOverallExecutionBlueprint,
+        service: Service,
+        field: ExecutableNormalizedField,
+        state: State,
+    ): NadelTransformFieldResult {
+        return NadelTransformFieldResult(
+            newField = field.toBuilder().normalizedArguments(state.newFieldArgs).build()
+        )
+    }
+
+    override suspend fun getResultInstructions(
+        executionContext: NadelExecutionContext,
+        executionBlueprint: NadelOverallExecutionBlueprint,
+        service: Service,
+        overallField: ExecutableNormalizedField,
+        underlyingParentField: ExecutableNormalizedField?,
+        result: ServiceExecutionResult,
+        state: State,
+        nodes: JsonNodes,
+    ): List<NadelResultInstruction> {
+        return emptyList()
+    }
+
+    private fun renameInputValueType(
+        inputValue: NormalizedInputValue,
+        executionBlueprint: NadelOverallExecutionBlueprint,
+        service: Service,
+    ): NormalizedInputValue {
+        val overallTypeName = inputValue.typeName
+        val underlyingTypeName = executionBlueprint.getUnderlyingTypeName(service, overallTypeName)
+        if (underlyingTypeName != overallTypeName) {
+            return NormalizedInputValue(underlyingTypeName, inputValue.value)
+        }
+        return inputValue
+    }
+}
+

--- a/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/transform/NadelRenameArgumentInputTypesTransform.kt
+++ b/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/transform/NadelRenameArgumentInputTypesTransform.kt
@@ -86,6 +86,13 @@ internal class NadelRenameArgumentInputTypesTransform : NadelTransform<State> {
         val overallTypeName = inputValue.typeName
         val underlyingTypeName = executionBlueprint.getUnderlyingTypeName(service, overallTypeName)
         if (underlyingTypeName != overallTypeName) {
+            //
+            // in theory one could navigate down the `value` and if it's an object / list
+            // we could rename the types inside it.  However, right now Nadel will never
+            // address these inner NormalizedInputValue named types and hence for performance / complexity
+            // reasons we don't do it.  Also, Nadel currently does not allow an input field to be renamed
+            // and hence we don't have to change inner map keys either.
+            //
             return NormalizedInputValue(underlyingTypeName, inputValue.value)
         }
         return inputValue

--- a/test/src/test/kotlin/graphql/nadel/tests/hooks/document-variables-handling.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/hooks/document-variables-handling.kt
@@ -43,8 +43,7 @@ class `primitive-json-arguments-variables` : EngineTestHook {
     override val wiringFactory = NeverWiringFactoryWithExtendedJsonScalar()
 }
 
-@UseHook
-class `inlined-all-arguments` : EngineTestHook {
+open class AllDocumentVariablesHintHook : EngineTestHook {
     override val wiringFactory = NeverWiringFactoryWithExtendedJsonScalar()
 
     override fun makeExecutionInput(
@@ -56,4 +55,12 @@ class `inlined-all-arguments` : EngineTestHook {
             }
         }
     }
+}
+
+@UseHook
+class `inlined-all-arguments` : AllDocumentVariablesHintHook() {
+}
+
+@UseHook
+class `inlined-all-arguments-with-mixed-literals-and-variables` : AllDocumentVariablesHintHook() {
 }

--- a/test/src/test/kotlin/graphql/nadel/tests/hooks/document-variables-handling.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/hooks/document-variables-handling.kt
@@ -68,3 +68,7 @@ class `inlined-all-arguments-with-mixed-literals-and-variables` : AllDocumentVar
 @UseHook
 class `inlined-all-arguments-with-renamed-field` : AllDocumentVariablesHintHook() {
 }
+
+@UseHook
+class `complex-identified-by-with-rename` : AllDocumentVariablesHintHook() {
+}

--- a/test/src/test/kotlin/graphql/nadel/tests/hooks/document-variables-handling.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/hooks/document-variables-handling.kt
@@ -64,3 +64,7 @@ class `inlined-all-arguments` : AllDocumentVariablesHintHook() {
 @UseHook
 class `inlined-all-arguments-with-mixed-literals-and-variables` : AllDocumentVariablesHintHook() {
 }
+
+@UseHook
+class `inlined-all-arguments-with-renamed-field` : AllDocumentVariablesHintHook() {
+}

--- a/test/src/test/resources/fixtures/document variable handling/inlined-all-arguments-with-mixed-literals-and-variables.yml
+++ b/test/src/test/resources/fixtures/document variable handling/inlined-all-arguments-with-mixed-literals-and-variables.yml
@@ -1,0 +1,71 @@
+name: inlined-all-arguments-with-mixed-literals-and-variables
+enabled: true
+overallSchema:
+  MyService: |
+    type Query {
+      hello(arg: InputArgType): String
+    }
+    
+    input InputArgType @renamed(from: "UnderlyingInputArgType") {
+      age : Int
+      inputWithJson : InputWithJson
+    }
+
+    input InputWithJson @renamed(from: "InputWithJsonUnderlying") {
+      names : [String!]!
+      payload: JSON 
+    }
+    
+    scalar JSON
+
+underlyingSchema:
+  MyService: |-
+    type Query {
+      hello(arg: UnderlyingInputArgType): String
+    }
+    
+    input UnderlyingInputArgType {
+      age : Int
+      inputWithJson : InputWithJsonUnderlying
+    }
+
+    input InputWithJsonUnderlying {
+      names : [String!]!
+      payload: JSON 
+    }
+    
+    scalar JSON
+query: |
+  query myQuery($varX : InputWithJson)  {
+    hello(arg: { age : 50, inputWithJson : $varX } )
+  }
+
+variables:
+  varX: { names: [ "Bobba","Fett" ], payload: { "name": "Bobert", age: "23" } }
+
+serviceCalls:
+  - serviceName: MyService
+    request:
+      query: |
+        query myQuery($v0: UnderlyingInputArgType) {
+          hello(arg: $v0)
+        }
+      variables:
+        v0: {age : 50, inputWithJson : { names: [ "Bobba","Fett" ], payload: { "name": "Bobert", age: "23" } } }
+      operationName: myQuery
+    # language=JSON
+    response: |-
+      {
+        "data": {
+          "hello": "world"
+        },
+        "extensions": {}
+      }
+# language=JSON
+response: |-
+  {
+    "data": {
+      "hello": "world"
+    },
+    "extensions": {}
+  }

--- a/test/src/test/resources/fixtures/document variable handling/inlined-all-arguments-with-renamed-field.yml
+++ b/test/src/test/resources/fixtures/document variable handling/inlined-all-arguments-with-renamed-field.yml
@@ -1,0 +1,87 @@
+name: inlined-all-arguments-with-renamed-field
+enabled: true
+overallSchema:
+  MyService: |
+    type Query {
+      hello(arg: InputArgType): Output @renamed(from: "helloUnderlying")
+    }
+    
+    input InputArgType @renamed(from: "UnderlyingInputArgType") {
+      age : Int
+      inputWithJson : InputWithJson
+    }
+
+    input InputWithJson @renamed(from: "InputWithJsonUnderlying") {
+      names : [String!]!
+      payload: JSON 
+    }
+    
+    type Output @renamed(from: "OutputUnderlying") {
+      value : String
+    }
+    
+    scalar JSON
+
+underlyingSchema:
+  MyService: |-
+    type Query {
+      helloUnderlying(arg: UnderlyingInputArgType): OutputUnderlying
+    }
+    
+    input UnderlyingInputArgType {
+      age : Int
+      inputWithJson : InputWithJsonUnderlying
+    }
+
+    input InputWithJsonUnderlying {
+      names : [String!]!
+      payload: JSON 
+    }
+    
+    type OutputUnderlying  {
+      value : String
+    }
+    
+    scalar JSON
+query: |
+  query myQuery($varX : InputWithJson)  {
+    hello(arg: { age : 50, inputWithJson : $varX } ) {
+      value
+    }
+  }
+
+variables:
+  varX: { names: [ "Bobba","Fett" ], payload: { "name": "Bobert", age: "23" } }
+
+serviceCalls:
+  - serviceName: MyService
+    request:
+      query: |
+        query myQuery($v0: UnderlyingInputArgType) {
+          rename__hello__helloUnderlying: helloUnderlying(arg: $v0) {
+            value
+          }
+        }
+      variables:
+        v0: {age : 50, inputWithJson : { names: [ "Bobba","Fett" ], payload: { "name": "Bobert", age: "23" } } }
+      operationName: myQuery
+    # language=JSON
+    response: |-
+      {
+        "data": {
+          "rename__hello__helloUnderlying": {
+            "value" : "world"
+          }
+        },
+        "extensions": {}
+      }
+# language=JSON
+response: |-
+  {
+    "data": {
+      "hello": {
+        "value" : "world"
+      }
+    },
+    "extensions": {}
+  }

--- a/test/src/test/resources/fixtures/document variable handling/inlined-all-arguments.yml
+++ b/test/src/test/resources/fixtures/document variable handling/inlined-all-arguments.yml
@@ -6,7 +6,7 @@ overallSchema:
       hello(arg: InputWithJson, arg1: JSON!): String
     }
     
-    input InputWithJson {
+    input InputWithJson @renamed(from: "InputWithJsonUnderlying") {
       names : [String!]!
       payload: JSON 
     }
@@ -15,10 +15,10 @@ overallSchema:
 underlyingSchema:
   MyService: |-
     type Query {
-      hello(arg: InputWithJson, arg1: JSON!): String
+      hello(arg: InputWithJsonUnderlying, arg1: JSON!): String
     }
     
-    input InputWithJson {
+    input InputWithJsonUnderlying {
       names : [String!]!
       payload: JSON 
     }
@@ -33,7 +33,7 @@ serviceCalls:
   - serviceName: MyService
     request:
       query: |
-        query myQuery($v0: InputWithJson, $v1: JSON!) {
+        query myQuery($v0: InputWithJsonUnderlying, $v1: JSON!) {
           hello(arg: $v0, arg1: $v1)
         }
       variables:

--- a/test/src/test/resources/fixtures/hydration/complex identified by/complex-identified-by-with-rename.yml
+++ b/test/src/test/resources/fixtures/hydration/complex identified by/complex-identified-by-with-rename.yml
@@ -1,0 +1,297 @@
+name: complex-identified-by-with-rename
+enabled: true
+overallSchema:
+  UserService: |
+    type Query {
+      users(id: [UserInput]): [User]
+    }
+    input UserInput @renamed(from : "UserInputUnderlying") {
+      userId: ID
+      site: String
+    }
+    type User {
+      id: ID
+      name: String
+    }
+  Issues: |
+    type Query {
+      issues: [Issue]
+    }
+    type Issue {
+      id: ID
+      author: User @hydrated(
+        service: "UserService"
+        field: "users"
+        arguments: [{name: "id" value: "$source.authorId"}]
+        inputIdentifiedBy: [
+          {sourceId: "authorId.userId" resultId: "id"}
+          {sourceId: "authorId.site" resultId: "siteId"}
+        ]
+        batchSize: 4
+      )
+    }
+underlyingSchema:
+  UserService: |
+    type Query {
+      users(id: [UserInputUnderlying]): [User]
+    }
+    
+    input UserInputUnderlying {
+      userId: ID
+      site: String
+    }
+
+    type User {
+      id: ID
+      siteId: ID
+      name: String
+    }
+  Issues: |
+    type Query {
+      issues: [Issue]
+    }
+    
+    type UserRef {
+      userId: ID
+      site: String
+    }
+    
+    type Issue {
+      authorId: UserRef
+      id: ID
+    }
+query: |
+  query {
+    issues {
+      id
+      author {
+        id
+        name
+      }
+    }
+  }
+variables: { }
+serviceCalls:
+  - serviceName: Issues
+    request:
+      query: |
+        query {
+          issues {
+            __typename__batch_hydration__author: __typename
+            batch_hydration__author__authorId: authorId {
+              userId
+            }
+            batch_hydration__author__authorId: authorId {
+              site
+            }
+            id
+          }
+        }
+      variables: { }
+    # language=JSON
+    response: |-
+      {
+        "data": {
+          "issues": [
+            {
+              "__typename__batch_hydration__author": "Issue",
+              "batch_hydration__author__authorId": {
+                "userId": "USER-1",
+                "site": "hello"
+              },
+              "id": "ISSUE-1"
+            },
+            {
+              "__typename__batch_hydration__author": "Issue",
+              "batch_hydration__author__authorId": {
+                "userId": "USER-3",
+                "site": "hello"
+              },
+              "id": "ISSUE-2"
+            },
+            {
+              "__typename__batch_hydration__author": "Issue",
+              "batch_hydration__author__authorId": {
+                "userId": "USER-2",
+                "site": "jdog"
+              },
+              "id": "ISSUE-3"
+            },
+            {
+              "__typename__batch_hydration__author": "Issue",
+              "batch_hydration__author__authorId": {
+                "userId": "USER-4",
+                "site": "hello"
+              },
+              "id": "ISSUE-4"
+            },
+            {
+              "__typename__batch_hydration__author": "Issue",
+              "batch_hydration__author__authorId": {
+                "userId": "USER-5",
+                "site": "hello"
+              },
+              "id": "ISSUE-5"
+            },
+            {
+              "__typename__batch_hydration__author": "Issue",
+              "batch_hydration__author__authorId": {
+                "userId": "USER-2",
+                "site": "jdog"
+              },
+              "id": "ISSUE-6"
+            },
+            {
+              "__typename__batch_hydration__author": "Issue",
+              "batch_hydration__author__authorId": {
+                "userId": "USER-2",
+                "site": "hello"
+              },
+              "id": "ISSUE-7"
+            }
+          ]
+        },
+        "extensions": {}
+      }
+  - serviceName: UserService
+    request:
+      query: |
+        query ($v0: [UserInputUnderlying]) {
+            users(id: $v0) {
+              id
+              name
+              batch_hydration__author__id: id
+              batch_hydration__author__siteId: siteId
+          }
+        }
+      variables: { v0 : [{site : "hello", userId : "USER-5"}, {site : "jdog", userId : "USER-2"}, {site : "hello", userId : "USER-2"}] }
+    # language=JSON
+    response: |-
+      {
+        "data": {
+          "users": [
+            {
+              "id": "USER-5",
+              "name": "H-Five",
+              "batch_hydration__author__id": "USER-5",
+              "batch_hydration__author__siteId": "hello"
+            },
+            {
+              "id": "USER-2",
+              "name": "J-Two",
+              "batch_hydration__author__id": "USER-2",
+              "batch_hydration__author__siteId": "jdog"
+            },
+            {
+              "id": "USER-2",
+              "name": "H-Two",
+              "batch_hydration__author__id": "USER-2",
+              "batch_hydration__author__siteId": "hello"
+            }
+          ]
+        },
+        "extensions": {}
+      }
+  - serviceName: UserService
+    request:
+      query: |
+        query ($v0: [UserInputUnderlying]) {
+            users(id: $v0) {
+              id
+              name
+              batch_hydration__author__id: id
+              batch_hydration__author__siteId: siteId
+          }
+        }
+      variables: { v0 : [{site : "hello", userId : "USER-1"}, {site : "hello", userId : "USER-3"}, {site : "jdog", userId : "USER-2"}, {site : "hello", userId : "USER-4"}]}
+    # language=JSON
+    response: |-
+      {
+        "data": {
+          "users": [
+            {
+              "id": "USER-1",
+              "name": "H-One",
+              "batch_hydration__author__id": "USER-1",
+              "batch_hydration__author__siteId": "hello"
+            },
+            {
+              "id": "USER-3",
+              "name": "H-Three",
+              "batch_hydration__author__id": "USER-3",
+              "batch_hydration__author__siteId": "hello"
+            },
+            {
+              "id": "USER-2",
+              "name": "J-Two",
+              "batch_hydration__author__id": "USER-2",
+              "batch_hydration__author__siteId": "jdog"
+            },
+            {
+              "id": "USER-4",
+              "name": "H-Four",
+              "batch_hydration__author__id": "USER-4",
+              "batch_hydration__author__siteId": "hello"
+            }
+          ]
+        },
+        "extensions": {}
+      }
+# language=JSON
+response: |-
+  {
+    "data": {
+      "issues": [
+        {
+          "id": "ISSUE-1",
+          "author": {
+            "id": "USER-1",
+            "name": "H-One"
+          }
+        },
+        {
+          "id": "ISSUE-2",
+          "author": {
+            "id": "USER-3",
+            "name": "H-Three"
+          }
+        },
+        {
+          "id": "ISSUE-3",
+          "author": {
+            "id": "USER-2",
+            "name": "J-Two"
+          }
+        },
+        {
+          "id": "ISSUE-4",
+          "author": {
+            "id": "USER-4",
+            "name": "H-Four"
+          }
+        },
+        {
+          "id": "ISSUE-5",
+          "author": {
+            "id": "USER-5",
+            "name": "H-Five"
+          }
+        },
+        {
+          "id": "ISSUE-6",
+          "author": {
+            "id": "USER-2",
+            "name": "J-Two"
+          }
+        },
+        {
+          "id": "ISSUE-7",
+          "author": {
+            "id": "USER-2",
+            "name": "H-Two"
+          }
+        }
+      ]
+    },
+    "extensions": {}
+  }


### PR DESCRIPTION

This allows for input types to be renamed when printed back out to call the underlying service

Please make sure you consider the following:

- [x ] Add tests that use __typename in queries
- [ /] Does this change work with all nadel transformations (rename, type rename, hydration, etc)? Add tests for this.
- [ /] Is it worth using hints for this change in order to be able to enable a percentage rollout?
- [ x] Do we need to add integration tests for this change in the graphql gateway?
- [x ] Do we need a pollinator check for this?
