### PR TITLE
Refactor blueprint to be per service

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -36,6 +36,7 @@
     </codeStyleSettings>
     <codeStyleSettings language="kotlin">
       <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
+      <option name="RIGHT_MARGIN" value="140" />
       <option name="LINE_COMMENT_AT_FIRST_COLUMN" value="false" />
       <option name="LINE_COMMENT_ADD_SPACE" value="true" />
       <option name="KEEP_BLANK_LINES_IN_DECLARATIONS" value="1" />

--- a/lib/src/main/java/graphql/nadel/Nadel.kt
+++ b/lib/src/main/java/graphql/nadel/Nadel.kt
@@ -359,8 +359,13 @@ class Nadel private constructor(
                     underlyingTypeDefinitions,
                     underlyingWiringFactory,
                 )
-                val nadelDefinitionRegistry: NadelDefinitionRegistry = NadelDefinitionRegistry.from(serviceSchema)
-                Service(serviceName, underlyingSchema, serviceExecution, nadelDefinitionRegistry)
+                val nadelDefinitionRegistry = NadelDefinitionRegistry.from(serviceSchema)
+                Service(
+                    name = serviceName,
+                    underlyingSchema = underlyingSchema,
+                    serviceExecution = serviceExecution,
+                    definitionRegistry = nadelDefinitionRegistry
+                )
             }
         }
 

--- a/lib/src/main/java/graphql/nadel/NadelDefinitionRegistry.kt
+++ b/lib/src/main/java/graphql/nadel/NadelDefinitionRegistry.kt
@@ -9,6 +9,13 @@ import graphql.nadel.util.AnySDLDefinition
 import java.util.Collections
 
 /**
+ * This stores a service's definitions to the _overall_ schema. However, this is
+ * NOT a comprehensive list of the types a service owns. It is missing things
+ * like shared types that were already defined by another service etc.
+ *
+ * We should look into phasing this out of the [Service] definition and replacing
+ * it with the blueprint code if necessary.
+ *
  * Alternative to [graphql.schema.idl.TypeDefinitionRegistry] but is more generic
  * and tailored to Nadel specific operations to build the overall schema.
  */

--- a/lib/src/main/java/graphql/nadel/Service.kt
+++ b/lib/src/main/java/graphql/nadel/Service.kt
@@ -1,20 +1,41 @@
 package graphql.nadel
 
+import graphql.nadel.engine.blueprint.NadelServiceBlueprint
 import graphql.schema.GraphQLSchema
 
-open class Service(
+class Service(
     val name: String,
     /**
      * These are the types as they are defined in the underlying service's schema.
      *
-     *
      * There are no renames, hydrations etc.
+     *
+     * You should avoid using this unless you are doing validations etc.
      */
     val underlyingSchema: GraphQLSchema,
-    // this is not enough in the future as we need to allow for dynamic delegationExecution
+    /**
+     * Callback provided to Nadel that performs the GraphQL call to this service.
+     */
     val serviceExecution: ServiceExecution,
     /**
      * These are the GraphQL definitions that a service contributes to the OVERALL schema.
      */
     val definitionRegistry: NadelDefinitionRegistry,
-)
+) {
+    /**
+     * For now, this is the actual overall schema. But in the future this will be a subset
+     * of the overall schema that this [Service] contributed.
+     */
+    lateinit var schema: GraphQLSchema
+        internal set
+
+    /**
+     * The blueprint associated with this [Service].
+     */
+    lateinit var blueprint: NadelServiceBlueprint
+        internal set
+
+    override fun toString(): String {
+        return "Service(name='$name')"
+    }
+}

--- a/lib/src/main/java/graphql/nadel/ServiceExecutionResult.kt
+++ b/lib/src/main/java/graphql/nadel/ServiceExecutionResult.kt
@@ -1,7 +1,20 @@
 package graphql.nadel
 
-class ServiceExecutionResult @JvmOverloads constructor(
+import graphql.ExecutionResult
+import graphql.ExecutionResultImpl
+import graphql.nadel.engine.util.extensions
+import graphql.nadel.util.ErrorUtil
+
+data class ServiceExecutionResult @JvmOverloads constructor(
     val data: MutableMap<String, Any?> = LinkedHashMap(),
     val errors: MutableList<MutableMap<String, Any?>> = ArrayList(),
     val extensions: MutableMap<String, Any?> = LinkedHashMap(),
-)
+) {
+    fun toExecutionResult(): ExecutionResult {
+        return ExecutionResultImpl.newExecutionResult()
+            .data(data)
+            .errors(ErrorUtil.createGraphQLErrorsFromRawErrors(errors))
+            .extensions(extensions)
+            .build()
+    }
+}

--- a/lib/src/main/java/graphql/nadel/engine/NadelEngineExecutionHooks.kt
+++ b/lib/src/main/java/graphql/nadel/engine/NadelEngineExecutionHooks.kt
@@ -6,6 +6,7 @@ import graphql.nadel.engine.transform.artificial.NadelAliasHelper
 import graphql.nadel.engine.transform.result.json.JsonNode
 import graphql.nadel.hooks.ServiceExecutionHooks
 
+// todo merge this with ServiceExecutionHooks
 interface NadelEngineExecutionHooks : ServiceExecutionHooks {
     fun <T : NadelGenericHydrationInstruction> getHydrationInstruction(
         instructions: List<T>,

--- a/lib/src/main/java/graphql/nadel/engine/blueprint/NadelExecutionBlueprint.kt
+++ b/lib/src/main/java/graphql/nadel/engine/blueprint/NadelExecutionBlueprint.kt
@@ -8,87 +8,22 @@ import graphql.nadel.engine.util.mapFrom
 import graphql.nadel.engine.util.strictAssociateBy
 import graphql.normalized.ExecutableNormalizedField
 import graphql.schema.FieldCoordinates
-import graphql.schema.GraphQLSchema
 
 /**
- * Execution blueprint where keys are in terms of the overall schema.
+ * Execution blueprints store prerequisite information for executing a service.
+ * This includes information like renames or hydrations etc. on specific fields.
+ * It includes further information like what types a service defines and its underlying
+ * schema.
+ *
+ * Defined as an interface to easily create a no-op placeholder.
  */
-data class NadelOverallExecutionBlueprint(
-    val engineSchema: GraphQLSchema,
-    val fieldInstructions: Map<FieldCoordinates, List<NadelFieldInstruction>>,
-    private val underlyingTypeNamesByService: Map<Service, Set<String>>,
-    private val overallTypeNamesByService: Map<Service, Set<String>>,
-    private val underlyingBlueprints: Map<String, NadelUnderlyingExecutionBlueprint>,
-    private val coordinatesToService: Map<FieldCoordinates, Service>,
-) {
-
-    private fun setOfServiceTypes(
-        map: Map<Service, Set<String>>,
-        service: Service
-    ): Set<String> {
-        return (map[service] ?: error("Could not find service: ${service.name}"))
-    }
-
-    fun getUnderlyingTypeNamesForService(service: Service): Set<String> {
-        return setOfServiceTypes(underlyingTypeNamesByService, service)
-    }
-
-    fun getOverAllTypeNamesForService(service: Service): Set<String> {
-        return setOfServiceTypes(overallTypeNamesByService, service)
-    }
-
-    fun getUnderlyingTypeName(
-        service: Service,
-        overallTypeName: String,
-    ): String {
-        // TODO: THIS SHOULD NOT BE HAPPENING, INTROSPECTIONS ARE DUMB AND DON'T NEED TRANSFORMING
-        if (service.name == IntrospectionService.name) {
-            return overallTypeName
-        }
-        return getUnderlyingBlueprint(service).typeInstructions.getUnderlyingName(overallTypeName)
-    }
-
-    fun getOverallTypeName(
-        service: Service,
-        underlyingTypeName: String,
-    ): String {
-        // TODO: THIS SHOULD NOT BE HAPPENING, INTROSPECTIONS ARE DUMB AND DON'T NEED TRANSFORMING
-        if (service.name == IntrospectionService.name) {
-            return underlyingTypeName
-        }
-        return getUnderlyingBlueprint(service).typeInstructions.getOverallName(underlyingTypeName)
-    }
-
-    fun getServiceOwning(fieldCoordinates: FieldCoordinates): Service? {
-        return coordinatesToService[fieldCoordinates]
-    }
-
-    private fun getUnderlyingBlueprint(service: Service): NadelUnderlyingExecutionBlueprint {
-        val name = service.name
-        return underlyingBlueprints[name] ?: error("Could not find service: $name")
-    }
-}
-
-data class NadelUnderlyingExecutionBlueprint internal constructor(
+data class NadelServiceBlueprint internal constructor(
     val service: Service,
-    val schema: GraphQLSchema,
-    val typeInstructions: NadelTypeRenameInstructions,
-) {
-    companion object {
-        // Hack for secondary constructor for data classes
-        operator fun invoke(
-            service: Service,
-            schema: GraphQLSchema,
-            typeInstructions: List<NadelTypeRenameInstruction>,
-        ): NadelUnderlyingExecutionBlueprint {
-            return NadelUnderlyingExecutionBlueprint(
-                service = service,
-                schema = schema,
-                typeInstructions = NadelTypeRenameInstructions(typeInstructions),
-            )
-        }
-    }
-}
+    val fieldInstructions: Map<FieldCoordinates, List<NadelFieldInstruction>>,
+    val typeRenames: NadelTypeRenameInstructions,
+    val overallTypesDefined: Set<String>,
+    val underlyingTypesDefined: Set<String>,
+)
 
 data class NadelTypeRenameInstructions internal constructor(
     private val byUnderlyingName: Map<String, NadelTypeRenameInstruction>,
@@ -108,7 +43,10 @@ data class NadelTypeRenameInstructions internal constructor(
             typeInstructions: List<NadelTypeRenameInstruction>,
         ): NadelTypeRenameInstructions {
             return NadelTypeRenameInstructions(
-                byUnderlyingName = typeInstructions.strictAssociateBy { it.underlyingName },
+                // todo: one day this should be turned back into strictAssociateBy
+                // The issue is that we have a grandfathered JSW schema that abuses this, but thankfully only for input types
+                // This is also enforced by validation these days, so we shouldn't actually get dupes
+                byUnderlyingName = typeInstructions.associateBy { it.underlyingName },
                 byOverallName = typeInstructions.strictAssociateBy { it.overallName },
             )
         }

--- a/lib/src/main/java/graphql/nadel/engine/blueprint/NadelTypeRenameInstruction.kt
+++ b/lib/src/main/java/graphql/nadel/engine/blueprint/NadelTypeRenameInstruction.kt
@@ -1,9 +1,6 @@
 package graphql.nadel.engine.blueprint
 
-import graphql.nadel.Service
-
 data class NadelTypeRenameInstruction(
-    val service: Service,
     val overallName: String,
     val underlyingName: String,
 )

--- a/lib/src/main/java/graphql/nadel/engine/introspection/IntrospectionService.kt
+++ b/lib/src/main/java/graphql/nadel/engine/introspection/IntrospectionService.kt
@@ -1,4 +1,4 @@
-package graphql.nadel.engine.blueprint
+package graphql.nadel.engine.introspection
 
 import graphql.ExecutionInput
 import graphql.GraphQL
@@ -12,12 +12,18 @@ import graphql.nadel.ServiceExecutionResult
 import graphql.schema.GraphQLSchema
 import java.util.concurrent.CompletableFuture
 
-internal class IntrospectionService constructor(
-    schema: GraphQLSchema,
-    introspectionRunnerFactory: NadelIntrospectionRunnerFactory,
-) : Service(name, schema, introspectionRunnerFactory.make(schema), NadelDefinitionRegistry()) {
-    companion object {
-        const val name = "__introspection"
+internal object IntrospectionService {
+    const val name = "__introspection"
+}
+
+internal object IntrospectionServiceFactory {
+    fun make(schema: GraphQLSchema, runnerFactory: NadelIntrospectionRunnerFactory): Service {
+        return Service(
+            name = IntrospectionService.name,
+            underlyingSchema = schema,
+            serviceExecution = runnerFactory.make(schema),
+            definitionRegistry = NadelDefinitionRegistry(),
+        )
     }
 }
 

--- a/lib/src/main/java/graphql/nadel/engine/plan/NadelExecutionPlanFactory.kt
+++ b/lib/src/main/java/graphql/nadel/engine/plan/NadelExecutionPlanFactory.kt
@@ -4,7 +4,6 @@ import graphql.nadel.NextgenEngine
 import graphql.nadel.Service
 import graphql.nadel.ServiceExecutionHydrationDetails
 import graphql.nadel.engine.NadelExecutionContext
-import graphql.nadel.engine.blueprint.NadelOverallExecutionBlueprint
 import graphql.nadel.engine.transform.NadelDeepRenameTransform
 import graphql.nadel.engine.transform.NadelRenameArgumentInputTypesTransform
 import graphql.nadel.engine.transform.NadelRenameTransform
@@ -17,7 +16,7 @@ import graphql.nadel.engine.transform.skipInclude.SkipIncludeTransform
 import graphql.normalized.ExecutableNormalizedField
 
 internal class NadelExecutionPlanFactory(
-    private val executionBlueprint: NadelOverallExecutionBlueprint,
+    private val services: Map<String, Service>,
     private val transforms: List<NadelTransform<Any>>,
 ) {
     /**
@@ -26,7 +25,6 @@ internal class NadelExecutionPlanFactory(
      */
     suspend fun create(
         executionContext: NadelExecutionContext,
-        services: Map<String, Service>,
         service: Service,
         rootField: ExecutableNormalizedField,
         serviceHydrationDetails: ServiceExecutionHydrationDetails? = null,
@@ -37,7 +35,6 @@ internal class NadelExecutionPlanFactory(
             transforms.forEach { transform ->
                 val state = transform.isApplicable(
                     executionContext,
-                    executionBlueprint,
                     services,
                     service,
                     field,
@@ -73,12 +70,12 @@ internal class NadelExecutionPlanFactory(
 
     companion object {
         fun create(
-            executionBlueprint: NadelOverallExecutionBlueprint,
+            services: Map<String, Service>,
             transforms: List<NadelTransform<out Any>>,
             engine: NextgenEngine,
         ): NadelExecutionPlanFactory {
             return NadelExecutionPlanFactory(
-                executionBlueprint,
+                services,
                 transforms = listOfTransforms(
                     SkipIncludeTransform(),
                     NadelServiceTypeFilterTransform(),

--- a/lib/src/main/java/graphql/nadel/engine/transform/NadelTransform.kt
+++ b/lib/src/main/java/graphql/nadel/engine/transform/NadelTransform.kt
@@ -5,7 +5,7 @@ import graphql.nadel.Service
 import graphql.nadel.ServiceExecutionHydrationDetails
 import graphql.nadel.ServiceExecutionResult
 import graphql.nadel.engine.NadelExecutionContext
-import graphql.nadel.engine.blueprint.NadelOverallExecutionBlueprint
+import graphql.nadel.engine.blueprint.NadelServiceBlueprint
 import graphql.nadel.engine.transform.query.NadelQueryTransformer
 import graphql.nadel.engine.transform.result.NadelResultInstruction
 import graphql.nadel.engine.transform.result.json.JsonNodes
@@ -18,14 +18,13 @@ interface NadelTransform<State : Any> {
      * The returned [State] is then fed into [transformField] and [getResultInstructions].
      *
      * So here you will want to check whether the [overallField] has a specific [Directive] or
-     * if the field has an instruction inside [NadelOverallExecutionBlueprint] etc.
+     * if the field has an instruction inside [NadelServiceBlueprint] etc.
      *
      * The state should hold data that is shared between [transformField] and [getResultInstructions]
      * e.g. the names of fields that will be added etc. The implementation of [State] is completely up
      * to you. You can make it mutable if that makes your life easier etc.
      *
-     * @param executionBlueprint the [NadelOverallExecutionBlueprint] of the Nadel instance being operated on
-     * @param service the [Service] the [overallField] belongs to
+     * @param service the [Service] the [overallField] is being executed on
      * @param overallField the [ExecutableNormalizedField] in question, we are asking whether it [isApplicable] for transforms
      * @param hydrationDetails the [ServiceExecutionHydrationDetails] when the [NadelTransform] is applied to fields inside
      * hydrations, `null` otherwise
@@ -34,7 +33,6 @@ interface NadelTransform<State : Any> {
      */
     suspend fun isApplicable(
         executionContext: NadelExecutionContext,
-        executionBlueprint: NadelOverallExecutionBlueprint,
         services: Map<String, Service>,
         service: Service,
         overallField: ExecutableNormalizedField,
@@ -51,7 +49,6 @@ interface NadelTransform<State : Any> {
     suspend fun transformField(
         executionContext: NadelExecutionContext,
         transformer: NadelQueryTransformer,
-        executionBlueprint: NadelOverallExecutionBlueprint,
         service: Service,
         field: ExecutableNormalizedField,
         state: State,
@@ -65,7 +62,6 @@ interface NadelTransform<State : Any> {
      */
     suspend fun getResultInstructions(
         executionContext: NadelExecutionContext,
-        executionBlueprint: NadelOverallExecutionBlueprint,
         service: Service,
         overallField: ExecutableNormalizedField,
         underlyingParentField: ExecutableNormalizedField?,

--- a/lib/src/main/java/graphql/nadel/engine/transform/NadelTransformJavaCompat.kt
+++ b/lib/src/main/java/graphql/nadel/engine/transform/NadelTransformJavaCompat.kt
@@ -4,7 +4,6 @@ import graphql.nadel.Service
 import graphql.nadel.ServiceExecutionHydrationDetails
 import graphql.nadel.ServiceExecutionResult
 import graphql.nadel.engine.NadelExecutionContext
-import graphql.nadel.engine.blueprint.NadelOverallExecutionBlueprint
 import graphql.nadel.engine.transform.query.NadelQueryTransformer
 import graphql.nadel.engine.transform.query.NadelQueryTransformerJavaCompat
 import graphql.nadel.engine.transform.result.NadelResultInstruction
@@ -23,7 +22,6 @@ interface NadelTransformJavaCompat<State : Any> {
      */
     fun isApplicable(
         executionContext: NadelExecutionContext,
-        executionBlueprint: NadelOverallExecutionBlueprint,
         services: Map<String, Service>,
         service: Service,
         overallField: ExecutableNormalizedField,
@@ -36,7 +34,6 @@ interface NadelTransformJavaCompat<State : Any> {
     fun transformField(
         executionContext: NadelExecutionContext,
         transformer: NadelQueryTransformerJavaCompat,
-        executionBlueprint: NadelOverallExecutionBlueprint,
         service: Service,
         field: ExecutableNormalizedField,
         state: State,
@@ -47,7 +44,6 @@ interface NadelTransformJavaCompat<State : Any> {
      */
     fun getResultInstructions(
         executionContext: NadelExecutionContext,
-        executionBlueprint: NadelOverallExecutionBlueprint,
         service: Service,
         overallField: ExecutableNormalizedField,
         underlyingParentField: ExecutableNormalizedField?,
@@ -61,7 +57,6 @@ interface NadelTransformJavaCompat<State : Any> {
             return object : NadelTransform<State> {
                 override suspend fun isApplicable(
                     executionContext: NadelExecutionContext,
-                    executionBlueprint: NadelOverallExecutionBlueprint,
                     services: Map<String, Service>,
                     service: Service,
                     overallField: ExecutableNormalizedField,
@@ -69,7 +64,6 @@ interface NadelTransformJavaCompat<State : Any> {
                 ): State? {
                     return compat.isApplicable(
                         executionContext = executionContext,
-                        executionBlueprint = executionBlueprint,
                         services = services,
                         service = service,
                         overallField = overallField,
@@ -80,7 +74,6 @@ interface NadelTransformJavaCompat<State : Any> {
                 override suspend fun transformField(
                     executionContext: NadelExecutionContext,
                     transformer: NadelQueryTransformer,
-                    executionBlueprint: NadelOverallExecutionBlueprint,
                     service: Service,
                     field: ExecutableNormalizedField,
                     state: State,
@@ -91,8 +84,7 @@ interface NadelTransformJavaCompat<State : Any> {
                         compat.transformField(
                             executionContext = executionContext,
                             transformer = NadelQueryTransformerJavaCompat(transformer, scope),
-                            executionBlueprint = executionBlueprint,
-                            service = service,
+                                service = service,
                             field = field,
                             state = state,
                         ).asDeferred().await()
@@ -101,7 +93,6 @@ interface NadelTransformJavaCompat<State : Any> {
 
                 override suspend fun getResultInstructions(
                     executionContext: NadelExecutionContext,
-                    executionBlueprint: NadelOverallExecutionBlueprint,
                     service: Service,
                     overallField: ExecutableNormalizedField,
                     underlyingParentField: ExecutableNormalizedField?,
@@ -111,7 +102,6 @@ interface NadelTransformJavaCompat<State : Any> {
                 ): List<NadelResultInstruction> {
                     return compat.getResultInstructions(
                         executionContext = executionContext,
-                        executionBlueprint = executionBlueprint,
                         service = service,
                         overallField = overallField,
                         underlyingParentField = underlyingParentField,

--- a/lib/src/main/java/graphql/nadel/engine/transform/NadelTypeRenameResultTransform.kt
+++ b/lib/src/main/java/graphql/nadel/engine/transform/NadelTypeRenameResultTransform.kt
@@ -5,7 +5,6 @@ import graphql.nadel.Service
 import graphql.nadel.ServiceExecutionHydrationDetails
 import graphql.nadel.ServiceExecutionResult
 import graphql.nadel.engine.NadelExecutionContext
-import graphql.nadel.engine.blueprint.NadelOverallExecutionBlueprint
 import graphql.nadel.engine.transform.NadelTypeRenameResultTransform.State
 import graphql.nadel.engine.transform.query.NadelQueryPath
 import graphql.nadel.engine.transform.query.NadelQueryTransformer
@@ -21,7 +20,6 @@ internal class NadelTypeRenameResultTransform : NadelTransform<State> {
 
     override suspend fun isApplicable(
         executionContext: NadelExecutionContext,
-        executionBlueprint: NadelOverallExecutionBlueprint,
         services: Map<String, Service>,
         service: Service,
         overallField: ExecutableNormalizedField,
@@ -39,7 +37,6 @@ internal class NadelTypeRenameResultTransform : NadelTransform<State> {
     override suspend fun transformField(
         executionContext: NadelExecutionContext,
         transformer: NadelQueryTransformer,
-        executionBlueprint: NadelOverallExecutionBlueprint,
         service: Service,
         field: ExecutableNormalizedField,
         state: State,
@@ -49,7 +46,6 @@ internal class NadelTypeRenameResultTransform : NadelTransform<State> {
 
     override suspend fun getResultInstructions(
         executionContext: NadelExecutionContext,
-        executionBlueprint: NadelOverallExecutionBlueprint,
         service: Service,
         overallField: ExecutableNormalizedField,
         underlyingParentField: ExecutableNormalizedField?,
@@ -65,8 +61,7 @@ internal class NadelTypeRenameResultTransform : NadelTransform<State> {
         return typeNameNodes.mapNotNull { typeNameNode ->
             val underlyingTypeName = typeNameNode.value as String?
                 ?: return@mapNotNull null
-            val overallTypeName = executionBlueprint.getOverallTypeName(
-                service = service,
+            val overallTypeName = service.blueprint.typeRenames.getOverallName(
                 underlyingTypeName = underlyingTypeName,
             )
             NadelResultInstruction.Set(

--- a/lib/src/main/java/graphql/nadel/engine/transform/hydration/batch/NadelBatchHydrationByObjectId.kt
+++ b/lib/src/main/java/graphql/nadel/engine/transform/hydration/batch/NadelBatchHydrationByObjectId.kt
@@ -2,7 +2,6 @@ package graphql.nadel.engine.transform.hydration.batch
 
 import graphql.nadel.ServiceExecutionResult
 import graphql.nadel.engine.blueprint.NadelBatchHydrationFieldInstruction
-import graphql.nadel.engine.blueprint.NadelOverallExecutionBlueprint
 import graphql.nadel.engine.blueprint.hydration.NadelBatchHydrationMatchStrategy
 import graphql.nadel.engine.transform.NadelTransformUtil
 import graphql.nadel.engine.transform.hydration.NadelHydrationUtil.getHydrationActorNodes
@@ -21,7 +20,6 @@ import graphql.nadel.engine.util.unwrapNonNull
 
 internal object NadelBatchHydrationByObjectId {
     fun getHydrateInstructionsMatchingObjectIds(
-        executionBlueprint: NadelOverallExecutionBlueprint,
         state: NadelBatchHydrationTransform.State,
         instruction: NadelBatchHydrationFieldInstruction,
         parentNodes: List<JsonNode>,
@@ -29,7 +27,6 @@ internal object NadelBatchHydrationByObjectId {
         matchStrategy: NadelBatchHydrationMatchStrategy.MatchObjectIdentifiers,
     ): List<NadelResultInstruction> {
         return getHydrateInstructionsMatchingObjectIds(
-            executionBlueprint,
             state,
             instruction,
             parentNodes,
@@ -39,7 +36,6 @@ internal object NadelBatchHydrationByObjectId {
     }
 
     fun getHydrateInstructionsMatchingObjectId(
-        executionBlueprint: NadelOverallExecutionBlueprint,
         state: NadelBatchHydrationTransform.State,
         instruction: NadelBatchHydrationFieldInstruction,
         parentNodes: List<JsonNode>,
@@ -47,7 +43,6 @@ internal object NadelBatchHydrationByObjectId {
         matchStrategy: NadelBatchHydrationMatchStrategy.MatchObjectIdentifier,
     ): List<NadelResultInstruction> {
         return getHydrateInstructionsMatchingObjectIds(
-            executionBlueprint,
             state,
             instruction,
             parentNodes,
@@ -57,7 +52,6 @@ internal object NadelBatchHydrationByObjectId {
     }
 
     private fun getHydrateInstructionsMatchingObjectIds(
-        executionBlueprint: NadelOverallExecutionBlueprint,
         state: NadelBatchHydrationTransform.State,
         instruction: NadelBatchHydrationFieldInstruction,
         parentNodes: List<JsonNode>,
@@ -117,7 +111,6 @@ internal object NadelBatchHydrationByObjectId {
                 }
 
             getHydrateInstructionsForNodeMatchingObjectId(
-                executionBlueprint = executionBlueprint,
                 state = state,
                 sourceNode = sourceNode,
                 sourceIds = sourceIds,
@@ -127,7 +120,6 @@ internal object NadelBatchHydrationByObjectId {
     }
 
     private fun getHydrateInstructionsForNodeMatchingObjectId(
-        executionBlueprint: NadelOverallExecutionBlueprint,
         state: NadelBatchHydrationTransform.State,
         sourceNode: JsonNode,
         sourceIds: List<List<Any?>>,
@@ -137,7 +129,6 @@ internal object NadelBatchHydrationByObjectId {
             overallField = state.hydratedField,
             parentNode = sourceNode,
             service = state.hydratedFieldService,
-            executionBlueprint = executionBlueprint,
             aliasHelper = state.aliasHelper,
         ) ?: error("Unable to find field definition for ${state.hydratedField.queryPath}")
 

--- a/lib/src/main/java/graphql/nadel/engine/transform/query/DynamicServiceResolution.kt
+++ b/lib/src/main/java/graphql/nadel/engine/transform/query/DynamicServiceResolution.kt
@@ -14,7 +14,7 @@ import graphql.schema.GraphQLSchema
 internal class DynamicServiceResolution(
     private val engineSchema: GraphQLSchema,
     private val serviceExecutionHooks: ServiceExecutionHooks,
-    private val services: List<Service>,
+    private val services: Map<String, Service>,
 ) {
 
     /**
@@ -39,7 +39,7 @@ internal class DynamicServiceResolution(
      * Resolves the service for a field
      */
     fun resolveServiceForField(field: ExecutableNormalizedField): Service {
-        val serviceOrError = serviceExecutionHooks.resolveServiceForField(services, field)
+        val serviceOrError = serviceExecutionHooks.resolveServiceForField(services.values.toList(), field)
             ?: throw GraphqlErrorException.newErrorException()
                 .message("Could not resolve service for field '${field.name}'")
                 .path(field.queryPath.segments)

--- a/lib/src/main/java/graphql/nadel/engine/transform/query/NadelQueryTransformer.kt
+++ b/lib/src/main/java/graphql/nadel/engine/transform/query/NadelQueryTransformer.kt
@@ -2,7 +2,6 @@ package graphql.nadel.engine.transform.query
 
 import graphql.nadel.Service
 import graphql.nadel.engine.NadelExecutionContext
-import graphql.nadel.engine.blueprint.NadelOverallExecutionBlueprint
 import graphql.nadel.engine.plan.NadelExecutionPlan
 import graphql.nadel.engine.transform.NadelTransform
 import graphql.nadel.engine.transform.NadelTransformFieldResult
@@ -10,7 +9,6 @@ import graphql.nadel.engine.util.toBuilder
 import graphql.normalized.ExecutableNormalizedField
 
 class NadelQueryTransformer private constructor(
-    private val executionBlueprint: NadelOverallExecutionBlueprint,
     private val service: Service,
     private val executionContext: NadelExecutionContext,
     private val executionPlan: NadelExecutionPlan,
@@ -18,7 +16,6 @@ class NadelQueryTransformer private constructor(
 ) {
     companion object {
         suspend fun transformQuery(
-            executionBlueprint: NadelOverallExecutionBlueprint,
             service: Service,
             executionContext: NadelExecutionContext,
             executionPlan: NadelExecutionPlan,
@@ -27,7 +24,6 @@ class NadelQueryTransformer private constructor(
             val transformContext = TransformContext()
 
             val transformer = NadelQueryTransformer(
-                executionBlueprint,
                 service,
                 executionContext,
                 executionPlan,
@@ -149,7 +145,6 @@ class NadelQueryTransformer private constructor(
             val transformResultForStep = transform.transformField(
                 executionContext,
                 this,
-                executionBlueprint,
                 service,
                 fieldFromPreviousTransform,
                 state,
@@ -168,9 +163,7 @@ class NadelQueryTransformer private constructor(
     }
 
     private fun getUnderlyingTypeNames(objectTypeNames: Collection<String>): List<String> {
-        return objectTypeNames.map {
-            executionBlueprint.getUnderlyingTypeName(service, overallTypeName = it)
-        }
+        return objectTypeNames.map(service.blueprint.typeRenames::getUnderlyingName)
     }
 
     private fun fixParentRefs(

--- a/lib/src/main/java/graphql/nadel/engine/transform/result/NadelResultTransformer.kt
+++ b/lib/src/main/java/graphql/nadel/engine/transform/result/NadelResultTransformer.kt
@@ -3,7 +3,6 @@ package graphql.nadel.engine.transform.result
 import graphql.nadel.Service
 import graphql.nadel.ServiceExecutionResult
 import graphql.nadel.engine.NadelExecutionContext
-import graphql.nadel.engine.blueprint.NadelOverallExecutionBlueprint
 import graphql.nadel.engine.plan.NadelExecutionPlan
 import graphql.nadel.engine.transform.result.NadelResultTransformer.DataMutation
 import graphql.nadel.engine.transform.result.json.AnyJsonNodePathSegment
@@ -26,7 +25,7 @@ import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 import kotlin.reflect.KClass
 
-internal class NadelResultTransformer(private val executionBlueprint: NadelOverallExecutionBlueprint) {
+internal class NadelResultTransformer(private val services: Map<String, Service>) {
     suspend fun transform(
         executionContext: NadelExecutionContext,
         executionPlan: NadelExecutionPlan,
@@ -52,7 +51,6 @@ internal class NadelResultTransformer(private val executionBlueprint: NadelOvera
                         async {
                             step.transform.getResultInstructions(
                                 executionContext,
-                                executionBlueprint,
                                 service,
                                 field,
                                 underlyingFields.first().parent,

--- a/lib/src/main/java/graphql/nadel/engine/transform/skipInclude/SkipIncludeTransform.kt
+++ b/lib/src/main/java/graphql/nadel/engine/transform/skipInclude/SkipIncludeTransform.kt
@@ -7,7 +7,6 @@ import graphql.nadel.Service
 import graphql.nadel.ServiceExecutionHydrationDetails
 import graphql.nadel.ServiceExecutionResult
 import graphql.nadel.engine.NadelExecutionContext
-import graphql.nadel.engine.blueprint.NadelOverallExecutionBlueprint
 import graphql.nadel.engine.transform.NadelTransform
 import graphql.nadel.engine.transform.NadelTransformFieldResult
 import graphql.nadel.engine.transform.artificial.NadelAliasHelper
@@ -44,7 +43,6 @@ internal class SkipIncludeTransform : NadelTransform<State> {
 
     override suspend fun isApplicable(
         executionContext: NadelExecutionContext,
-        executionBlueprint: NadelOverallExecutionBlueprint,
         services: Map<String, Service>,
         service: Service,
         overallField: ExecutableNormalizedField,
@@ -55,7 +53,7 @@ internal class SkipIncludeTransform : NadelTransform<State> {
             val mergedField = executionContext.query.getMergedField(overallField)
             if (hasAnyChildren(mergedField)) {
                 // Adds a field so we can transform it
-                overallField.children.add(createSkipField(executionBlueprint.engineSchema, overallField))
+                overallField.children.add(createSkipField(service.schema, overallField))
             }
         }
 
@@ -74,7 +72,6 @@ internal class SkipIncludeTransform : NadelTransform<State> {
     override suspend fun transformField(
         executionContext: NadelExecutionContext,
         transformer: NadelQueryTransformer,
-        executionBlueprint: NadelOverallExecutionBlueprint,
         service: Service,
         field: ExecutableNormalizedField,
         state: State,
@@ -92,7 +89,6 @@ internal class SkipIncludeTransform : NadelTransform<State> {
 
     override suspend fun getResultInstructions(
         executionContext: NadelExecutionContext,
-        executionBlueprint: NadelOverallExecutionBlueprint,
         service: Service,
         overallField: ExecutableNormalizedField,
         underlyingParentField: ExecutableNormalizedField?,

--- a/lib/src/main/java/graphql/nadel/engine/util/GraphQLUtil.kt
+++ b/lib/src/main/java/graphql/nadel/engine/util/GraphQLUtil.kt
@@ -475,3 +475,8 @@ internal fun javaValueToAstValue(value: Any?): AnyAstValue {
 
 val GraphQLSchema.operationTypes
     get() = listOfNotNull(queryType, mutationType, subscriptionType)
+
+internal fun ExecutionResultImpl.Builder.extensions(extensions: Map<String, Any?>): ExecutionResultImpl.Builder {
+    @Suppress("UNCHECKED_CAST")
+    return extensions(extensions as Map<Any, Any>)
+}

--- a/lib/src/main/java/graphql/nadel/util/ColectionUtil.kt
+++ b/lib/src/main/java/graphql/nadel/util/ColectionUtil.kt
@@ -1,0 +1,5 @@
+package graphql.nadel.util
+
+inline fun <E, T> Collection<E>.mapToSet(transform: (E) -> T): Set<T> {
+    return mapTo(LinkedHashSet(size), transform)
+}

--- a/lib/src/main/java/graphql/nadel/util/NamespacedUtil.kt
+++ b/lib/src/main/java/graphql/nadel/util/NamespacedUtil.kt
@@ -5,7 +5,7 @@ import graphql.language.ObjectTypeExtensionDefinition
 import graphql.nadel.Service
 import graphql.schema.GraphQLObjectType
 
-object NamespacedUtil {
+internal object NamespacedUtil {
     fun serviceOwnsNamespacedField(namespacedObjectType: GraphQLObjectType, service: Service): Boolean {
         return serviceOwnsNamespacedField(namespacedObjectType.name, service)
     }

--- a/lib/src/main/java/graphql/nadel/validation/util/NadelCombinedTypeUtil.kt
+++ b/lib/src/main/java/graphql/nadel/validation/util/NadelCombinedTypeUtil.kt
@@ -9,7 +9,7 @@ import graphql.schema.GraphQLFieldDefinition
 import graphql.schema.GraphQLNamedSchemaElement
 import graphql.schema.GraphQLSchema
 
-object NadelCombinedTypeUtil {
+internal object NadelCombinedTypeUtil {
     fun getFieldsThatServiceContributed(schemaElement: NadelServiceSchemaElement): Set<String> {
         return getFieldsThatServiceContributed(
             service = schemaElement.service,
@@ -68,7 +68,7 @@ object NadelCombinedTypeUtil {
      */
     fun isCombinedType(overallSchema: GraphQLSchema, type: GraphQLNamedSchemaElement): Boolean {
         val usesTypeAsNamespaced = { field: GraphQLFieldDefinition ->
-            field.hasDirective(NadelDirectives.namespacedDirectiveDefinition.name)
+            field.hasAppliedDirective(NadelDirectives.namespacedDirectiveDefinition.name)
                 && field.type.unwrapAll().name == type.name
         }
 

--- a/lib/src/main/java/graphql/nadel/validation/util/NadelGetServiceTypes.kt
+++ b/lib/src/main/java/graphql/nadel/validation/util/NadelGetServiceTypes.kt
@@ -1,0 +1,128 @@
+package graphql.nadel.validation.util
+
+import graphql.language.ObjectTypeDefinition
+import graphql.nadel.Service
+import graphql.nadel.engine.util.AnyNamedNode
+import graphql.nadel.engine.util.isExtensionDef
+import graphql.nadel.engine.util.operationTypes
+import graphql.nadel.engine.util.unwrapAll
+import graphql.nadel.schema.NadelDirectives
+import graphql.nadel.schema.NadelDirectives.hydratedDirectiveDefinition
+import graphql.nadel.validation.NadelSchemaValidationError
+import graphql.nadel.validation.NadelServiceSchemaElement
+import graphql.schema.GraphQLNamedType
+import graphql.schema.GraphQLSchema
+import graphql.schema.GraphQLUnionType
+
+fun getServiceTypes(
+    engineSchema: GraphQLSchema,
+    service: Service,
+): Pair<List<NadelServiceSchemaElement>, List<NadelSchemaValidationError>> {
+    val errors = mutableListOf<NadelSchemaValidationError>()
+    val polymorphicHydrationUnions = getPolymorphicHydrationUnions(engineSchema, service)
+    val namesUsed = getTypeNamesUsed(engineSchema, service, externalTypes = polymorphicHydrationUnions)
+
+    fun addMissingUnderlyingTypeError(overallType: GraphQLNamedType) {
+        errors.add(NadelSchemaValidationError.MissingUnderlyingType(service, overallType))
+    }
+
+    return engineSchema
+        .typeMap
+        .asSequence()
+        .filter { (key) ->
+            key in namesUsed
+        }
+        .filterNot { (key) ->
+            key in NadelBuiltInTypes.allNadelBuiltInTypeNames
+        }
+        .mapNotNull { (_, overallType) ->
+            val underlyingType = NadelSchemaUtil.getUnderlyingType(overallType, service)
+
+            if (underlyingType == null) {
+                addMissingUnderlyingTypeError(overallType).let { null }
+            } else {
+                NadelServiceSchemaElement(
+                    service = service,
+                    overall = overallType,
+                    underlying = underlyingType,
+                )
+            }
+        }
+        .toList()
+        .also { types ->
+            // Add error for duplicated types
+            errors.addAll(
+                types
+                    .groupBy { it.underlying.name }
+                    .filterValues { it.size > 1 }
+                    .values
+                    .map { duplicatedTypes ->
+                        NadelSchemaValidationError.DuplicatedUnderlyingType(duplicatedTypes)
+                    },
+            )
+        } to errors
+}
+
+private fun getPolymorphicHydrationUnions(
+    engineSchema: GraphQLSchema,
+    service: Service,
+): Set<GraphQLUnionType> {
+    return service
+        .definitionRegistry
+        .definitions
+        .asSequence()
+        .filterIsInstance<ObjectTypeDefinition>()
+        .flatMap { it.fieldDefinitions }
+        .filter { it.getDirectives(hydratedDirectiveDefinition.name).size > 1 }
+        .map { it.type.unwrapAll() }
+        .map { engineSchema.getType(it.name) }
+        .filterIsInstance<GraphQLUnionType>()
+        .toSet()
+}
+
+private fun getTypeNamesUsed(
+    engineSchema: GraphQLSchema,
+    service: Service,
+    externalTypes: Set<GraphQLNamedType>,
+): Set<String> {
+    // There is no shared service to validate.
+    // These shared types are USED in other services. When they are used, the validation
+    // will validate that the service has a compatible underlying type.
+    if (service.name == "shared") {
+        return emptySet()
+    }
+
+    val namesToIgnore = externalTypes.map { it.name }.toSet()
+
+    val definitionNames = service.definitionRegistry.definitions
+        .asSequence()
+        .filterIsInstance<AnyNamedNode>()
+        .filter { def ->
+            if (def.isExtensionDef) {
+                isNamespacedOperationType(engineSchema, typeName = def.name)
+            } else {
+                true
+            }
+        }
+        .map {
+            it.name
+        }
+        .toSet() - namesToIgnore
+
+    // If it can be reached by using your service, you must own it to return it!
+    val referencedTypes = getReachableTypeNames(engineSchema, service, definitionNames)
+
+    return (definitionNames + referencedTypes).toSet()
+}
+
+private fun isNamespacedOperationType(
+    engineSchema: GraphQLSchema,
+    typeName: String,
+): Boolean {
+    return engineSchema.operationTypes.any { operationType ->
+        operationType.fields.any { field ->
+            field.hasAppliedDirective(NadelDirectives.namespacedDirectiveDefinition.name) &&
+                field.type.unwrapAll().name == typeName
+        }
+    }
+}

--- a/test/src/test/java/graphql/nadel/tests/hooks/JavaAriTransform.java
+++ b/test/src/test/java/graphql/nadel/tests/hooks/JavaAriTransform.java
@@ -5,7 +5,6 @@ import graphql.nadel.Service;
 import graphql.nadel.ServiceExecutionHydrationDetails;
 import graphql.nadel.ServiceExecutionResult;
 import graphql.nadel.engine.NadelExecutionContext;
-import graphql.nadel.engine.blueprint.NadelOverallExecutionBlueprint;
 import graphql.nadel.engine.transform.NadelTransform;
 import graphql.nadel.engine.transform.NadelTransformFieldResult;
 import graphql.nadel.engine.transform.NadelTransformJavaCompat;
@@ -47,25 +46,24 @@ public class JavaAriTransform implements NadelTransformJavaCompat<Set<String>> {
     @NotNull
     @Override
     public CompletableFuture<Set<String>> isApplicable(@NotNull NadelExecutionContext executionContext,
-                                                       @NotNull NadelOverallExecutionBlueprint executionBlueprint,
-                                                       @NotNull Map<String, ? extends Service> services,
+                                                       @NotNull Map<String, Service> services,
                                                        @NotNull Service service,
                                                        @NotNull ExecutableNormalizedField overallField,
                                                        @Nullable ServiceExecutionHydrationDetails hydrationDetails) {
 
         String singleObjectTypeName = getSingleObjectTypeName(overallField);
         FieldCoordinates fieldCoordinates = makeFieldCoordinates(singleObjectTypeName, overallField.getName());
-        GraphQLFieldDefinition fieldDef = executionBlueprint.getEngineSchema().getFieldDefinition(fieldCoordinates);
+        GraphQLFieldDefinition fieldDef = service.getSchema().getFieldDefinition(fieldCoordinates);
         Objects.requireNonNull(fieldDef, "No field def");
 
         var argDefsByName = CollectionUtilKt.strictAssociateBy(fieldDef.getArguments(), GraphQLArgument::getName);
 
         var argsToTransform = overallField.getNormalizedArguments().keySet()
-                .stream()
-                .filter((argName) -> {
-                    return argDefsByName.get(argName).hasDirective("interpretAri");
-                })
-                .collect(Collectors.toSet());
+            .stream()
+            .filter((argName) -> {
+                return argDefsByName.get(argName).hasDirective("interpretAri");
+            })
+            .collect(Collectors.toSet());
 
         if (argsToTransform.isEmpty()) {
             return CompletableFuture.completedFuture(null);
@@ -78,7 +76,6 @@ public class JavaAriTransform implements NadelTransformJavaCompat<Set<String>> {
     @Override
     public CompletableFuture<NadelTransformFieldResult> transformField(@NotNull NadelExecutionContext executionContext,
                                                                        @NotNull NadelQueryTransformerJavaCompat transformer,
-                                                                       @NotNull NadelOverallExecutionBlueprint executionBlueprint,
                                                                        @NotNull Service service,
                                                                        @NotNull ExecutableNormalizedField field,
                                                                        @NotNull Set<String> fieldsArgsToInterpret) {
@@ -123,7 +120,6 @@ public class JavaAriTransform implements NadelTransformJavaCompat<Set<String>> {
     @NotNull
     @Override
     public CompletableFuture<List<NadelResultInstruction>> getResultInstructions(@NotNull NadelExecutionContext executionContext,
-                                                                                 @NotNull NadelOverallExecutionBlueprint executionBlueprint,
                                                                                  @NotNull Service service,
                                                                                  @NotNull ExecutableNormalizedField overallField,
                                                                                  @Nullable ExecutableNormalizedField underlyingParentField,

--- a/test/src/test/kotlin/graphql/nadel/tests/CentralSchemaTesting.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/CentralSchemaTesting.kt
@@ -36,7 +36,7 @@ val File.parents: Sequence<File>
  * Set this to true to run the query. You'll have to modify the [ServiceExecutionFactory] to
  * actually return something e.g. response from Splunk etc.
  */
-const val runQuery = false
+const val runQuery = true
 
 /**
  * You can use this script to run central schema locally in Nadel without
@@ -152,4 +152,4 @@ suspend fun main() {
         }
 }
 
-const val query = ""
+const val query = "{echo}"

--- a/test/src/test/kotlin/graphql/nadel/tests/hooks/ari-transforms.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/hooks/ari-transforms.kt
@@ -5,7 +5,6 @@ import graphql.nadel.Service
 import graphql.nadel.ServiceExecutionHydrationDetails
 import graphql.nadel.ServiceExecutionResult
 import graphql.nadel.engine.NadelExecutionContext
-import graphql.nadel.engine.blueprint.NadelOverallExecutionBlueprint
 import graphql.nadel.engine.transform.NadelTransform
 import graphql.nadel.engine.transform.NadelTransformFieldResult
 import graphql.nadel.engine.transform.query.NadelQueryTransformer
@@ -24,7 +23,6 @@ import graphql.normalized.NormalizedInputValue
 private class AriTestTransform : NadelTransform<Set<String>> {
     override suspend fun isApplicable(
         executionContext: NadelExecutionContext,
-        executionBlueprint: NadelOverallExecutionBlueprint,
         services: Map<String, Service>,
         service: Service,
         overallField: ExecutableNormalizedField,
@@ -32,7 +30,7 @@ private class AriTestTransform : NadelTransform<Set<String>> {
     ): Set<String>? {
         // Let's not bother with abstract types in a test
         val fieldCoords = makeFieldCoordinates(overallField.objectTypeNames.single(), overallField.name)
-        val fieldDef = executionBlueprint.engineSchema.getField(fieldCoords)
+        val fieldDef = service.schema.getField(fieldCoords)
             ?: error("Unable to fetch field definition")
         val fieldArgDefs = fieldDef.arguments.strictAssociateBy { it.name }
 
@@ -50,7 +48,6 @@ private class AriTestTransform : NadelTransform<Set<String>> {
     override suspend fun transformField(
         executionContext: NadelExecutionContext,
         transformer: NadelQueryTransformer,
-        executionBlueprint: NadelOverallExecutionBlueprint,
         service: Service,
         field: ExecutableNormalizedField,
         state: Set<String>,
@@ -83,7 +80,6 @@ private class AriTestTransform : NadelTransform<Set<String>> {
 
     override suspend fun getResultInstructions(
         executionContext: NadelExecutionContext,
-        executionBlueprint: NadelOverallExecutionBlueprint,
         service: Service,
         overallField: ExecutableNormalizedField,
         underlyingParentField: ExecutableNormalizedField?,

--- a/test/src/test/kotlin/graphql/nadel/tests/hooks/chain-rename-transform.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/hooks/chain-rename-transform.kt
@@ -6,7 +6,6 @@ import graphql.nadel.Service
 import graphql.nadel.ServiceExecutionHydrationDetails
 import graphql.nadel.ServiceExecutionResult
 import graphql.nadel.engine.NadelExecutionContext
-import graphql.nadel.engine.blueprint.NadelOverallExecutionBlueprint
 import graphql.nadel.engine.transform.NadelTransform
 import graphql.nadel.engine.transform.NadelTransformFieldResult
 import graphql.nadel.engine.transform.query.NadelQueryTransformer
@@ -21,7 +20,6 @@ import graphql.normalized.NormalizedInputValue
 private class ChainRenameTransform : NadelTransform<Any> {
     override suspend fun isApplicable(
         executionContext: NadelExecutionContext,
-        executionBlueprint: NadelOverallExecutionBlueprint,
         services: Map<String, Service>,
         service: Service,
         overallField: ExecutableNormalizedField,
@@ -33,7 +31,6 @@ private class ChainRenameTransform : NadelTransform<Any> {
     override suspend fun transformField(
         executionContext: NadelExecutionContext,
         transformer: NadelQueryTransformer,
-        executionBlueprint: NadelOverallExecutionBlueprint,
         service: Service,
         field: ExecutableNormalizedField,
         state: Any,
@@ -63,7 +60,6 @@ private class ChainRenameTransform : NadelTransform<Any> {
 
     override suspend fun getResultInstructions(
         executionContext: NadelExecutionContext,
-        executionBlueprint: NadelOverallExecutionBlueprint,
         service: Service,
         overallField: ExecutableNormalizedField,
         underlyingParentField: ExecutableNormalizedField?,

--- a/test/src/test/kotlin/graphql/nadel/tests/hooks/transformer-on-hydration-fields.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/hooks/transformer-on-hydration-fields.kt
@@ -5,7 +5,6 @@ import graphql.nadel.Service
 import graphql.nadel.ServiceExecutionHydrationDetails
 import graphql.nadel.ServiceExecutionResult
 import graphql.nadel.engine.NadelExecutionContext
-import graphql.nadel.engine.blueprint.NadelOverallExecutionBlueprint
 import graphql.nadel.engine.transform.NadelTransform
 import graphql.nadel.engine.transform.NadelTransformFieldResult
 import graphql.nadel.engine.transform.query.NadelQueryTransformer
@@ -38,7 +37,6 @@ class `transformer-on-hydration-fields` : EngineTestHook {
             object : NadelTransform<Any> {
                 override suspend fun isApplicable(
                     executionContext: NadelExecutionContext,
-                    executionBlueprint: NadelOverallExecutionBlueprint,
                     services: Map<String, Service>,
                     service: Service,
                     overallField: ExecutableNormalizedField,
@@ -59,7 +57,6 @@ class `transformer-on-hydration-fields` : EngineTestHook {
                 override suspend fun transformField(
                     executionContext: NadelExecutionContext,
                     transformer: NadelQueryTransformer,
-                    executionBlueprint: NadelOverallExecutionBlueprint,
                     service: Service,
                     field: ExecutableNormalizedField,
                     state: Any,
@@ -80,7 +77,6 @@ class `transformer-on-hydration-fields` : EngineTestHook {
 
                 override suspend fun getResultInstructions(
                     executionContext: NadelExecutionContext,
-                    executionBlueprint: NadelOverallExecutionBlueprint,
                     service: Service,
                     overallField: ExecutableNormalizedField,
                     underlyingParentField: ExecutableNormalizedField?,

--- a/test/src/test/kotlin/graphql/nadel/tests/hooks/transforms-can-copy-array-value.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/hooks/transforms-can-copy-array-value.kt
@@ -4,7 +4,6 @@ import graphql.nadel.Service
 import graphql.nadel.ServiceExecutionHydrationDetails
 import graphql.nadel.ServiceExecutionResult
 import graphql.nadel.engine.NadelExecutionContext
-import graphql.nadel.engine.blueprint.NadelOverallExecutionBlueprint
 import graphql.nadel.engine.transform.NadelTransform
 import graphql.nadel.engine.transform.NadelTransformFieldResult
 import graphql.nadel.engine.transform.query.NadelQueryTransformer
@@ -23,7 +22,6 @@ class `transforms-can-copy-array-value` : EngineTestHook {
             object : NadelTransform<Any> {
                 override suspend fun isApplicable(
                     executionContext: NadelExecutionContext,
-                    executionBlueprint: NadelOverallExecutionBlueprint,
                     services: Map<String, Service>,
                     service: Service,
                     overallField: ExecutableNormalizedField,
@@ -35,7 +33,6 @@ class `transforms-can-copy-array-value` : EngineTestHook {
                 override suspend fun transformField(
                     executionContext: NadelExecutionContext,
                     transformer: NadelQueryTransformer,
-                    executionBlueprint: NadelOverallExecutionBlueprint,
                     service: Service,
                     field: ExecutableNormalizedField,
                     state: Any,
@@ -45,7 +42,6 @@ class `transforms-can-copy-array-value` : EngineTestHook {
 
                 override suspend fun getResultInstructions(
                     executionContext: NadelExecutionContext,
-                    executionBlueprint: NadelOverallExecutionBlueprint,
                     service: Service,
                     overallField: ExecutableNormalizedField,
                     underlyingParentField: ExecutableNormalizedField?,

--- a/test/src/test/kotlin/graphql/nadel/tests/hooks/transforms-can-set-array-value.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/hooks/transforms-can-set-array-value.kt
@@ -4,7 +4,6 @@ import graphql.nadel.Service
 import graphql.nadel.ServiceExecutionHydrationDetails
 import graphql.nadel.ServiceExecutionResult
 import graphql.nadel.engine.NadelExecutionContext
-import graphql.nadel.engine.blueprint.NadelOverallExecutionBlueprint
 import graphql.nadel.engine.transform.NadelTransform
 import graphql.nadel.engine.transform.NadelTransformFieldResult
 import graphql.nadel.engine.transform.query.NadelQueryTransformer
@@ -23,7 +22,6 @@ class `transforms-can-set-array-value` : EngineTestHook {
             object : NadelTransform<Any> {
                 override suspend fun isApplicable(
                     executionContext: NadelExecutionContext,
-                    executionBlueprint: NadelOverallExecutionBlueprint,
                     services: Map<String, Service>,
                     service: Service,
                     overallField: ExecutableNormalizedField,
@@ -35,7 +33,6 @@ class `transforms-can-set-array-value` : EngineTestHook {
                 override suspend fun transformField(
                     executionContext: NadelExecutionContext,
                     transformer: NadelQueryTransformer,
-                    executionBlueprint: NadelOverallExecutionBlueprint,
                     service: Service,
                     field: ExecutableNormalizedField,
                     state: Any,
@@ -45,7 +42,6 @@ class `transforms-can-set-array-value` : EngineTestHook {
 
                 override suspend fun getResultInstructions(
                     executionContext: NadelExecutionContext,
-                    executionBlueprint: NadelOverallExecutionBlueprint,
                     service: Service,
                     overallField: ExecutableNormalizedField,
                     underlyingParentField: ExecutableNormalizedField?,

--- a/test/src/test/kotlin/graphql/nadel/tests/transforms/RemoveFieldTestTransform.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/transforms/RemoveFieldTestTransform.kt
@@ -6,7 +6,6 @@ import graphql.nadel.Service
 import graphql.nadel.ServiceExecutionHydrationDetails
 import graphql.nadel.ServiceExecutionResult
 import graphql.nadel.engine.NadelExecutionContext
-import graphql.nadel.engine.blueprint.NadelOverallExecutionBlueprint
 import graphql.nadel.engine.transform.NadelTransform
 import graphql.nadel.engine.transform.NadelTransformFieldResult
 import graphql.nadel.engine.transform.query.NadelQueryPath
@@ -23,7 +22,6 @@ import graphql.validation.ValidationErrorType
 class RemoveFieldTestTransform : NadelTransform<GraphQLError> {
     override suspend fun isApplicable(
         executionContext: NadelExecutionContext,
-        executionBlueprint: NadelOverallExecutionBlueprint,
         services: Map<String, Service>,
         service: Service,
         overallField: ExecutableNormalizedField,
@@ -31,7 +29,7 @@ class RemoveFieldTestTransform : NadelTransform<GraphQLError> {
     ): GraphQLError? {
         val objectType = overallField.objectTypeNames.asSequence()
             .map {
-                executionBlueprint.engineSchema.getType(it) as GraphQLObjectType?
+                service.schema.getType(it) as GraphQLObjectType?
             }
             .filterNotNull()
             .firstOrNull()
@@ -47,7 +45,6 @@ class RemoveFieldTestTransform : NadelTransform<GraphQLError> {
     override suspend fun transformField(
         executionContext: NadelExecutionContext,
         transformer: NadelQueryTransformer,
-        executionBlueprint: NadelOverallExecutionBlueprint,
         service: Service,
         field: ExecutableNormalizedField,
         state: GraphQLError,
@@ -68,7 +65,6 @@ class RemoveFieldTestTransform : NadelTransform<GraphQLError> {
 
     override suspend fun getResultInstructions(
         executionContext: NadelExecutionContext,
-        executionBlueprint: NadelOverallExecutionBlueprint,
         service: Service,
         overallField: ExecutableNormalizedField,
         underlyingParentField: ExecutableNormalizedField?,

--- a/test/src/test/resources/fixtures/hydration/query-with-hydrated-interfaces-work-as-expected.yml
+++ b/test/src/test/resources/fixtures/hydration/query-with-hydrated-interfaces-work-as-expected.yml
@@ -57,6 +57,10 @@ overallSchema:
     }
 underlyingSchema:
   PetService: |
+    interface Owner {
+      name: String
+    }
+
     interface Collar {
       color: String
       size: String

--- a/test/src/test/resources/fixtures/renames/types/renamed-type-is-shared.yml
+++ b/test/src/test/resources/fixtures/renames/types/renamed-type-is-shared.yml
@@ -16,9 +16,9 @@ overallSchema:
 underlyingSchema:
   NextgenIssues: |-
     type Query {
-      fastIssue(id: ID!): NextgenIssue
+      fastIssue(id: ID!): Issue
     }
-    type NextgenIssue {
+    type Issue {
       id: ID
     }
   IssueService: |-
@@ -52,7 +52,7 @@ serviceCalls:
       {
         "data": {
           "fastIssue": {
-            "__typename": "NextgenIssue",
+            "__typename": "Issue",
             "id": "ISSUE-1"
           }
         },


### PR DESCRIPTION
Pending #403 and need to rebase onto master to get Artyom's blueprint changes.

Effectively this change uses the more correct way to collect services types that the validation has been doing i.e. uses `getServiceTypes` and `getReachableTypes` to collect all the types a service _uses_.

This improves the way we handle shared types as blueprints are now per service, which is actually a better view as we only execute the "query" on one service at a time anyway.

Stuff is not final and am happy to discuss this change.

Please make sure you consider the following:

- [ ] Add tests that use __typename in queries
- [ ] Does this change work with all nadel transformations (rename, type rename, hydration, etc)? Add tests for this.
- [ ] Is it worth using hints for this change in order to be able to enable a percentage rollout?
- [ ] Do we need to add integration tests for this change in the graphql gateway?
- [ ] Do we need a pollinator check for this?
