### PR TITLE
input rename when arg type is a list

### DIFF
--- a/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/transform/NadelRenameArgumentInputTypesTransform.kt
+++ b/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/transform/NadelRenameArgumentInputTypesTransform.kt
@@ -83,7 +83,7 @@ internal class NadelRenameArgumentInputTypesTransform : NadelTransform<State> {
         executionBlueprint: NadelOverallExecutionBlueprint,
         service: Service,
     ): NormalizedInputValue {
-        val overallTypeName = inputValue.typeName
+        val overallTypeName = inputValue.unwrappedTypeName
         val underlyingTypeName = executionBlueprint.getUnderlyingTypeName(service, overallTypeName)
         if (underlyingTypeName != overallTypeName) {
             //
@@ -93,7 +93,10 @@ internal class NadelRenameArgumentInputTypesTransform : NadelTransform<State> {
             // reasons we don't do it.  Also, Nadel currently does not allow an input field to be renamed
             // and hence we don't have to change inner map keys either.
             //
-            return NormalizedInputValue(underlyingTypeName, inputValue.value)
+            val overallWrappedTypename = inputValue.typeName
+            val newUnderlyingTypeNameWithOriginalWrapping =
+                overallWrappedTypename.replace(overallTypeName, underlyingTypeName)
+            return NormalizedInputValue(newUnderlyingTypeNameWithOriginalWrapping, inputValue.value)
         }
         return inputValue
     }

--- a/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/transform/NadelRenameArgumentInputTypesTransform.kt
+++ b/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/transform/NadelRenameArgumentInputTypesTransform.kt
@@ -9,6 +9,7 @@ import graphql.nadel.enginekt.transform.NadelRenameArgumentInputTypesTransform.S
 import graphql.nadel.enginekt.transform.query.NadelQueryTransformer
 import graphql.nadel.enginekt.transform.result.NadelResultInstruction
 import graphql.nadel.enginekt.transform.result.json.JsonNodes
+import graphql.nadel.enginekt.util.replaceTypeName
 import graphql.nadel.enginekt.util.toBuilder
 import graphql.normalized.ExecutableNormalizedField
 import graphql.normalized.NormalizedInputValue
@@ -93,10 +94,7 @@ internal class NadelRenameArgumentInputTypesTransform : NadelTransform<State> {
             // reasons we don't do it.  Also, Nadel currently does not allow an input field to be renamed
             // and hence we don't have to change inner map keys either.
             //
-            val overallWrappedTypename = inputValue.typeName
-            val newUnderlyingTypeNameWithOriginalWrapping =
-                overallWrappedTypename.replace(overallTypeName, underlyingTypeName)
-            return NormalizedInputValue(newUnderlyingTypeNameWithOriginalWrapping, inputValue.value)
+            return inputValue.replaceTypeName(underlyingTypeName)
         }
         return inputValue
     }

--- a/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/util/GraphQLUtil.kt
+++ b/engine-nextgen/src/main/kotlin/graphql/nadel/enginekt/util/GraphQLUtil.kt
@@ -428,6 +428,17 @@ fun makeNormalizedInputValue(
     )
 }
 
+/**
+ * Will return a new NormalizedInputValue with a new typename. The type will be renamed but the
+ * original wrapping will be intact.
+ *
+ * todo: find a better way of doing this? currently it's just a string.replace hack
+ */
+fun NormalizedInputValue.replaceTypeName(newTypeName: String): NormalizedInputValue {
+    val newTypenameWithOriginalWrapping = this.typeName.replace(this.unwrappedTypeName, newTypeName)
+    return NormalizedInputValue(newTypenameWithOriginalWrapping, this.value)
+}
+
 internal fun javaValueToAstValue(value: Any?): AnyAstValue {
     return when (value) {
         is AnyList -> ArrayValue(

--- a/test/src/test/kotlin/graphql/nadel/tests/hooks/document-variables-handling.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/hooks/document-variables-handling.kt
@@ -67,6 +67,10 @@ class `inlined-all-arguments-with-mixed-literals-and-variables` : AllDocumentVar
 
 @UseHook
 class `inlined-all-arguments-with-renamed-field` : AllDocumentVariablesHintHook() {
+
+}
+@UseHook
+class `inlined-all-arguments-with-renamed-field-input-is-wrapped-in-a-list` : AllDocumentVariablesHintHook() {
 }
 
 @UseHook

--- a/test/src/test/resources/fixtures/document variable handling/inlined-all-arguments-with-renamed-field-input-is-wrapped-in-a-list.yml
+++ b/test/src/test/resources/fixtures/document variable handling/inlined-all-arguments-with-renamed-field-input-is-wrapped-in-a-list.yml
@@ -1,0 +1,87 @@
+name: inlined-all-arguments-with-renamed-field-input-is-wrapped-in-a-list
+enabled: true
+overallSchema:
+  MyService: |
+    type Query {
+      hello(arg: [InputArgType]): Output @renamed(from: "helloUnderlying")
+    }
+    
+    input InputArgType @renamed(from: "UnderlyingInputArgType") {
+      age : Int
+      inputWithJson : [InputWithJson]
+    }
+
+    input InputWithJson @renamed(from: "InputWithJsonUnderlying") {
+      names : [String!]!
+      payload: JSON 
+    }
+    
+    type Output @renamed(from: "OutputUnderlying") {
+      value : String
+    }
+    
+    scalar JSON
+
+underlyingSchema:
+  MyService: |-
+    type Query {
+      helloUnderlying(arg: [UnderlyingInputArgType]): OutputUnderlying
+    }
+    
+    input UnderlyingInputArgType {
+      age : Int
+      inputWithJson : [InputWithJsonUnderlying]
+    }
+
+    input InputWithJsonUnderlying {
+      names : [String!]!
+      payload: JSON 
+    }
+    
+    type OutputUnderlying  {
+      value : String
+    }
+    
+    scalar JSON
+query: |
+  query myQuery($varX : [InputWithJson])  {
+    hello(arg: [{ age : 50, inputWithJson : $varX }] ) {
+      value
+    }
+  }
+
+variables:
+  varX: [ { names: [ "Bobba","Fett" ], payload: { "name": "Bobert", age: "23" } } ]
+
+serviceCalls:
+  - serviceName: MyService
+    request:
+      query: |
+        query myQuery($v0: [UnderlyingInputArgType]) {
+          rename__hello__helloUnderlying: helloUnderlying(arg: $v0) {
+            value
+          }
+        }
+      variables:
+        v0: [ { age: 50, inputWithJson: [ { names: [ "Bobba","Fett" ], payload: { "name": "Bobert", age: "23" } } ] } ]
+      operationName: myQuery
+    # language=JSON
+    response: |-
+      {
+        "data": {
+          "rename__hello__helloUnderlying": {
+            "value" : "world"
+          }
+        },
+        "extensions": {}
+      }
+# language=JSON
+response: |-
+  {
+    "data": {
+      "hello": {
+        "value" : "world"
+      }
+    },
+    "extensions": {}
+  }


### PR DESCRIPTION
Follow up on the recent PR with input rename. There appears to be a bug when argument type is wrapped (list or non-null)


Please make sure you consider the following:

- [ ] Add tests that use __typename in queries
- [ ] Does this change work with all nadel transformations (rename, type rename, hydration, etc)? Add tests for this.
- [ ] Is it worth using hints for this change in order to be able to enable a percentage rollout?
- [ ] Do we need to add integration tests for this change in the graphql gateway?
- [ ] Do we need a pollinator check for this?
