### PR TITLE
GQLGW-1587 - killing unsound log message

### DIFF
--- a/lib/src/main/java/graphql/nadel/Nadel.kt
+++ b/lib/src/main/java/graphql/nadel/Nadel.kt
@@ -18,17 +18,14 @@ import graphql.nadel.instrumentation.NadelInstrumentation
 import graphql.nadel.instrumentation.parameters.NadelInstrumentationCreateStateParameters
 import graphql.nadel.instrumentation.parameters.NadelInstrumentationQueryExecutionParameters
 import graphql.nadel.instrumentation.parameters.NadelInstrumentationQueryValidationParameters
-import graphql.nadel.schema.NeverWiringFactory
 import graphql.nadel.schema.QuerySchemaGenerator
 import graphql.nadel.schema.SchemaTransformationHook
-import graphql.nadel.util.LogKit
 import graphql.parser.InvalidSyntaxException
 import graphql.parser.Parser
 import graphql.schema.GraphQLSchema
 import graphql.schema.idl.WiringFactory
 import graphql.validation.ValidationError
 import graphql.validation.Validator
-import org.slf4j.Logger
 import java.io.Reader
 import java.io.StringReader
 import java.util.concurrent.CompletableFuture
@@ -134,11 +131,9 @@ class Nadel private constructor(
         var executionInput = executionInputRef.get()!!
 
         val query = executionInput.query
-        logNotSafe.debug("Parsing query: '{}'...", query)
         val parseResult = parse(executionInput, graphQLSchema, instrumentationState)
 
         return if (parseResult.isFailure) {
-            logNotSafe.warn("Query failed to parse : '{}'", executionInput.query)
             PreparsedDocumentEntry(parseResult.syntaxException.toInvalidSyntaxError())
         } else {
             val document = parseResult.document
@@ -149,11 +144,9 @@ class Nadel private constructor(
             }
             executionInputRef.set(executionInput)
 
-            logNotSafe.debug("Validating query: '{}'", query)
             val errors = validate(executionInput, document, graphQLSchema, instrumentationState)
 
             if (errors.isNotEmpty()) {
-                logNotSafe.warn("Query failed to validate : '{}' because of {} ", query, errors)
                 PreparsedDocumentEntry(errors)
             } else {
                 PreparsedDocumentEntry(document)
@@ -382,9 +375,6 @@ class Nadel private constructor(
     }
 
     companion object {
-        private val logNotSafe: Logger = LogKit.getNotPrivacySafeLogger<Nadel>()
-        private val log: Logger = LogKit.getLogger<Nadel>()
-
         /**
          * @return a builder of Nadel objects
          */

--- a/lib/src/main/java/graphql/nadel/NextgenEngine.kt
+++ b/lib/src/main/java/graphql/nadel/NextgenEngine.kt
@@ -36,7 +36,6 @@ import graphql.nadel.engine.util.toBuilder
 import graphql.nadel.hooks.ServiceExecutionHooks
 import graphql.nadel.util.ErrorUtil
 import graphql.nadel.util.LogKit.getLogger
-import graphql.nadel.util.LogKit.getNotPrivacySafeLogger
 import graphql.nadel.util.OperationNameUtil
 import graphql.normalized.ExecutableNormalizedField
 import graphql.normalized.ExecutableNormalizedOperationFactory.createExecutableNormalizedOperationWithRawVariables
@@ -61,7 +60,6 @@ class NextgenEngine @JvmOverloads constructor(
     transforms: List<NadelTransform<out Any>> = emptyList(),
     introspectionRunnerFactory: NadelIntrospectionRunnerFactory = NadelIntrospectionRunnerFactory(::NadelDefaultIntrospectionRunner),
 ) : NadelExecutionEngine {
-    private val logNotSafe = getNotPrivacySafeLogger<NextgenEngine>()
     private val log = getLogger<NextgenEngine>()
 
     private val coroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
@@ -312,8 +310,7 @@ class NextgenEngine @JvmOverloads constructor(
             val errorMessage = "An exception occurred invoking the service '${service.name}'"
             val errorMessageNotSafe = "$errorMessage: ${e.message}"
             val executionId = serviceExecParams.executionId.toString()
-            logNotSafe.error("$errorMessageNotSafe. Execution ID '$executionId'", e)
-            log.error("$errorMessage. Execution ID '$executionId'", e)
+            log.error(errorMessage, e)
 
             newServiceExecutionResult(
                 errors = mutableListOf(

--- a/lib/src/main/java/graphql/nadel/util/LogKit.kt
+++ b/lib/src/main/java/graphql/nadel/util/LogKit.kt
@@ -7,16 +7,4 @@ internal object LogKit {
     inline fun <reified T> getLogger(): Logger {
         return LoggerFactory.getLogger(T::class.java)
     }
-
-    /**
-     * Creates a logger with a name indicating that the content might not be privacy safe
-     * eg it could contain user generated content or privacy information.
-     *
-     * @param clazz the class to make a logger for
-     *
-     * @return a new Logger
-     */
-    inline fun <reified T> getNotPrivacySafeLogger(): Logger {
-        return LoggerFactory.getLogger("notprivacysafe." + T::class.java.name)
-    }
 }


### PR DESCRIPTION
Take 2

Removes privacy unsafe logging in Nadel - bad idea

Tweaks the engine exception to TAKE out the execution id