### PR TITLE
Update tests to all vars

### DIFF
--- a/lib/src/main/java/graphql/nadel/engine/util/CollectionUtil.kt
+++ b/lib/src/main/java/graphql/nadel/engine/util/CollectionUtil.kt
@@ -44,7 +44,7 @@ inline fun <K, E> Sequence<E>.strictAssociateBy(crossinline keyExtractor: (E) ->
  */
 @JvmName("mapFromPairs")
 fun <K, V> mapFrom(entries: Collection<Pair<K, V>>): Map<K, V> {
-    val map = HashMap<K, V>(entries.size)
+    val map = LinkedHashMap<K, V>(entries.size)
     map.putAll(entries)
     require(map.size == entries.size) {
         @Suppress("SimpleRedundantLet") // For debugging purposes if you want to visit the values
@@ -61,7 +61,7 @@ fun <K, V> mapFrom(entries: Collection<Pair<K, V>>): Map<K, V> {
  */
 @JvmName("mapFromPairs")
 fun <K, V> mapFrom(entries: Sequence<Pair<K, V>>): Map<K, V> {
-    val map = HashMap<K, V>()
+    val map = LinkedHashMap<K, V>()
     var count = 0
     entries.forEach {
         map[it.first] = it.second
@@ -90,7 +90,7 @@ fun <K, V> Collection<Pair<K, V>>.toMapStrictly(): Map<K, V> {
  */
 @JvmName("mapFromEntries")
 fun <K, V> mapFrom(entries: Collection<Map.Entry<K, V>>): Map<K, V> {
-    val map = HashMap<K, V>(entries.size)
+    val map = LinkedHashMap<K, V>(entries.size)
     entries.forEach(map::put)
     require(map.size == entries.size)
     return map
@@ -114,7 +114,7 @@ fun <K, V> MutableMap<K, V>.put(entry: Pair<K, V>) {
  * Inverts the [Map] such that the values are now the keys and the keys are now the values.
  */
 fun <K, V> Map<K, V>.invert(): Map<V, K> {
-    val map = HashMap<V, K>(this.size)
+    val map = LinkedHashMap<V, K>(this.size)
     forEach { (key, value) ->
         map[value] = key
     }

--- a/test/src/test/kotlin/graphql/nadel/tests/EngineTests.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/EngineTests.kt
@@ -50,6 +50,7 @@ private val singleTestToRun = (System.getenv("TEST_NAME") ?: "")
  * NadelExecutionInput.Builder#transformExecutionHints method in your test hook class.
  */
 private val defaultHints = NadelExecutionHints.newHints()
+    .allDocumentVariablesHint { true }
     .build()
 
 private val sep = "-".repeat(50)

--- a/test/src/test/kotlin/graphql/nadel/tests/TestFixtureUpdater.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/TestFixtureUpdater.kt
@@ -111,7 +111,7 @@ private fun getUpdatedServiceCalls(testFixture: TestFixture): List<ServiceCall> 
         }
 }
 
-fun writeOut(fixtureFile: File, testFixture: TestFixture) {
+private fun writeOut(fixtureFile: File, testFixture: TestFixture) {
     val commentsFromOldYaml = collectComments(fixtureFile).toMutableMap()
 
     val rootNodes = traverseYaml(yamlObjectMapper.writeValueAsString(testFixture)) { path, node ->

--- a/test/src/test/kotlin/graphql/nadel/tests/hooks/transformer-on-hydration-fields.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/hooks/transformer-on-hydration-fields.kt
@@ -64,7 +64,7 @@ class `transformer-on-hydration-fields` : EngineTestHook {
                     field: ExecutableNormalizedField,
                     state: Any,
                 ): NadelTransformFieldResult {
-                    val transformedArgs = mapOf("id" to NormalizedInputValue("String", StringValue("transformed-id")))
+                    val transformedArgs = mapOf("id" to NormalizedInputValue("ID", StringValue("transformed-id")))
                     return transformer.transform(field.children)
                         .let {
                             field.toBuilder()

--- a/test/src/test/resources/fixtures/basic/call-with-variables-inside-input-objects.yml
+++ b/test/src/test/resources/fixtures/basic/call-with-variables-inside-input-objects.yml
@@ -26,10 +26,11 @@ serviceCalls:
   - serviceName: "MyService"
     request:
       query: |
-        query myQuery {
-          hello(arg: {})
+        query myQuery($v0: Arg) {
+          hello(arg: $v0)
         }
-      variables: { }
+      variables:
+        v0: { }
       operationName: "myQuery"
     # language=JSON
     response: |-

--- a/test/src/test/resources/fixtures/chained transforms/ari use case/ari-argument-transform-on-renamed-field.yml
+++ b/test/src/test/resources/fixtures/chained transforms/ari use case/ari-argument-transform-on-renamed-field.yml
@@ -28,13 +28,14 @@ serviceCalls:
   - serviceName: "service"
     request:
       query: |
-        query {
-          rename__issue__issueById: issueById(id: "57") {
+        query ($v0: ID) {
+          rename__issue__issueById: issueById(id: $v0) {
             __typename__rename__key: __typename
             rename__key__id: id
           }
         }
-      variables: { }
+      variables:
+        v0: "57"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/chained transforms/ari use case/ari-argument-transform.yml
+++ b/test/src/test/resources/fixtures/chained transforms/ari use case/ari-argument-transform.yml
@@ -28,13 +28,14 @@ serviceCalls:
   - serviceName: "service"
     request:
       query: |
-        query {
-          issue(id: "57") {
+        query ($v0: ID) {
+          issue(id: $v0) {
             __typename__rename__key: __typename
             rename__key__id: id
           }
         }
-      variables: { }
+      variables:
+        v0: "57"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/deep renames/deep-rename-inside-batch-hydration-null-object.yml
+++ b/test/src/test/resources/fixtures/deep renames/deep-rename-inside-batch-hydration-null-object.yml
@@ -89,8 +89,8 @@ serviceCalls:
   - serviceName: "IssueService"
     request:
       query: |
-        query {
-          issuesByIds(id: ["issue-1", "issue-2", "issue-3"]) {
+        query ($v0: [ID!]) {
+          issuesByIds(id: $v0) {
             __typename__deep_rename__name: __typename
             deep_rename__name__detail: detail {
               detailName
@@ -98,7 +98,11 @@ serviceCalls:
             batch_hydration__issue__id: id
           }
         }
-      variables: { }
+      variables:
+        v0:
+          - "issue-1"
+          - "issue-2"
+          - "issue-3"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/deep renames/deep-rename-inside-batch-hydration.yml
+++ b/test/src/test/resources/fixtures/deep renames/deep-rename-inside-batch-hydration.yml
@@ -89,8 +89,8 @@ serviceCalls:
   - serviceName: "IssueService"
     request:
       query: |
-        query {
-          issuesByIds(id: ["issue-1", "issue-2", "issue-3"]) {
+        query ($v0: [ID!]) {
+          issuesByIds(id: $v0) {
             __typename__deep_rename__name: __typename
             deep_rename__name__detail: detail {
               detailName
@@ -98,7 +98,11 @@ serviceCalls:
             batch_hydration__issue__id: id
           }
         }
-      variables: { }
+      variables:
+        v0:
+          - "issue-1"
+          - "issue-2"
+          - "issue-3"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/deep renames/deep-rename-inside-hydration.yml
+++ b/test/src/test/resources/fixtures/deep renames/deep-rename-inside-hydration.yml
@@ -76,15 +76,16 @@ serviceCalls:
   - serviceName: "IssueService"
     request:
       query: |
-        query {
-          issueById(id: "issue-1") {
+        query ($v0: ID!) {
+          issueById(id: $v0) {
             __typename__deep_rename__name: __typename
             deep_rename__name__detail: detail {
               detailName
             }
           }
         }
-      variables: { }
+      variables:
+        v0: "issue-1"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/deep renames/deep-rename-inside-hydrations.yml
+++ b/test/src/test/resources/fixtures/deep renames/deep-rename-inside-hydrations.yml
@@ -86,15 +86,16 @@ serviceCalls:
   - serviceName: "IssueService"
     request:
       query: |
-        query {
-          issueById(id: "issue-1") {
+        query ($v0: ID!) {
+          issueById(id: $v0) {
             __typename__deep_rename__name: __typename
             deep_rename__name__detail: detail {
               detailName
             }
           }
         }
-      variables: { }
+      variables:
+        v0: "issue-1"
     # language=JSON
     response: |-
       {
@@ -111,15 +112,16 @@ serviceCalls:
   - serviceName: "IssueService"
     request:
       query: |
-        query {
-          issueById(id: "issue-2") {
+        query ($v0: ID!) {
+          issueById(id: $v0) {
             __typename__deep_rename__name: __typename
             deep_rename__name__detail: detail {
               detailName
             }
           }
         }
-      variables: { }
+      variables:
+        v0: "issue-2"
     # language=JSON
     response: |-
       {
@@ -136,15 +138,16 @@ serviceCalls:
   - serviceName: "IssueService"
     request:
       query: |
-        query {
-          issueById(id: "issue-3") {
+        query ($v0: ID!) {
+          issueById(id: $v0) {
             __typename__deep_rename__name: __typename
             deep_rename__name__detail: detail {
               detailName
             }
           }
         }
-      variables: { }
+      variables:
+        v0: "issue-3"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/deep renames/deep-rename-with-argument-works.yml
+++ b/test/src/test/resources/fixtures/deep renames/deep-rename-with-argument-works.yml
@@ -32,15 +32,16 @@ serviceCalls:
   - serviceName: "IssueService"
     request:
       query: |
-        query {
+        query ($v0: ID!) {
           issue {
             __typename__deep_rename__name: __typename
             deep_rename__name__detail: detail {
-              detailName(userId: "USER-01")
+              detailName(userId: $v0)
             }
           }
         }
-      variables: { }
+      variables:
+        v0: "USER-01"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/deep renames/deep-rename-with-more-unions.yml
+++ b/test/src/test/resources/fixtures/deep renames/deep-rename-with-more-unions.yml
@@ -1,3 +1,4 @@
+# Pretty sure this test doesn't actually make any sense, we should delete it if so
 name: "deep rename with more unions"
 enabled: true
 overallSchema:

--- a/test/src/test/resources/fixtures/deep renames/deep-rename-with-unions.yml
+++ b/test/src/test/resources/fixtures/deep renames/deep-rename-with-unions.yml
@@ -1,3 +1,4 @@
+# Pretty sure this test doesn't actually make any sense, we should delete it if so
 name: "deep rename with unions"
 enabled: true
 overallSchema:

--- a/test/src/test/resources/fixtures/document variable handling/inlined-json-arguments.yml
+++ b/test/src/test/resources/fixtures/document variable handling/inlined-json-arguments.yml
@@ -31,13 +31,14 @@ serviceCalls:
   - serviceName: "MyService"
     request:
       query: |
-        query myQuery($v0: JSON, $v1: JSON!) {
-          hello(arg: {payload : $v0}, arg1: $v1)
+        query myQuery($v0: InputWithJson, $v1: JSON!) {
+          hello(arg: $v0, arg1: $v1)
         }
       variables:
         v0:
-          name: "Bobert"
-          age: "23"
+          payload:
+            name: "Bobert"
+            age: "23"
         v1:
           interests:
             - "photography"

--- a/test/src/test/resources/fixtures/document variable handling/input-object-with-json-field.yml
+++ b/test/src/test/resources/fixtures/document variable handling/input-object-with-json-field.yml
@@ -33,12 +33,13 @@ serviceCalls:
   - serviceName: "MyService"
     request:
       query: |
-        query myQuery($v0: JSON) {
-          hello(arg: {payload : $v0})
+        query myQuery($v0: InputWithJson) {
+          hello(arg: $v0)
         }
       variables:
         v0:
-          48x48: "file.jpeg"
+          payload:
+            48x48: "file.jpeg"
       operationName: "myQuery"
     # language=JSON
     response: |-

--- a/test/src/test/resources/fixtures/document variable handling/primitive-json-arguments-variables.yml
+++ b/test/src/test/resources/fixtures/document variable handling/primitive-json-arguments-variables.yml
@@ -33,11 +33,12 @@ serviceCalls:
   - serviceName: "MyService"
     request:
       query: |
-        query myQuery($v0: JSON, $v1: JSON!) {
-          hello(arg: {payload : $v0}, arg1: $v1)
+        query myQuery($v0: InputWithJson, $v1: JSON!) {
+          hello(arg: $v0, arg1: $v1)
         }
       variables:
-        v0: "String JSON input"
+        v0:
+          payload: "String JSON input"
         v1: false
       operationName: "myQuery"
     # language=JSON

--- a/test/src/test/resources/fixtures/document variable handling/primitive-json-arguments.yml
+++ b/test/src/test/resources/fixtures/document variable handling/primitive-json-arguments.yml
@@ -31,11 +31,12 @@ serviceCalls:
   - serviceName: "MyService"
     request:
       query: |
-        query myQuery($v0: JSON, $v1: JSON!) {
-          hello(arg: {payload : $v0}, arg1: $v1)
+        query myQuery($v0: InputWithJson, $v1: JSON!) {
+          hello(arg: $v0, arg1: $v1)
         }
       variables:
-        v0: "String JSON input"
+        v0:
+          payload: "String JSON input"
         v1: false
       operationName: "myQuery"
     # language=JSON

--- a/test/src/test/resources/fixtures/dynamic service resolution/dynamic-service-resolution-directive-not-in-interface.yml
+++ b/test/src/test/resources/fixtures/dynamic service resolution/dynamic-service-resolution-directive-not-in-interface.yml
@@ -28,13 +28,7 @@ query: |-
     }
   }
 variables: { }
-serviceCalls:
-  - serviceName: "RepoService"
-    request:
-      query: ""
-      variables: { }
-    # language=JSON
-    response: ""
+serviceCalls: [ ]
 # language=JSON
 response: null
 exception:

--- a/test/src/test/resources/fixtures/dynamic service resolution/dynamic-service-resolution-handles-complex-fragments.yml
+++ b/test/src/test/resources/fixtures/dynamic service resolution/dynamic-service-resolution-handles-complex-fragments.yml
@@ -91,8 +91,8 @@ serviceCalls:
   - serviceName: "RepoService"
     request:
       query: |
-        query {
-          node(id: "pull-request:id-123") {
+        query ($v0: ID!) {
+          node(id: $v0) {
             id
             ... on PullRequest {
               author {
@@ -103,7 +103,8 @@ serviceCalls:
             }
           }
         }
-      variables: { }
+      variables:
+        v0: "pull-request:id-123"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/dynamic service resolution/dynamic-service-resolution-handles-inline-fragments-from-multiple-services.yml
+++ b/test/src/test/resources/fixtures/dynamic service resolution/dynamic-service-resolution-handles-inline-fragments-from-multiple-services.yml
@@ -72,8 +72,8 @@ serviceCalls:
   - serviceName: "RepoService"
     request:
       query: |
-        query {
-          node(id: "pull-request:id-123") {
+        query ($v0: ID!) {
+          node(id: $v0) {
             __typename__type_filter__issueKey: __typename
             id
             ... on PullRequest {
@@ -81,7 +81,8 @@ serviceCalls:
             }
           }
         }
-      variables: { }
+      variables:
+        v0: "pull-request:id-123"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/dynamic service resolution/dynamic-service-resolution-multiple-services-with-one-unmapped-node-lookup.yml
+++ b/test/src/test/resources/fixtures/dynamic service resolution/dynamic-service-resolution-multiple-services-with-one-unmapped-node-lookup.yml
@@ -72,15 +72,16 @@ serviceCalls:
   - serviceName: "IssueService"
     request:
       query: |
-        query {
-          issue: node(id: "issue/id-123") {
+        query ($v0: ID!) {
+          issue: node(id: $v0) {
             id
             ... on Issue {
               issueKey
             }
           }
         }
-      variables: { }
+      variables:
+        v0: "issue/id-123"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/dynamic service resolution/dynamic-service-resolution-multiple-services.yml
+++ b/test/src/test/resources/fixtures/dynamic service resolution/dynamic-service-resolution-multiple-services.yml
@@ -72,15 +72,16 @@ serviceCalls:
   - serviceName: "RepoService"
     request:
       query: |
-        query {
-          pr: node(id: "pull-request:id-123") {
+        query ($v0: ID!) {
+          pr: node(id: $v0) {
             id
             ... on PullRequest {
               description
             }
           }
         }
-      variables: { }
+      variables:
+        v0: "pull-request:id-123"
     # language=JSON
     response: |-
       {
@@ -94,15 +95,16 @@ serviceCalls:
   - serviceName: "IssueService"
     request:
       query: |
-        query {
-          issue: node(id: "issue/id-123") {
+        query ($v0: ID!) {
+          issue: node(id: $v0) {
             id
             ... on Issue {
               issueKey
             }
           }
         }
-      variables: { }
+      variables:
+        v0: "issue/id-123"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/dynamic service resolution/dynamic-service-resolution-simple-success-case.yml
+++ b/test/src/test/resources/fixtures/dynamic service resolution/dynamic-service-resolution-simple-success-case.yml
@@ -48,15 +48,16 @@ serviceCalls:
   - serviceName: "RepoService"
     request:
       query: |
-        query {
-          node(id: "pull-request:id-123") {
+        query ($v0: ID!) {
+          node(id: $v0) {
             id
             ... on PullRequest {
               description
             }
           }
         }
-      variables: { }
+      variables:
+        v0: "pull-request:id-123"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/dynamic service resolution/dynamic-service-resolution-with-no-fragments.yml
+++ b/test/src/test/resources/fixtures/dynamic service resolution/dynamic-service-resolution-with-no-fragments.yml
@@ -63,12 +63,13 @@ serviceCalls:
   - serviceName: "RepoService"
     request:
       query: |
-        query {
-          node(id: "pull-request:id-123") {
+        query ($v0: ID!) {
+          node(id: $v0) {
             id
           }
         }
-      variables: { }
+      variables:
+        v0: "pull-request:id-123"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/dynamic service resolution/typename-is-passed-on-queries-using-dynamic-resolved-services.yml
+++ b/test/src/test/resources/fixtures/dynamic service resolution/typename-is-passed-on-queries-using-dynamic-resolved-services.yml
@@ -49,8 +49,8 @@ serviceCalls:
   - serviceName: "RepoService"
     request:
       query: |
-        query {
-          node(id: "pull-request:id-123") {
+        query ($v0: ID!) {
+          node(id: $v0) {
             __typename
             id
             ... on PullRequest {
@@ -58,7 +58,8 @@ serviceCalls:
             }
           }
         }
-      variables: { }
+      variables:
+        v0: "pull-request:id-123"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/extend type/extending-types-from-another-service-is-possible-with-synthetic-fields.yml
+++ b/test/src/test/resources/fixtures/extend type/extending-types-from-another-service-is-possible-with-synthetic-fields.yml
@@ -115,15 +115,16 @@ serviceCalls:
   - serviceName: "Service2"
     request:
       query: |
-        query {
+        query ($v0: ID) {
           lookUpQuery {
-            lookup(id: "rootId") {
+            lookup(id: $v0) {
               id
               name
             }
           }
         }
-      variables: { }
+      variables:
+        v0: "rootId"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/extend type/extending-types-from-another-service-is-possible.yml
+++ b/test/src/test/resources/fixtures/extend type/extending-types-from-another-service-is-possible.yml
@@ -108,13 +108,14 @@ serviceCalls:
   - serviceName: "Service2"
     request:
       query: |
-        query {
-          lookup(id: "rootId") {
+        query ($v0: ID) {
+          lookup(id: $v0) {
             id
             name
           }
         }
-      variables: { }
+      variables:
+        v0: "rootId"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/extend type/extending-types-via-hydration-returning-a-connection.yml
+++ b/test/src/test/resources/fixtures/extend type/extending-types-via-hydration-returning-a-connection.yml
@@ -120,15 +120,18 @@ serviceCalls:
   - serviceName: "Association"
     request:
       query: |
-        query {
-          association(filter: {name : "value"}, id: "ISSUE-1") {
+        query ($v0: Filter, $v1: ID) {
+          association(filter: $v0, id: $v1) {
             nodes {
               __typename__hydration__page: __typename
               hydration__page__pageId: pageId
             }
           }
         }
-      variables: { }
+      variables:
+        v0:
+          name: "value"
+        v1: "ISSUE-1"
     # language=JSON
     response: |-
       {
@@ -147,14 +150,15 @@ serviceCalls:
   - serviceName: "Association"
     request:
       query: |
-        query {
+        query ($v0: ID) {
           pages {
-            page(id: "1") {
+            page(id: $v0) {
               id
             }
           }
         }
-      variables: { }
+      variables:
+        v0: "1"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/extend type/extending-types-via-hydration-with-arguments-passed-on.yml
+++ b/test/src/test/resources/fixtures/extend type/extending-types-via-hydration-with-arguments-passed-on.yml
@@ -78,12 +78,15 @@ serviceCalls:
   - serviceName: "Association"
     request:
       query: |
-        query {
-          association(filter: {name : "value"}, id: "ISSUE-1") {
+        query ($v0: Filter, $v1: ID) {
+          association(filter: $v0, id: $v1) {
             nameOfAssociation
           }
         }
-      variables: { }
+      variables:
+        v0:
+          name: "value"
+        v1: "ISSUE-1"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/extend type/extending-types-via-hydration-with-variables-arguments.yml
+++ b/test/src/test/resources/fixtures/extend type/extending-types-via-hydration-with-variables-arguments.yml
@@ -81,12 +81,15 @@ serviceCalls:
   - serviceName: "Association"
     request:
       query: |
-        query MyQuery {
-          association(filter: {name : "value"}, id: "ISSUE-1") {
+        query MyQuery($v0: Filter, $v1: ID) {
+          association(filter: $v0, id: $v1) {
             nameOfAssociation
           }
         }
-      variables: { }
+      variables:
+        v0:
+          name: "value"
+        v1: "ISSUE-1"
       operationName: "MyQuery"
     # language=JSON
     response: |-

--- a/test/src/test/resources/fixtures/field removed/all-fields-are-removed-from-hydrated-field.yml
+++ b/test/src/test/resources/fixtures/field removed/all-fields-are-removed-from-hydrated-field.yml
@@ -60,12 +60,13 @@ serviceCalls:
   - serviceName: "CommentService"
     request:
       query: |
-        query nadel_2_CommentService {
-          commentById(id: "C1") {
+        query nadel_2_CommentService($v0: ID) {
+          commentById(id: $v0) {
             authorId
           }
         }
-      variables: { }
+      variables:
+        v0: "C1"
       operationName: "nadel_2_CommentService"
     # language=JSON
     response: |-
@@ -80,12 +81,13 @@ serviceCalls:
   - serviceName: "UserService"
     request:
       query: |
-        query nadel_2_UserService {
-          userById(id: "fred") {
+        query nadel_2_UserService($v0: ID) {
+          userById(id: $v0) {
             empty_selection_set_typename__UUID: __typename
           }
         }
-      variables: { }
+      variables:
+        v0: "fred"
       operationName: "nadel_2_UserService"
     # language=JSON
     response: |-

--- a/test/src/test/resources/fixtures/field removed/all-fields-in-a-selection-set-are-removed.yml
+++ b/test/src/test/resources/fixtures/field removed/all-fields-in-a-selection-set-are-removed.yml
@@ -101,15 +101,16 @@ serviceCalls:
   - serviceName: "IssueService"
     request:
       query: |
-        query nadel_2_IssueService {
-          issueById(id: "I1") {
-            id
+        query nadel_2_IssueService($v0: String) {
+          issueById(id: $v0) {
             epic {
               empty_selection_set_typename__UUID: __typename
             }
+            id
           }
         }
-      variables: { }
+      variables:
+        v0: "I1"
       operationName: "nadel_2_IssueService"
     # language=JSON
     response: |-

--- a/test/src/test/resources/fixtures/field removed/all-non-hydrated-fields-in-query-are-removed.yml
+++ b/test/src/test/resources/fixtures/field removed/all-non-hydrated-fields-in-query-are-removed.yml
@@ -96,12 +96,13 @@ serviceCalls:
   - serviceName: "CommentService"
     request:
       query: |
-        query nadel_2_CommentService {
-          commentById(id: "C1") {
+        query nadel_2_CommentService($v0: ID) {
+          commentById(id: $v0) {
             empty_selection_set_typename__UUID: __typename
           }
         }
-      variables: { }
+      variables:
+        v0: "C1"
       operationName: "nadel_2_CommentService"
     # language=JSON
     response: |-

--- a/test/src/test/resources/fixtures/field removed/field-in-a-selection-set-is-removed.yml
+++ b/test/src/test/resources/fixtures/field removed/field-in-a-selection-set-is-removed.yml
@@ -101,15 +101,16 @@ serviceCalls:
   - serviceName: "IssueService"
     request:
       query: |
-        query nadel_2_IssueService {
-          issueById(id: "I1") {
-            id
+        query nadel_2_IssueService($v0: String) {
+          issueById(id: $v0) {
             epic {
               id
             }
+            id
           }
         }
-      variables: { }
+      variables:
+        v0: "I1"
       operationName: "nadel_2_IssueService"
     # language=JSON
     response: |-

--- a/test/src/test/resources/fixtures/field removed/field-in-non-hydrated-query-is-removed.yml
+++ b/test/src/test/resources/fixtures/field removed/field-in-non-hydrated-query-is-removed.yml
@@ -36,12 +36,13 @@ serviceCalls:
   - serviceName: "CommentService"
     request:
       query: |
-        query nadel_2_CommentService {
-          commentById(id: "C1") {
+        query nadel_2_CommentService($v0: ID) {
+          commentById(id: $v0) {
             id
           }
         }
-      variables: { }
+      variables:
+        v0: "C1"
       operationName: "nadel_2_CommentService"
     # language=JSON
     response: |-

--- a/test/src/test/resources/fixtures/field removed/field-is-removed-from-hydrated-field.yml
+++ b/test/src/test/resources/fixtures/field removed/field-is-removed-from-hydrated-field.yml
@@ -60,12 +60,13 @@ serviceCalls:
   - serviceName: "CommentService"
     request:
       query: |
-        query nadel_2_CommentService {
-          commentById(id: "C1") {
+        query nadel_2_CommentService($v0: ID) {
+          commentById(id: $v0) {
             authorId
           }
         }
-      variables: { }
+      variables:
+        v0: "C1"
       operationName: "nadel_2_CommentService"
     # language=JSON
     response: |-
@@ -80,12 +81,13 @@ serviceCalls:
   - serviceName: "UserService"
     request:
       query: |
-        query nadel_2_UserService {
-          userById(id: "fred") {
+        query nadel_2_UserService($v0: ID) {
+          userById(id: $v0) {
             displayName
           }
         }
-      variables: { }
+      variables:
+        v0: "fred"
       operationName: "nadel_2_UserService"
     # language=JSON
     response: |-

--- a/test/src/test/resources/fixtures/field removed/field-is-removed-from-nested-hydrated-field.yml
+++ b/test/src/test/resources/fixtures/field removed/field-is-removed-from-nested-hydrated-field.yml
@@ -112,12 +112,10 @@ serviceCalls:
       query: |
         query nadel_2_IssueService {
           issues {
-            key
-            summary
-            key
-            summary
-            reporterId
             commentIds
+            key
+            reporterId
+            summary
           }
         }
       variables: { }
@@ -154,12 +152,13 @@ serviceCalls:
   - serviceName: "UserService"
     request:
       query: |
-        query nadel_2_UserService {
-          userById(id: "fred") {
+        query nadel_2_UserService($v0: ID) {
+          userById(id: $v0) {
             displayName
           }
         }
-      variables: { }
+      variables:
+        v0: "fred"
       operationName: "nadel_2_UserService"
     # language=JSON
     response: |-
@@ -174,12 +173,13 @@ serviceCalls:
   - serviceName: "UserService"
     request:
       query: |
-        query nadel_2_UserService {
-          userById(id: "zed") {
+        query nadel_2_UserService($v0: ID) {
+          userById(id: $v0) {
             displayName
           }
         }
-      variables: { }
+      variables:
+        v0: "zed"
       operationName: "nadel_2_UserService"
     # language=JSON
     response: |-
@@ -194,13 +194,14 @@ serviceCalls:
   - serviceName: "CommentService"
     request:
       query: |
-        query nadel_2_CommentService {
-          commentById(id: "C1") {
-            text
+        query nadel_2_CommentService($v0: ID) {
+          commentById(id: $v0) {
             authorId
+            text
           }
         }
-      variables: { }
+      variables:
+        v0: "C1"
       operationName: "nadel_2_CommentService"
     # language=JSON
     response: |-
@@ -216,13 +217,14 @@ serviceCalls:
   - serviceName: "CommentService"
     request:
       query: |
-        query nadel_2_CommentService {
-          commentById(id: "C3") {
-            text
+        query nadel_2_CommentService($v0: ID) {
+          commentById(id: $v0) {
             authorId
+            text
           }
         }
-      variables: { }
+      variables:
+        v0: "C3"
       operationName: "nadel_2_CommentService"
     # language=JSON
     response: |-
@@ -238,13 +240,14 @@ serviceCalls:
   - serviceName: "CommentService"
     request:
       query: |
-        query nadel_2_CommentService {
-          commentById(id: "C5") {
-            text
+        query nadel_2_CommentService($v0: ID) {
+          commentById(id: $v0) {
             authorId
+            text
           }
         }
-      variables: { }
+      variables:
+        v0: "C5"
       operationName: "nadel_2_CommentService"
     # language=JSON
     response: |-
@@ -260,13 +263,14 @@ serviceCalls:
   - serviceName: "CommentService"
     request:
       query: |
-        query nadel_2_CommentService {
-          commentById(id: "C2") {
-            text
+        query nadel_2_CommentService($v0: ID) {
+          commentById(id: $v0) {
             authorId
+            text
           }
         }
-      variables: { }
+      variables:
+        v0: "C2"
       operationName: "nadel_2_CommentService"
     # language=JSON
     response: |-
@@ -282,13 +286,14 @@ serviceCalls:
   - serviceName: "CommentService"
     request:
       query: |
-        query nadel_2_CommentService {
-          commentById(id: "C4") {
-            text
+        query nadel_2_CommentService($v0: ID) {
+          commentById(id: $v0) {
             authorId
+            text
           }
         }
-      variables: { }
+      variables:
+        v0: "C4"
       operationName: "nadel_2_CommentService"
     # language=JSON
     response: |-
@@ -304,13 +309,14 @@ serviceCalls:
   - serviceName: "CommentService"
     request:
       query: |
-        query nadel_2_CommentService {
-          commentById(id: "C6") {
-            text
+        query nadel_2_CommentService($v0: ID) {
+          commentById(id: $v0) {
             authorId
+            text
           }
         }
-      variables: { }
+      variables:
+        v0: "C6"
       operationName: "nadel_2_CommentService"
     # language=JSON
     response: |-
@@ -326,12 +332,13 @@ serviceCalls:
   - serviceName: "UserService"
     request:
       query: |
-        query nadel_2_UserService {
-          userById(id: "fred") {
+        query nadel_2_UserService($v0: ID) {
+          userById(id: $v0) {
             displayName
           }
         }
-      variables: { }
+      variables:
+        v0: "fred"
       operationName: "nadel_2_UserService"
     # language=JSON
     response: |-
@@ -346,12 +353,13 @@ serviceCalls:
   - serviceName: "UserService"
     request:
       query: |
-        query nadel_2_UserService {
-          userById(id: "zed") {
+        query nadel_2_UserService($v0: ID) {
+          userById(id: $v0) {
             displayName
           }
         }
-      variables: { }
+      variables:
+        v0: "zed"
       operationName: "nadel_2_UserService"
     # language=JSON
     response: |-
@@ -366,12 +374,13 @@ serviceCalls:
   - serviceName: "UserService"
     request:
       query: |
-        query nadel_2_UserService {
-          userById(id: "fred") {
+        query nadel_2_UserService($v0: ID) {
+          userById(id: $v0) {
             displayName
           }
         }
-      variables: { }
+      variables:
+        v0: "fred"
       operationName: "nadel_2_UserService"
     # language=JSON
     response: |-
@@ -386,12 +395,13 @@ serviceCalls:
   - serviceName: "UserService"
     request:
       query: |
-        query nadel_2_UserService {
-          userById(id: "ned") {
+        query nadel_2_UserService($v0: ID) {
+          userById(id: $v0) {
             displayName
           }
         }
-      variables: { }
+      variables:
+        v0: "ned"
       operationName: "nadel_2_UserService"
     # language=JSON
     response: |-
@@ -406,12 +416,13 @@ serviceCalls:
   - serviceName: "UserService"
     request:
       query: |
-        query nadel_2_UserService {
-          userById(id: "jed") {
+        query nadel_2_UserService($v0: ID) {
+          userById(id: $v0) {
             displayName
           }
         }
-      variables: { }
+      variables:
+        v0: "jed"
       operationName: "nadel_2_UserService"
     # language=JSON
     response: |-
@@ -426,12 +437,13 @@ serviceCalls:
   - serviceName: "UserService"
     request:
       query: |
-        query nadel_2_UserService {
-          userById(id: "ted") {
+        query nadel_2_UserService($v0: ID) {
+          userById(id: $v0) {
             displayName
           }
         }
-      variables: { }
+      variables:
+        v0: "ted"
       operationName: "nadel_2_UserService"
     # language=JSON
     response: |-

--- a/test/src/test/resources/fixtures/field removed/field-with-selections-is-removed.yml
+++ b/test/src/test/resources/fixtures/field removed/field-with-selections-is-removed.yml
@@ -101,12 +101,13 @@ serviceCalls:
   - serviceName: "IssueService"
     request:
       query: |
-        query nadel_2_IssueService {
-          issueById(id: "I1") {
+        query nadel_2_IssueService($v0: String) {
+          issueById(id: $v0) {
             id
           }
         }
-      variables: { }
+      variables:
+        v0: "I1"
       operationName: "nadel_2_IssueService"
     # language=JSON
     response: |-

--- a/test/src/test/resources/fixtures/field removed/hydrated-field-is-removed.yml
+++ b/test/src/test/resources/fixtures/field removed/hydrated-field-is-removed.yml
@@ -59,12 +59,13 @@ serviceCalls:
   - serviceName: "CommentService"
     request:
       query: |
-        query nadel_2_CommentService {
-          commentById(id: "C1") {
+        query nadel_2_CommentService($v0: ID) {
+          commentById(id: $v0) {
             empty_selection_set_typename__UUID: __typename
           }
         }
-      variables: { }
+      variables:
+        v0: "C1"
       operationName: "nadel_2_CommentService"
     # language=JSON
     response: |-

--- a/test/src/test/resources/fixtures/field removed/nested-hydrated-field-is-removed.yml
+++ b/test/src/test/resources/fixtures/field removed/nested-hydrated-field-is-removed.yml
@@ -101,12 +101,13 @@ serviceCalls:
   - serviceName: "IssueService"
     request:
       query: |
-        query nadel_2_IssueService {
-          issueById(id: "I1") {
+        query nadel_2_IssueService($v0: String) {
+          issueById(id: $v0) {
             commentIds
           }
         }
-      variables: { }
+      variables:
+        v0: "I1"
       operationName: "nadel_2_IssueService"
     # language=JSON
     response: |-
@@ -123,12 +124,13 @@ serviceCalls:
   - serviceName: "CommentService"
     request:
       query: |
-        query nadel_2_CommentService {
-          commentById(id: "C1") {
+        query nadel_2_CommentService($v0: ID) {
+          commentById(id: $v0) {
             empty_selection_set_typename__UUID: __typename
           }
         }
-      variables: { }
+      variables:
+        v0: "C1"
       operationName: "nadel_2_CommentService"
     # language=JSON
     response: |-

--- a/test/src/test/resources/fixtures/field removed/restricted-field-inside-hydration-via-fragments-used-twice.yml
+++ b/test/src/test/resources/fixtures/field removed/restricted-field-inside-hydration-via-fragments-used-twice.yml
@@ -63,16 +63,13 @@ serviceCalls:
       query: |
         query nadel_2_Issues {
           issue {
-            ...IssueFragment
             relatedIssue {
-              ...IssueFragment
+              authorId
+              id
             }
+            authorId
+            id
           }
-        }
-        
-        fragment IssueFragment on Issue {
-          id
-          authorId
         }
       variables: { }
       operationName: "nadel_2_Issues"
@@ -94,13 +91,16 @@ serviceCalls:
   - serviceName: "UserService"
     request:
       query: |
-        query nadel_2_UserService {
-          usersById(id: ["USER-1", "USER-2"]) {
+        query nadel_2_UserService($v0: [ID]) {
+          usersById(id: $v0) {
             id
             object_identifier__UUID: id
           }
         }
-      variables: { }
+      variables:
+        v0:
+          - "USER-1"
+          - "USER-2"
       operationName: "nadel_2_UserService"
     # language=JSON
     response: |-

--- a/test/src/test/resources/fixtures/field removed/restricted-field-via-fragments-used-twice.yml
+++ b/test/src/test/resources/fixtures/field removed/restricted-field-via-fragments-used-twice.yml
@@ -42,15 +42,11 @@ serviceCalls:
       query: |
         query nadel_2_Issues {
           issue {
-            ...IssueFragment
             relatedIssue {
-              ...IssueFragment
+              id
             }
+            id
           }
-        }
-        
-        fragment IssueFragment on Issue {
-          id
         }
       variables: { }
       operationName: "nadel_2_Issues"

--- a/test/src/test/resources/fixtures/field removed/restricted-single-field-inside-hydration-via-fragments-used-twice.yml
+++ b/test/src/test/resources/fixtures/field removed/restricted-single-field-inside-hydration-via-fragments-used-twice.yml
@@ -63,16 +63,13 @@ serviceCalls:
       query: |
         query nadel_2_Issues {
           issue {
-            ...IssueFragment
             relatedIssue {
-              ...IssueFragment
+              authorId
+              id
             }
+            authorId
+            id
           }
-        }
-        
-        fragment IssueFragment on Issue {
-          id
-          authorId
         }
       variables: { }
       operationName: "nadel_2_Issues"
@@ -94,14 +91,17 @@ serviceCalls:
   - serviceName: "UserService"
     request:
       query: |
-        query nadel_2_UserService {
-          usersById(id: ["USER-1", "USER-2"]) {
+        query nadel_2_UserService($v0: [ID]) {
+          usersById(id: $v0) {
             id
-            restricted
             object_identifier__UUID: id
+            restricted
           }
         }
-      variables: { }
+      variables:
+        v0:
+          - "USER-1"
+          - "USER-2"
       operationName: "nadel_2_UserService"
     # language=JSON
     response: |-

--- a/test/src/test/resources/fixtures/field removed/restricted-single-field-via-fragments-used-twice.yml
+++ b/test/src/test/resources/fixtures/field removed/restricted-single-field-via-fragments-used-twice.yml
@@ -42,16 +42,13 @@ serviceCalls:
       query: |
         query nadel_2_Issues {
           issue {
-            ...IssueFragment
             relatedIssue {
-              ...IssueFragment
+              id
+              restricted
             }
+            id
+            restricted
           }
-        }
-        
-        fragment IssueFragment on Issue {
-          id
-          restricted
         }
       variables: { }
       operationName: "nadel_2_Issues"

--- a/test/src/test/resources/fixtures/field removed/the-only-field-in-a-selection-set-is-removed.yml
+++ b/test/src/test/resources/fixtures/field removed/the-only-field-in-a-selection-set-is-removed.yml
@@ -54,15 +54,16 @@ serviceCalls:
   - serviceName: "IssueService"
     request:
       query: |
-        query nadel_2_IssueService {
-          issueById(id: "I1") {
-            id
+        query nadel_2_IssueService($v0: String) {
+          issueById(id: $v0) {
             epic {
               empty_selection_set_typename__UUID: __typename
             }
+            id
           }
         }
-      variables: { }
+      variables:
+        v0: "I1"
       operationName: "nadel_2_IssueService"
     # language=JSON
     response: |-

--- a/test/src/test/resources/fixtures/hydration/able-to-ask-for-field-and-use-same-field-as-hydration-source.yml
+++ b/test/src/test/resources/fixtures/hydration/able-to-ask-for-field-and-use-same-field-as-hydration-source.yml
@@ -65,14 +65,15 @@ serviceCalls:
   - serviceName: "Bar"
     request:
       query: |
-        query {
-          barById(id: "1") {
+        query ($v0: ID) {
+          barById(id: $v0) {
             __typename__hydration__nestedBar: __typename
             hydration__nestedBar__barId: barId
             barId
           }
         }
-      variables: { }
+      variables:
+        v0: "1"
     # language=JSON
     response: |-
       {
@@ -88,12 +89,13 @@ serviceCalls:
   - serviceName: "Bar"
     request:
       query: |
-        query {
-          barById(id: "1") {
+        query ($v0: ID) {
+          barById(id: $v0) {
             barId
           }
         }
-      variables: { }
+      variables:
+        v0: "1"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/hydration/basic-hydration-directive-based.yml
+++ b/test/src/test/resources/fixtures/hydration/basic-hydration-directive-based.yml
@@ -88,12 +88,13 @@ serviceCalls:
   - serviceName: "service2"
     request:
       query: |
-        query {
-          barById(id: "barId") {
+        query ($v0: ID) {
+          barById(id: $v0) {
             name
           }
         }
-      variables: { }
+      variables:
+        v0: "barId"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/hydration/basic-hydration-from-directive-based.yml
+++ b/test/src/test/resources/fixtures/hydration/basic-hydration-from-directive-based.yml
@@ -93,12 +93,13 @@ serviceCalls:
   - serviceName: "service2"
     request:
       query: |
-        query {
-          barById(id: "barId") {
+        query ($v0: ID) {
+          barById(id: $v0) {
             name
           }
         }
-      variables: { }
+      variables:
+        v0: "barId"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/hydration/basic-hydration-with-actor-field-rename.yml
+++ b/test/src/test/resources/fixtures/hydration/basic-hydration-with-actor-field-rename.yml
@@ -76,12 +76,13 @@ serviceCalls:
   - serviceName: "service2"
     request:
       query: |
-        query {
-          rename__barByIdOverall__barById: barById(id: "barId") {
+        query ($v0: ID) {
+          rename__barByIdOverall__barById: barById(id: $v0) {
             name
           }
         }
-      variables: { }
+      variables:
+        v0: "barId"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/hydration/basic-hydration.yml
+++ b/test/src/test/resources/fixtures/hydration/basic-hydration.yml
@@ -76,12 +76,13 @@ serviceCalls:
   - serviceName: "service2"
     request:
       query: |
-        query {
-          barById(id: "barId") {
+        query ($v0: ID) {
+          barById(id: $v0) {
             name
           }
         }
-      variables: { }
+      variables:
+        v0: "barId"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/hydration/batch-hydration-with-renamed-actor-field.yml
+++ b/test/src/test/resources/fixtures/hydration/batch-hydration-with-renamed-actor-field.yml
@@ -74,13 +74,17 @@ serviceCalls:
   - serviceName: "service2"
     request:
       query: |
-        query {
-          rename__barsByIdOverall__barsById: barsById(id: ["barId1", "barId2", "barId3"]) {
+        query ($v0: [ID]) {
+          rename__barsByIdOverall__barsById: barsById(id: $v0) {
             batch_hydration__bar__id: id
             name
           }
         }
-      variables: { }
+      variables:
+        v0:
+          - "barId1"
+          - "barId2"
+          - "barId3"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/hydration/batched-hydration-from-direct-query-with-a-synthetic-field.yml
+++ b/test/src/test/resources/fixtures/hydration/batched-hydration-from-direct-query-with-a-synthetic-field.yml
@@ -114,15 +114,19 @@ serviceCalls:
   - serviceName: "service2"
     request:
       query: |
-        query {
+        query ($v0: [ID]) {
           users {
-            usersByIds(id: ["USER-2", "USER-4", "USER-5"]) {
+            usersByIds(id: $v0) {
               id
               batch_hydration__authors__id: id
             }
           }
         }
-      variables: { }
+      variables:
+        v0:
+          - "USER-2"
+          - "USER-4"
+          - "USER-5"
     # language=JSON
     response: |-
       {
@@ -149,15 +153,19 @@ serviceCalls:
   - serviceName: "service2"
     request:
       query: |
-        query {
+        query ($v0: [ID]) {
           users {
-            usersByIds(id: ["USER-1", "USER-2", "USER-3"]) {
+            usersByIds(id: $v0) {
               id
               batch_hydration__authors__id: id
             }
           }
         }
-      variables: { }
+      variables:
+        v0:
+          - "USER-1"
+          - "USER-2"
+          - "USER-3"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/hydration/batched-hydration-query-with-a-synthetic-field.yml
+++ b/test/src/test/resources/fixtures/hydration/batched-hydration-query-with-a-synthetic-field.yml
@@ -103,15 +103,19 @@ serviceCalls:
   - serviceName: "service2"
     request:
       query: |
-        query {
+        query ($v0: [ID]) {
           users {
-            usersByIds(id: ["USER-2", "USER-4", "USER-5"]) {
+            usersByIds(id: $v0) {
               id
               batch_hydration__authors__id: id
             }
           }
         }
-      variables: { }
+      variables:
+        v0:
+          - "USER-2"
+          - "USER-4"
+          - "USER-5"
     # language=JSON
     response: |-
       {
@@ -138,15 +142,19 @@ serviceCalls:
   - serviceName: "service2"
     request:
       query: |
-        query {
+        query ($v0: [ID]) {
           users {
-            usersByIds(id: ["USER-1", "USER-2", "USER-3"]) {
+            usersByIds(id: $v0) {
               id
               batch_hydration__authors__id: id
             }
           }
         }
-      variables: { }
+      variables:
+        v0:
+          - "USER-1"
+          - "USER-2"
+          - "USER-3"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/hydration/batching-of-hydration-list-with-flattened-arguments.yml
+++ b/test/src/test/resources/fixtures/hydration/batching-of-hydration-list-with-flattened-arguments.yml
@@ -111,13 +111,17 @@ serviceCalls:
   - serviceName: "UserService"
     request:
       query: |
-        query {
-          usersByIds(id: ["USER-1", "USER-2", "USER-3"]) {
+        query ($v0: [ID]) {
+          usersByIds(id: $v0) {
             id
             batch_hydration__authors__id: id
           }
         }
-      variables: { }
+      variables:
+        v0:
+          - "USER-1"
+          - "USER-2"
+          - "USER-3"
     # language=JSON
     response: |-
       {
@@ -142,13 +146,17 @@ serviceCalls:
   - serviceName: "UserService"
     request:
       query: |
-        query {
-          usersByIds(id: ["USER-2", "USER-4", "USER-5"]) {
+        query ($v0: [ID]) {
+          usersByIds(id: $v0) {
             id
             batch_hydration__authors__id: id
           }
         }
-      variables: { }
+      variables:
+        v0:
+          - "USER-2"
+          - "USER-4"
+          - "USER-5"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/hydration/batching-of-hydration-list-with-partition.yml
+++ b/test/src/test/resources/fixtures/hydration/batching-of-hydration-list-with-partition.yml
@@ -91,13 +91,16 @@ serviceCalls:
   - serviceName: "UserService"
     request:
       query: |
-        query {
-          usersByIds(id: ["CLOUD-ID-1/USER-1", "CLOUD-ID-1/USER-3"]) {
+        query ($v0: [ID]) {
+          usersByIds(id: $v0) {
             id
             batch_hydration__authors__id: id
           }
         }
-      variables: { }
+      variables:
+        v0:
+          - "CLOUD-ID-1/USER-1"
+          - "CLOUD-ID-1/USER-3"
     # language=JSON
     response: |-
       {
@@ -118,13 +121,15 @@ serviceCalls:
   - serviceName: "UserService"
     request:
       query: |
-        query {
-          usersByIds(id: ["CLOUD-ID-1/USER-5"]) {
+        query ($v0: [ID]) {
+          usersByIds(id: $v0) {
             id
             batch_hydration__authors__id: id
           }
         }
-      variables: { }
+      variables:
+        v0:
+          - "CLOUD-ID-1/USER-5"
     # language=JSON
     response: |-
       {
@@ -141,13 +146,16 @@ serviceCalls:
   - serviceName: "UserService"
     request:
       query: |
-        query {
-          usersByIds(id: ["CLOUD-ID-2/USER-2", "CLOUD-ID-2/USER-4"]) {
+        query ($v0: [ID]) {
+          usersByIds(id: $v0) {
             id
             batch_hydration__authors__id: id
           }
         }
-      variables: { }
+      variables:
+        v0:
+          - "CLOUD-ID-2/USER-2"
+          - "CLOUD-ID-2/USER-4"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/hydration/batching-of-hydration-list.yml
+++ b/test/src/test/resources/fixtures/hydration/batching-of-hydration-list.yml
@@ -92,13 +92,17 @@ serviceCalls:
   - serviceName: "UserService"
     request:
       query: |
-        query {
-          usersByIds(id: ["USER-1", "USER-2", "USER-3"]) {
+        query ($v0: [ID]) {
+          usersByIds(id: $v0) {
             id
             batch_hydration__authors__id: id
           }
         }
-      variables: { }
+      variables:
+        v0:
+          - "USER-1"
+          - "USER-2"
+          - "USER-3"
     # language=JSON
     response: |-
       {
@@ -123,13 +127,17 @@ serviceCalls:
   - serviceName: "UserService"
     request:
       query: |
-        query {
-          usersByIds(id: ["USER-2", "USER-4", "USER-5"]) {
+        query ($v0: [ID]) {
+          usersByIds(id: $v0) {
             id
             batch_hydration__authors__id: id
           }
         }
-      variables: { }
+      variables:
+        v0:
+          - "USER-2"
+          - "USER-4"
+          - "USER-5"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/hydration/can-generate-legacy-operation-name-on-batch-hydration-for-specific-service.yml
+++ b/test/src/test/resources/fixtures/hydration/can-generate-legacy-operation-name-on-batch-hydration-for-specific-service.yml
@@ -74,13 +74,17 @@ serviceCalls:
   - serviceName: "service2"
     request:
       query: |
-        query nadel_2_service2 {
-          barsById(id: ["barId1", "barId2", "barId3"]) {
+        query nadel_2_service2($v0: [ID]) {
+          barsById(id: $v0) {
             batch_hydration__bar__id: id
             name
           }
         }
-      variables: { }
+      variables:
+        v0:
+          - "barId1"
+          - "barId2"
+          - "barId3"
       operationName: "nadel_2_service2"
     # language=JSON
     response: |-

--- a/test/src/test/resources/fixtures/hydration/can-generate-legacy-operation-name-on-batch-hydration.yml
+++ b/test/src/test/resources/fixtures/hydration/can-generate-legacy-operation-name-on-batch-hydration.yml
@@ -75,13 +75,17 @@ serviceCalls:
   - serviceName: "service2"
     request:
       query: |
-        query nadel_2_service2 {
-          barsById(id: ["barId1", "barId2", "barId3"]) {
+        query nadel_2_service2($v0: [ID]) {
+          barsById(id: $v0) {
             batch_hydration__bar__id: id
             name
           }
         }
-      variables: { }
+      variables:
+        v0:
+          - "barId1"
+          - "barId2"
+          - "barId3"
       operationName: "nadel_2_service2"
     # language=JSON
     response: |-

--- a/test/src/test/resources/fixtures/hydration/can-generate-legacy-operation-name-on-hydration.yml
+++ b/test/src/test/resources/fixtures/hydration/can-generate-legacy-operation-name-on-hydration.yml
@@ -77,12 +77,13 @@ serviceCalls:
   - serviceName: "service2"
     request:
       query: |
-        query nadel_2_service2_TestFoo {
-          barById(id: "barId") {
+        query nadel_2_service2_TestFoo($v0: ID) {
+          barById(id: $v0) {
             name
           }
         }
-      variables: { }
+      variables:
+        v0: "barId"
       operationName: "nadel_2_service2_TestFoo"
     # language=JSON
     response: |-

--- a/test/src/test/resources/fixtures/hydration/complex identified by/complex-identified-by-hydration-batching-returns-null-batch.yml
+++ b/test/src/test/resources/fixtures/hydration/complex identified by/complex-identified-by-hydration-batching-returns-null-batch.yml
@@ -79,13 +79,17 @@ serviceCalls:
   - serviceName: "service2"
     request:
       query: |
-        query {
-          barsById(id: ["barId1", "barId2", "barId3"]) {
+        query ($v0: [ID]) {
+          barsById(id: $v0) {
             batch_hydration__bar__id: id
             name
           }
         }
-      variables: { }
+      variables:
+        v0:
+          - "barId1"
+          - "barId2"
+          - "barId3"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/hydration/complex identified by/complex-identified-by-uses-same-source-for-2-hydrations-and-a-deep-rename.yml
+++ b/test/src/test/resources/fixtures/hydration/complex identified by/complex-identified-by-uses-same-source-for-2-hydrations-and-a-deep-rename.yml
@@ -29,7 +29,7 @@ overallSchema:
       name: String
     }
     type Issue {
-      fooId: ID
+      issueId: ID
       field: String
     }
 underlyingSchema:
@@ -47,7 +47,7 @@ underlyingSchema:
 
     type Issue {
       field: String
-      fooId: ID
+      issueId: ID
     }
 
     type Query {
@@ -127,13 +127,16 @@ serviceCalls:
   - serviceName: "Foo"
     request:
       query: |
-        query {
-          issues(issueIds: ["Foo-1", "Foo-2"]) {
-            batch_hydration__issue__issueId: issueId
+        query ($v0: [ID]) {
+          issues(issueIds: $v0) {
             field
+            batch_hydration__issue__issueId: issueId
           }
         }
-      variables: { }
+      variables:
+        v0:
+          - "Foo-1"
+          - "Foo-2"
     # language=JSON
     response: |-
       {
@@ -154,13 +157,15 @@ serviceCalls:
   - serviceName: "Foo"
     request:
       query: |
-        query {
-          issues(issueIds: ["Foo-3"]) {
-            batch_hydration__issue__issueId: issueId
+        query ($v0: [ID]) {
+          issues(issueIds: $v0) {
             field
+            batch_hydration__issue__issueId: issueId
           }
         }
-      variables: { }
+      variables:
+        v0:
+          - "Foo-3"
     # language=JSON
     response: |-
       {
@@ -177,13 +182,16 @@ serviceCalls:
   - serviceName: "Foo"
     request:
       query: |
-        query {
-          details(detailIds: ["Foo-1", "Foo-2"]) {
+        query ($v0: [ID]) {
+          details(detailIds: $v0) {
             batch_hydration__detail__detailId: detailId
             name
           }
         }
-      variables: { }
+      variables:
+        v0:
+          - "Foo-1"
+          - "Foo-2"
     # language=JSON
     response: |-
       {
@@ -204,13 +212,15 @@ serviceCalls:
   - serviceName: "Foo"
     request:
       query: |
-        query {
-          details(detailIds: ["Foo-4"]) {
+        query ($v0: [ID]) {
+          details(detailIds: $v0) {
             batch_hydration__detail__detailId: detailId
             name
           }
         }
-      variables: { }
+      variables:
+        v0:
+          - "Foo-4"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/hydration/complex identified by/complex-identified-by-uses-same-source-for-2-hydrations.yml
+++ b/test/src/test/resources/fixtures/hydration/complex identified by/complex-identified-by-uses-same-source-for-2-hydrations.yml
@@ -28,7 +28,7 @@ overallSchema:
       name: String
     }
     type Issue {
-      fooId: ID
+      issueId: ID
       field: String
     }
 underlyingSchema:
@@ -46,7 +46,7 @@ underlyingSchema:
 
     type Issue {
       field: String
-      fooId: ID
+      issueId: ID
     }
 
     type Query {
@@ -109,13 +109,16 @@ serviceCalls:
   - serviceName: "Foo"
     request:
       query: |
-        query {
-          issues(issueIds: ["Foo-1", "Foo-2"]) {
-            batch_hydration__issue__issueId: issueId
+        query ($v0: [ID]) {
+          issues(issueIds: $v0) {
             field
+            batch_hydration__issue__issueId: issueId
           }
         }
-      variables: { }
+      variables:
+        v0:
+          - "Foo-1"
+          - "Foo-2"
     # language=JSON
     response: |-
       {
@@ -136,13 +139,15 @@ serviceCalls:
   - serviceName: "Foo"
     request:
       query: |
-        query {
-          issues(issueIds: ["Foo-3"]) {
-            batch_hydration__issue__issueId: issueId
+        query ($v0: [ID]) {
+          issues(issueIds: $v0) {
             field
+            batch_hydration__issue__issueId: issueId
           }
         }
-      variables: { }
+      variables:
+        v0:
+          - "Foo-3"
     # language=JSON
     response: |-
       {
@@ -159,13 +164,16 @@ serviceCalls:
   - serviceName: "Foo"
     request:
       query: |
-        query {
-          details(detailIds: ["Foo-1", "Foo-2"]) {
+        query ($v0: [ID]) {
+          details(detailIds: $v0) {
             batch_hydration__detail__detailId: detailId
             name
           }
         }
-      variables: { }
+      variables:
+        v0:
+          - "Foo-1"
+          - "Foo-2"
     # language=JSON
     response: |-
       {
@@ -186,13 +194,15 @@ serviceCalls:
   - serviceName: "Foo"
     request:
       query: |
-        query {
-          details(detailIds: ["Foo-4"]) {
+        query ($v0: [ID]) {
+          details(detailIds: $v0) {
             batch_hydration__detail__detailId: detailId
             name
           }
         }
-      variables: { }
+      variables:
+        v0:
+          - "Foo-4"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/hydration/complex identified by/complex-identified-by-with-list-source-id.yml
+++ b/test/src/test/resources/fixtures/hydration/complex identified by/complex-identified-by-with-list-source-id.yml
@@ -144,15 +144,22 @@ serviceCalls:
   - serviceName: "UserService"
     request:
       query: |
-        query {
-          users(id: [{site : "hello", userId : "USER-1"}, {site : "hello", userId : "USER-2"}, {site : "hello", userId : "USER-3"}]) {
+        query ($v0: [UserInput]) {
+          users(id: $v0) {
             id
             batch_hydration__authors__id: id
             name
             batch_hydration__authors__siteId: siteId
           }
         }
-      variables: { }
+      variables:
+        v0:
+          - userId: "USER-1"
+            site: "hello"
+          - userId: "USER-2"
+            site: "hello"
+          - userId: "USER-3"
+            site: "hello"
     # language=JSON
     response: |-
       {
@@ -183,15 +190,22 @@ serviceCalls:
   - serviceName: "UserService"
     request:
       query: |
-        query {
-          users(id: [{site : "jdog", userId : "USER-2"}, {site : "hello", userId : "USER-4"}, {site : "hello", userId : "USER-5"}]) {
+        query ($v0: [UserInput]) {
+          users(id: $v0) {
             id
             batch_hydration__authors__id: id
             name
             batch_hydration__authors__siteId: siteId
           }
         }
-      variables: { }
+      variables:
+        v0:
+          - userId: "USER-2"
+            site: "jdog"
+          - userId: "USER-4"
+            site: "hello"
+          - userId: "USER-5"
+            site: "hello"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/hydration/complex identified by/complex-identified-by-with-rename.yml
+++ b/test/src/test/resources/fixtures/hydration/complex identified by/complex-identified-by-with-rename.yml
@@ -1,4 +1,4 @@
-name: "complex-identified-by-with-rename"
+name: "complex identified by with rename"
 enabled: true
 overallSchema:
   UserService: |
@@ -157,21 +157,21 @@ serviceCalls:
     request:
       query: |
         query ($v0: [UserInputUnderlying]) {
-            users(id: $v0) {
-              id
-              name
-              batch_hydration__author__id: id
-              batch_hydration__author__siteId: siteId
+          users(id: $v0) {
+            id
+            batch_hydration__author__id: id
+            name
+            batch_hydration__author__siteId: siteId
           }
         }
       variables:
         v0:
-          - site: "hello"
-            userId: "USER-5"
-          - site: "jdog"
-            userId: "USER-2"
-          - site: "hello"
-            userId: "USER-2"
+          - userId: "USER-5"
+            site: "hello"
+          - userId: "USER-2"
+            site: "jdog"
+          - userId: "USER-2"
+            site: "hello"
     # language=JSON
     response: |-
       {
@@ -203,23 +203,23 @@ serviceCalls:
     request:
       query: |
         query ($v0: [UserInputUnderlying]) {
-            users(id: $v0) {
-              id
-              name
-              batch_hydration__author__id: id
-              batch_hydration__author__siteId: siteId
+          users(id: $v0) {
+            id
+            batch_hydration__author__id: id
+            name
+            batch_hydration__author__siteId: siteId
           }
         }
       variables:
         v0:
-          - site: "hello"
-            userId: "USER-1"
-          - site: "hello"
-            userId: "USER-3"
-          - site: "jdog"
-            userId: "USER-2"
-          - site: "hello"
-            userId: "USER-4"
+          - userId: "USER-1"
+            site: "hello"
+          - userId: "USER-3"
+            site: "hello"
+          - userId: "USER-2"
+            site: "jdog"
+          - userId: "USER-4"
+            site: "hello"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/hydration/complex identified by/complex-identified-by-with-some-null-source-ids.yml
+++ b/test/src/test/resources/fixtures/hydration/complex identified by/complex-identified-by-with-some-null-source-ids.yml
@@ -136,15 +136,22 @@ serviceCalls:
   - serviceName: "UserService"
     request:
       query: |
-        query {
-          users(id: [{site : "hello", userId : "USER-2"}, {site : "hello", userId : "USER-3"}, {site : "jdog", userId : "USER-2"}]) {
+        query ($v0: [UserInput]) {
+          users(id: $v0) {
             id
             batch_hydration__authors__id: id
             name
             batch_hydration__authors__siteId: siteId
           }
         }
-      variables: { }
+      variables:
+        v0:
+          - userId: "USER-2"
+            site: "hello"
+          - userId: "USER-3"
+            site: "hello"
+          - userId: "USER-2"
+            site: "jdog"
     # language=JSON
     response: |-
       {
@@ -175,15 +182,18 @@ serviceCalls:
   - serviceName: "UserService"
     request:
       query: |
-        query {
-          users(id: [{site : "hello", userId : "USER-5"}]) {
+        query ($v0: [UserInput]) {
+          users(id: $v0) {
             id
             batch_hydration__authors__id: id
             name
             batch_hydration__authors__siteId: siteId
           }
         }
-      variables: { }
+      variables:
+        v0:
+          - userId: "USER-5"
+            site: "hello"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/hydration/complex identified by/complex-identified-by.yml
+++ b/test/src/test/resources/fixtures/hydration/complex identified by/complex-identified-by.yml
@@ -156,15 +156,22 @@ serviceCalls:
   - serviceName: "UserService"
     request:
       query: |
-        query {
-          users(id: [{site : "hello", userId : "USER-5"}, {site : "jdog", userId : "USER-2"}, {site : "hello", userId : "USER-2"}]) {
+        query ($v0: [UserInput]) {
+          users(id: $v0) {
             id
-            name
             batch_hydration__author__id: id
+            name
             batch_hydration__author__siteId: siteId
           }
         }
-      variables: { }
+      variables:
+        v0:
+          - userId: "USER-5"
+            site: "hello"
+          - userId: "USER-2"
+            site: "jdog"
+          - userId: "USER-2"
+            site: "hello"
     # language=JSON
     response: |-
       {
@@ -195,15 +202,24 @@ serviceCalls:
   - serviceName: "UserService"
     request:
       query: |
-        query {
-          users(id: [{site : "hello", userId : "USER-1"}, {site : "hello", userId : "USER-3"}, {site : "jdog", userId : "USER-2"}, {site : "hello", userId : "USER-4"}]) {
+        query ($v0: [UserInput]) {
+          users(id: $v0) {
             id
-            name
             batch_hydration__author__id: id
+            name
             batch_hydration__author__siteId: siteId
           }
         }
-      variables: { }
+      variables:
+        v0:
+          - userId: "USER-1"
+            site: "hello"
+          - userId: "USER-3"
+            site: "hello"
+          - userId: "USER-2"
+            site: "jdog"
+          - userId: "USER-4"
+            site: "hello"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/hydration/expecting-one-child-error-on-extensive-field-argument-passed-to-hydration.yml
+++ b/test/src/test/resources/fixtures/hydration/expecting-one-child-error-on-extensive-field-argument-passed-to-hydration.yml
@@ -69,8 +69,8 @@ serviceCalls:
   - serviceName: "TestBoard"
     request:
       query: |
-        query {
-          board(id: 1) {
+        query ($v0: ID) {
+          board(id: $v0) {
             __typename__rename__cardChildren: __typename
             id
             rename__cardChildren__issueChildren: issueChildren {
@@ -84,7 +84,8 @@ serviceCalls:
             }
           }
         }
-      variables: { }
+      variables:
+        v0: 1
     # language=JSON
     response: |-
       {
@@ -128,13 +129,17 @@ serviceCalls:
   - serviceName: "Users"
     request:
       query: |
-        query {
-          users(accountIds: ["1", "2", "3"]) {
+        query ($v0: [ID]) {
+          users(accountIds: $v0) {
             accountId
             batch_hydration__assignee__accountId: accountId
           }
         }
-      variables: { }
+      variables:
+        v0:
+          - "1"
+          - "2"
+          - "3"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/hydration/expecting-one-child-error-on-extensive-field-argument-passed-to-synthetic-hydration.yml
+++ b/test/src/test/resources/fixtures/hydration/expecting-one-child-error-on-extensive-field-argument-passed-to-synthetic-hydration.yml
@@ -75,8 +75,8 @@ serviceCalls:
   - serviceName: "TestBoard"
     request:
       query: |
-        query {
-          board(id: 1) {
+        query ($v0: ID) {
+          board(id: $v0) {
             __typename__rename__cardChildren: __typename
             id
             rename__cardChildren__issueChildren: issueChildren {
@@ -89,7 +89,8 @@ serviceCalls:
             }
           }
         }
-      variables: { }
+      variables:
+        v0: 1
     # language=JSON
     response: |-
       {
@@ -130,15 +131,19 @@ serviceCalls:
   - serviceName: "Users"
     request:
       query: |
-        query {
+        query ($v0: [ID]) {
           usersQuery {
-            users(accountIds: ["1", "2", "3"]) {
+            users(accountIds: $v0) {
               accountId
               batch_hydration__assignee__accountId: accountId
             }
           }
         }
-      variables: { }
+      variables:
+        v0:
+          - "1"
+          - "2"
+          - "3"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/hydration/hydration-batching-returns-null.yml
+++ b/test/src/test/resources/fixtures/hydration/hydration-batching-returns-null.yml
@@ -74,13 +74,17 @@ serviceCalls:
   - serviceName: "service2"
     request:
       query: |
-        query {
-          barsById(id: ["barId1", "barId2", "barId3"]) {
+        query ($v0: [ID]) {
+          barsById(id: $v0) {
             batch_hydration__bar__id: id
             name
           }
         }
-      variables: { }
+      variables:
+        v0:
+          - "barId1"
+          - "barId2"
+          - "barId3"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/hydration/hydration-call-forwards-error.yml
+++ b/test/src/test/resources/fixtures/hydration/hydration-call-forwards-error.yml
@@ -70,12 +70,13 @@ serviceCalls:
   - serviceName: "service2"
     request:
       query: |
-        query {
-          barById(id: "barId1") {
+        query ($v0: ID) {
+          barById(id: $v0) {
             name
           }
         }
-      variables: { }
+      variables:
+        v0: "barId1"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/hydration/hydration-call-over-itself-with-renamed-types.yml
+++ b/test/src/test/resources/fixtures/hydration/hydration-call-over-itself-with-renamed-types.yml
@@ -106,14 +106,17 @@ serviceCalls:
   - serviceName: "testing"
     request:
       query: |
-        query {
-          characters(ids: ["C2", "C3"]) {
+        query ($v0: [ID!]!) {
+          characters(ids: $v0) {
             id
             batch_hydration__characters__id: id
             name
           }
         }
-      variables: { }
+      variables:
+        v0:
+          - "C2"
+          - "C3"
     # language=JSON
     response: |-
       {
@@ -136,14 +139,18 @@ serviceCalls:
   - serviceName: "testing"
     request:
       query: |
-        query {
-          characters(ids: ["C1", "C2", "C1"]) {
+        query ($v0: [ID!]!) {
+          characters(ids: $v0) {
             id
             batch_hydration__characters__id: id
             name
           }
         }
-      variables: { }
+      variables:
+        v0:
+          - "C1"
+          - "C2"
+          - "C1"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/hydration/hydration-call-with-argument-value-from-original-field-argument.yml
+++ b/test/src/test/resources/fixtures/hydration/hydration-call-with-argument-value-from-original-field-argument.yml
@@ -84,13 +84,16 @@ serviceCalls:
   - serviceName: "UserService"
     request:
       query: |
-        query {
-          usersByIds(extraArg: "extraArg", id: ["USER-1"]) {
+        query ($v0: String, $v1: [ID]) {
+          usersByIds(extraArg: $v0, id: $v1) {
             batch_hydration__author__id: id
             name
           }
         }
-      variables: { }
+      variables:
+        v0: "extraArg"
+        v1:
+          - "USER-1"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/hydration/hydration-call-with-fragments-in-the-hydrated-part-and-synthetic-field.yml
+++ b/test/src/test/resources/fixtures/hydration/hydration-call-with-fragments-in-the-hydrated-part-and-synthetic-field.yml
@@ -87,15 +87,17 @@ serviceCalls:
   - serviceName: "UserService"
     request:
       query: |
-        query {
+        query ($v0: [ID]) {
           userQuery {
-            usersByIds(id: ["USER-1"]) {
+            usersByIds(id: $v0) {
               id
               name
             }
           }
         }
-      variables: { }
+      variables:
+        v0:
+          - "USER-1"
     # language=JSON
     response: |-
       {
@@ -148,16 +150,19 @@ serviceCalls:
   - serviceName: "UserService"
     request:
       query: |
-        query {
+        query ($v0: [ID]) {
           userQuery {
-            usersByIds(id: ["USER-1", "USER-2"]) {
+            usersByIds(id: $v0) {
               id
               batch_hydration__authors__id: id
               name
             }
           }
         }
-      variables: { }
+      variables:
+        v0:
+          - "USER-1"
+          - "USER-2"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/hydration/hydration-call-with-fragments-in-the-hydrated-part.yml
+++ b/test/src/test/resources/fixtures/hydration/hydration-call-with-fragments-in-the-hydrated-part.yml
@@ -78,13 +78,15 @@ serviceCalls:
   - serviceName: "UserService"
     request:
       query: |
-        query {
-          usersByIds(id: ["USER-1"]) {
+        query ($v0: [ID]) {
+          usersByIds(id: $v0) {
             id
             name
           }
         }
-      variables: { }
+      variables:
+        v0:
+          - "USER-1"
     # language=JSON
     response: |-
       {
@@ -135,14 +137,17 @@ serviceCalls:
   - serviceName: "UserService"
     request:
       query: |
-        query {
-          usersByIds(id: ["USER-1", "USER-2"]) {
+        query ($v0: [ID]) {
+          usersByIds(id: $v0) {
             id
             batch_hydration__authors__id: id
             name
           }
         }
-      variables: { }
+      variables:
+        v0:
+          - "USER-1"
+          - "USER-2"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/hydration/hydration-call-with-two-argument-values-from-original-field-arguments.yml
+++ b/test/src/test/resources/fixtures/hydration/hydration-call-with-two-argument-values-from-original-field-arguments.yml
@@ -85,13 +85,17 @@ serviceCalls:
   - serviceName: "UserService"
     request:
       query: |
-        query {
-          usersByIds(extraArg1: "extraArg1", extraArg2: 10, id: ["USER-1"]) {
+        query ($v0: String, $v1: Int, $v2: [ID]) {
+          usersByIds(extraArg1: $v0, extraArg2: $v1, id: $v2) {
             batch_hydration__author__id: id
             name
           }
         }
-      variables: { }
+      variables:
+        v0: "extraArg1"
+        v1: 10
+        v2:
+          - "USER-1"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/hydration/hydration-from-field-in-interface-with-type-rename.yml
+++ b/test/src/test/resources/fixtures/hydration/hydration-from-field-in-interface-with-type-rename.yml
@@ -61,8 +61,8 @@ serviceCalls:
   - serviceName: "issues"
     request:
       query: |
-        query {
-          issue(id: "1") {
+        query ($v0: ID) {
+          issue(id: $v0) {
             __typename__hydration__issueAuthor: __typename
             hydration__issueAuthor__author: author {
               userId
@@ -70,7 +70,8 @@ serviceCalls:
             title
           }
         }
-      variables: { }
+      variables:
+        v0: "1"
     # language=JSON
     response: |-
       {
@@ -88,12 +89,13 @@ serviceCalls:
   - serviceName: "users"
     request:
       query: |
-        query {
-          user(id: "1001") {
+        query ($v0: ID!) {
+          user(id: $v0) {
             name
           }
         }
-      variables: { }
+      variables:
+        v0: "1001"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/hydration/hydration-from-field-in-interface.yml
+++ b/test/src/test/resources/fixtures/hydration/hydration-from-field-in-interface.yml
@@ -61,8 +61,8 @@ serviceCalls:
   - serviceName: "issues"
     request:
       query: |
-        query {
-          issue(id: "1") {
+        query ($v0: ID) {
+          issue(id: $v0) {
             __typename__hydration__issueAuthor: __typename
             hydration__issueAuthor__author: author {
               userId
@@ -70,7 +70,8 @@ serviceCalls:
             title
           }
         }
-      variables: { }
+      variables:
+        v0: "1"
     # language=JSON
     response: |-
       {
@@ -88,12 +89,13 @@ serviceCalls:
   - serviceName: "users"
     request:
       query: |
-        query {
-          user(id: "1001") {
+        query ($v0: ID!) {
+          user(id: $v0) {
             name
           }
         }
-      variables: { }
+      variables:
+        v0: "1001"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/hydration/hydration-inside-a-renamed-field.yml
+++ b/test/src/test/resources/fixtures/hydration/hydration-inside-a-renamed-field.yml
@@ -71,12 +71,13 @@ serviceCalls:
   - serviceName: "Bar"
     request:
       query: |
-        query {
-          barById(id: "hydrated-bar") {
+        query ($v0: ID!) {
+          barById(id: $v0) {
             id
           }
         }
-      variables: { }
+      variables:
+        v0: "hydrated-bar"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/hydration/hydration-list-input.yml
+++ b/test/src/test/resources/fixtures/hydration/hydration-list-input.yml
@@ -75,13 +75,14 @@ serviceCalls:
   - serviceName: "service2"
     request:
       query: |
-        query {
-          barById(id: "barId1") {
+        query ($v0: ID) {
+          barById(id: $v0) {
             id
             name
           }
         }
-      variables: { }
+      variables:
+        v0: "barId1"
     # language=JSON
     response: |-
       {
@@ -96,13 +97,14 @@ serviceCalls:
   - serviceName: "service2"
     request:
       query: |
-        query {
-          barById(id: "barId3") {
+        query ($v0: ID) {
+          barById(id: $v0) {
             id
             name
           }
         }
-      variables: { }
+      variables:
+        v0: "barId3"
     # language=JSON
     response: |-
       {
@@ -117,13 +119,14 @@ serviceCalls:
   - serviceName: "service2"
     request:
       query: |
-        query {
-          barById(id: "barId2") {
+        query ($v0: ID) {
+          barById(id: $v0) {
             id
             name
           }
         }
-      variables: { }
+      variables:
+        v0: "barId2"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/hydration/hydration-list-with-batching-forwards-error.yml
+++ b/test/src/test/resources/fixtures/hydration/hydration-list-with-batching-forwards-error.yml
@@ -74,13 +74,17 @@ serviceCalls:
   - serviceName: "service2"
     request:
       query: |
-        query {
-          barsById(id: ["barId1", "barId2", "barId3"]) {
+        query ($v0: [ID]) {
+          barsById(id: $v0) {
             batch_hydration__bar__id: id
             name
           }
         }
-      variables: { }
+      variables:
+        v0:
+          - "barId1"
+          - "barId2"
+          - "barId3"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/hydration/hydration-list-with-batching.yml
+++ b/test/src/test/resources/fixtures/hydration/hydration-list-with-batching.yml
@@ -74,13 +74,17 @@ serviceCalls:
   - serviceName: "service2"
     request:
       query: |
-        query {
-          barsById(id: ["barId1", "barId2", "barId3"]) {
+        query ($v0: [ID]) {
+          barsById(id: $v0) {
             batch_hydration__bar__id: id
             name
           }
         }
-      variables: { }
+      variables:
+        v0:
+          - "barId1"
+          - "barId2"
+          - "barId3"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/hydration/hydration-list-with-one-element.yml
+++ b/test/src/test/resources/fixtures/hydration/hydration-list-with-one-element.yml
@@ -73,13 +73,14 @@ serviceCalls:
   - serviceName: "service2"
     request:
       query: |
-        query {
-          barById(id: "barId1") {
+        query ($v0: ID) {
+          barById(id: $v0) {
             id
             name
           }
         }
-      variables: { }
+      variables:
+        v0: "barId1"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/hydration/hydration-with-interfaces-asking-typename.yml
+++ b/test/src/test/resources/fixtures/hydration/hydration-with-interfaces-asking-typename.yml
@@ -81,10 +81,11 @@ serviceCalls:
   - serviceName: "Issues"
     request:
       query: |
-        query {
-          ariById(id: "ari:i-always-forget-the-format/1")
+        query ($v0: ID!) {
+          ariById(id: $v0)
         }
-      variables: { }
+      variables:
+        v0: "ari:i-always-forget-the-format/1"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/hydration/hydration-with-interfaces.yml
+++ b/test/src/test/resources/fixtures/hydration/hydration-with-interfaces.yml
@@ -77,10 +77,11 @@ serviceCalls:
   - serviceName: "Issues"
     request:
       query: |
-        query {
-          idByAri(id: "ari:i-always-forget-the-format/1")
+        query ($v0: ID!) {
+          idByAri(id: $v0)
         }
-      variables: { }
+      variables:
+        v0: "ari:i-always-forget-the-format/1"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/hydration/hydration-with-more-interfaces.yml
+++ b/test/src/test/resources/fixtures/hydration/hydration-with-more-interfaces.yml
@@ -96,10 +96,11 @@ serviceCalls:
   - serviceName: "Issues"
     request:
       query: |
-        query {
-          trollName(id: "My Arm")
+        query ($v0: ID!) {
+          trollName(id: $v0)
         }
-      variables: { }
+      variables:
+        v0: "My Arm"
     # language=JSON
     response: |-
       {
@@ -111,10 +112,11 @@ serviceCalls:
   - serviceName: "Issues"
     request:
       query: |
-        query {
-          ariById(id: "Franklin")
+        query ($v0: ID!) {
+          ariById(id: $v0)
         }
-      variables: { }
+      variables:
+        v0: "Franklin"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/hydration/hydration-within-hydration-with-variables.yml
+++ b/test/src/test/resources/fixtures/hydration/hydration-within-hydration-with-variables.yml
@@ -102,13 +102,14 @@ serviceCalls:
   - serviceName: "issues"
     request:
       query: |
-        query {
-          issue(id: "ISSUE-1") {
+        query ($v0: ID!) {
+          issue(id: $v0) {
             __typename__hydration__comments: __typename
             hydration__comments__cloudId: cloudId
           }
         }
-      variables: { }
+      variables:
+        v0: "ISSUE-1"
     # language=JSON
     response: |-
       {
@@ -123,12 +124,14 @@ serviceCalls:
   - serviceName: "comments"
     request:
       query: |
-        query {
-          comments(cloudId: "CLOUD_ID-1", first: 10) {
+        query ($v0: ID!, $v1: Int) {
+          comments(cloudId: $v0, first: $v1) {
             totalCount
           }
         }
-      variables: { }
+      variables:
+        v0: "CLOUD_ID-1"
+        v1: 10
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/hydration/hydration-works-when-an-ancestor-field-has-been-renamed.yml
+++ b/test/src/test/resources/fixtures/hydration/hydration-works-when-an-ancestor-field-has-been-renamed.yml
@@ -76,12 +76,13 @@ serviceCalls:
   - serviceName: "IssueService"
     request:
       query: |
-        query {
-          issue(id: "1") {
+        query ($v0: ID) {
+          issue(id: $v0) {
             id
           }
         }
-      variables: { }
+      variables:
+        v0: "1"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/hydration/index/hydration-matching-using-index-one-batch-returns-errors.yml
+++ b/test/src/test/resources/fixtures/hydration/index/hydration-matching-using-index-one-batch-returns-errors.yml
@@ -91,12 +91,15 @@ serviceCalls:
   - serviceName: "UserService"
     request:
       query: |
-        query {
-          usersByIds(ids: ["1", "1"]) {
+        query ($v0: [ID]) {
+          usersByIds(ids: $v0) {
             name
           }
         }
-      variables: { }
+      variables:
+        v0:
+          - "1"
+          - "1"
     # language=JSON
     response: |-
       {
@@ -113,12 +116,15 @@ serviceCalls:
   - serviceName: "UserService"
     request:
       query: |
-        query {
-          usersByIds(ids: ["2", "2"]) {
+        query ($v0: [ID]) {
+          usersByIds(ids: $v0) {
             name
           }
         }
-      variables: { }
+      variables:
+        v0:
+          - "2"
+          - "2"
     # language=JSON
     response: |-
       {
@@ -135,12 +141,14 @@ serviceCalls:
   - serviceName: "UserService"
     request:
       query: |
-        query {
-          usersByIds(ids: ["4"]) {
+        query ($v0: [ID]) {
+          usersByIds(ids: $v0) {
             name
           }
         }
-      variables: { }
+      variables:
+        v0:
+          - "4"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/hydration/index/hydration-matching-using-index-result-size-invariant-mismatch.yml
+++ b/test/src/test/resources/fixtures/hydration/index/hydration-matching-using-index-result-size-invariant-mismatch.yml
@@ -85,12 +85,16 @@ serviceCalls:
   - serviceName: "UserService"
     request:
       query: |
-        query {
-          usersByIds(ids: ["1", "1", "2"]) {
+        query ($v0: [ID]) {
+          usersByIds(ids: $v0) {
             name
           }
         }
-      variables: { }
+      variables:
+        v0:
+          - "1"
+          - "1"
+          - "2"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/hydration/index/hydration-matching-using-index-returning-errors.yml
+++ b/test/src/test/resources/fixtures/hydration/index/hydration-matching-using-index-returning-errors.yml
@@ -83,12 +83,16 @@ serviceCalls:
   - serviceName: "UserService"
     request:
       query: |
-        query {
-          usersByIds(ids: ["1", "1", "2"]) {
+        query ($v0: [ID]) {
+          usersByIds(ids: $v0) {
             name
           }
         }
-      variables: { }
+      variables:
+        v0:
+          - "1"
+          - "1"
+          - "2"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/hydration/index/hydration-matching-using-index-returning-null-elements.yml
+++ b/test/src/test/resources/fixtures/hydration/index/hydration-matching-using-index-returning-null-elements.yml
@@ -85,12 +85,16 @@ serviceCalls:
   - serviceName: "UserService"
     request:
       query: |
-        query {
-          usersByIds(ids: ["1", "1", "2"]) {
+        query ($v0: [ID]) {
+          usersByIds(ids: $v0) {
             name
           }
         }
-      variables: { }
+      variables:
+        v0:
+          - "1"
+          - "1"
+          - "2"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/hydration/index/hydration-matching-using-index-returning-null.yml
+++ b/test/src/test/resources/fixtures/hydration/index/hydration-matching-using-index-returning-null.yml
@@ -83,12 +83,16 @@ serviceCalls:
   - serviceName: "UserService"
     request:
       query: |
-        query {
-          usersByIds(ids: ["1", "1", "2"]) {
+        query ($v0: [ID]) {
+          usersByIds(ids: $v0) {
             name
           }
         }
-      variables: { }
+      variables:
+        v0:
+          - "1"
+          - "1"
+          - "2"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/hydration/index/hydration-matching-using-index-with-lists-with-hydration-field-not-exposed.yml
+++ b/test/src/test/resources/fixtures/hydration/index/hydration-matching-using-index-with-lists-with-hydration-field-not-exposed.yml
@@ -81,12 +81,15 @@ serviceCalls:
   - serviceName: "UserService"
     request:
       query: |
-        query {
-          usersByIssueIds(issueIds: ["ISSUE-1", "ISSUE-2"]) {
+        query ($v0: [ID]) {
+          usersByIssueIds(issueIds: $v0) {
             name
           }
         }
-      variables: { }
+      variables:
+        v0:
+          - "ISSUE-1"
+          - "ISSUE-2"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/hydration/index/hydration-matching-using-index-with-lists.yml
+++ b/test/src/test/resources/fixtures/hydration/index/hydration-matching-using-index-with-lists.yml
@@ -79,12 +79,15 @@ serviceCalls:
   - serviceName: "UserService"
     request:
       query: |
-        query {
-          usersByIssueIds(issueIds: ["ISSUE-1", "ISSUE-2"]) {
+        query ($v0: [ID]) {
+          usersByIssueIds(issueIds: $v0) {
             name
           }
         }
-      variables: { }
+      variables:
+        v0:
+          - "ISSUE-1"
+          - "ISSUE-2"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/hydration/index/hydration-matching-using-index-with-null-input-nodes.yml
+++ b/test/src/test/resources/fixtures/hydration/index/hydration-matching-using-index-with-null-input-nodes.yml
@@ -85,12 +85,15 @@ serviceCalls:
   - serviceName: "UserService"
     request:
       query: |
-        query {
-          usersByIds(ids: ["1", "2"]) {
+        query ($v0: [ID]) {
+          usersByIds(ids: $v0) {
             name
           }
         }
-      variables: { }
+      variables:
+        v0:
+          - "1"
+          - "2"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/hydration/index/hydration-matching-using-index.yml
+++ b/test/src/test/resources/fixtures/hydration/index/hydration-matching-using-index.yml
@@ -85,12 +85,16 @@ serviceCalls:
   - serviceName: "UserService"
     request:
       query: |
-        query {
-          usersByIds(ids: ["1", "1", "2"]) {
+        query ($v0: [ID]) {
+          usersByIds(ids: $v0) {
             name
           }
         }
-      variables: { }
+      variables:
+        v0:
+          - "1"
+          - "1"
+          - "2"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/hydration/nested-list-hydration-under-a-renamed-top-level-field.yml
+++ b/test/src/test/resources/fixtures/hydration/nested-list-hydration-under-a-renamed-top-level-field.yml
@@ -101,15 +101,16 @@ serviceCalls:
   - serviceName: "Foo"
     request:
       query: |
-        query {
-          connection(id: "ID") {
+        query ($v0: ID) {
+          connection(id: $v0) {
             __typename__hydration__nodes: __typename
             hydration__nodes__edges: edges {
               node
             }
           }
         }
-      variables: { }
+      variables:
+        v0: "ID"
     # language=JSON
     response: |-
       {
@@ -128,13 +129,14 @@ serviceCalls:
   - serviceName: "Foo"
     request:
       query: |
-        query {
-          node(id: "1") {
+        query ($v0: ID) {
+          node(id: $v0) {
             __typename__hydration__space: __typename
             hydration__space__id: id
           }
         }
-      variables: { }
+      variables:
+        v0: "1"
     # language=JSON
     response: |-
       {
@@ -149,12 +151,13 @@ serviceCalls:
   - serviceName: "Foo"
     request:
       query: |
-        query {
-          space(id: "1a") {
+        query ($v0: ID) {
+          space(id: $v0) {
             id
           }
         }
-      variables: { }
+      variables:
+        v0: "1a"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/hydration/nullable-argument-for-hydration-is-missing.yml
+++ b/test/src/test/resources/fixtures/hydration/nullable-argument-for-hydration-is-missing.yml
@@ -100,13 +100,14 @@ serviceCalls:
   - serviceName: "issues"
     request:
       query: |
-        query {
-          issue(id: "ISSUE-1") {
+        query ($v0: ID) {
+          issue(id: $v0) {
             __typename__hydration__comments: __typename
             hydration__comments__cloudId: cloudId
           }
         }
-      variables: { }
+      variables:
+        v0: "ISSUE-1"
     # language=JSON
     response: |-
       {
@@ -121,12 +122,13 @@ serviceCalls:
   - serviceName: "comments"
     request:
       query: |
-        query {
-          comments(cloudId: "CLOUD_ID-1") {
+        query ($v0: ID!) {
+          comments(cloudId: $v0) {
             totalCount
           }
         }
-      variables: { }
+      variables:
+        v0: "CLOUD_ID-1"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/hydration/one-hydration-call-with-fragments-defined.yml
+++ b/test/src/test/resources/fixtures/hydration/one-hydration-call-with-fragments-defined.yml
@@ -81,13 +81,14 @@ serviceCalls:
   - serviceName: "service2"
     request:
       query: |
-        query {
-          barById(id: "barId") {
+        query ($v0: ID) {
+          barById(id: $v0) {
             id
             name
           }
         }
-      variables: { }
+      variables:
+        v0: "barId"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/hydration/one-hydration-call-with-input-value-having-longer-path.yml
+++ b/test/src/test/resources/fixtures/hydration/one-hydration-call-with-input-value-having-longer-path.yml
@@ -80,12 +80,13 @@ serviceCalls:
   - serviceName: "service2"
     request:
       query: |
-        query {
-          barById(id: "barId") {
+        query ($v0: ID) {
+          barById(id: $v0) {
             name
           }
         }
-      variables: { }
+      variables:
+        v0: "barId"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/hydration/one-hydration-call-with-longer-path-and-same-named-overall-field.yml
+++ b/test/src/test/resources/fixtures/hydration/one-hydration-call-with-longer-path-and-same-named-overall-field.yml
@@ -107,13 +107,16 @@ serviceCalls:
   - serviceName: "UserService"
     request:
       query: |
-        query {
-          usersByIds(id: ["USER-1", "USER-2"]) {
+        query ($v0: [ID]) {
+          usersByIds(id: $v0) {
             id
             batch_hydration__authors__id: id
           }
         }
-      variables: { }
+      variables:
+        v0:
+          - "USER-1"
+          - "USER-2"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/hydration/one-hydration-call-with-longer-path-arguments-and-merged-fields.yml
+++ b/test/src/test/resources/fixtures/hydration/one-hydration-call-with-longer-path-arguments-and-merged-fields.yml
@@ -90,14 +90,17 @@ serviceCalls:
   - serviceName: "UserService"
     request:
       query: |
-        query {
-          usersByIds(id: ["USER-1", "USER-2"]) {
+        query ($v0: [ID]) {
+          usersByIds(id: $v0) {
             id
             batch_hydration__authors__id: id
             name
           }
         }
-      variables: { }
+      variables:
+        v0:
+          - "USER-1"
+          - "USER-2"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/hydration/one-hydration-call-with-variables-defined.yml
+++ b/test/src/test/resources/fixtures/hydration/one-hydration-call-with-variables-defined.yml
@@ -77,13 +77,14 @@ serviceCalls:
   - serviceName: "service2"
     request:
       query: |
-        query {
-          barById(id: "barId") {
+        query ($v0: ID) {
+          barById(id: $v0) {
             id
             name
           }
         }
-      variables: { }
+      variables:
+        v0: "barId"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/hydration/one-synthetic-hydration-call-with-longer-path-and-same-named-overall-field.yml
+++ b/test/src/test/resources/fixtures/hydration/one-synthetic-hydration-call-with-longer-path-and-same-named-overall-field.yml
@@ -114,15 +114,18 @@ serviceCalls:
   - serviceName: "UserService"
     request:
       query: |
-        query {
+        query ($v0: [ID]) {
           usersQuery {
-            usersByIds(id: ["USER-1", "USER-2"]) {
+            usersByIds(id: $v0) {
               id
               batch_hydration__authors__id: id
             }
           }
         }
-      variables: { }
+      variables:
+        v0:
+          - "USER-1"
+          - "USER-2"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/hydration/one-synthetic-hydration-call-with-longer-path-arguments-and-merged-fields-and-renamed-type.yml
+++ b/test/src/test/resources/fixtures/hydration/one-synthetic-hydration-call-with-longer-path-arguments-and-merged-fields-and-renamed-type.yml
@@ -97,16 +97,19 @@ serviceCalls:
   - serviceName: "UserService"
     request:
       query: |
-        query {
+        query ($v0: [ID]) {
           usersQuery {
-            usersByIds(id: ["USER-1", "USER-2"]) {
+            usersByIds(id: $v0) {
               id
               batch_hydration__authors__id: id
               name
             }
           }
         }
-      variables: { }
+      variables:
+        v0:
+          - "USER-1"
+          - "USER-2"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/hydration/polymorphic hydrations/batch-polymorphic-hydration-actor-fields-are-in-the-same-service-return-types-implement-same-interface.yml
+++ b/test/src/test/resources/fixtures/hydration/polymorphic hydrations/batch-polymorphic-hydration-actor-fields-are-in-the-same-service-return-types-implement-same-interface.yml
@@ -148,15 +148,18 @@ serviceCalls:
   - serviceName: "bar"
     request:
       query: |
-        query {
-          petById(ids: ["PET-0", "PET-1"]) {
+        query ($v0: [ID]) {
+          petById(ids: $v0) {
             __typename
             breed
             id
             batch_hydration__data__id: id
           }
         }
-      variables: { }
+      variables:
+        v0:
+          - "PET-0"
+          - "PET-1"
     # language=JSON
     response: |-
       {
@@ -180,15 +183,18 @@ serviceCalls:
   - serviceName: "bar"
     request:
       query: |
-        query {
-          humanById(ids: ["HUMAN-0", "HUMAN-1"]) {
+        query ($v0: [ID]) {
+          humanById(ids: $v0) {
             __typename
             id
             batch_hydration__data__id: id
             name
           }
         }
-      variables: { }
+      variables:
+        v0:
+          - "HUMAN-0"
+          - "HUMAN-1"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/hydration/polymorphic hydrations/batch-polymorphic-hydration-actor-fields-are-in-the-same-service.yml
+++ b/test/src/test/resources/fixtures/hydration/polymorphic hydrations/batch-polymorphic-hydration-actor-fields-are-in-the-same-service.yml
@@ -140,15 +140,18 @@ serviceCalls:
   - serviceName: "bar"
     request:
       query: |
-        query {
-          petById(ids: ["PET-0", "PET-1"]) {
+        query ($v0: [ID]) {
+          petById(ids: $v0) {
             __typename
             breed
             id
             batch_hydration__data__id: id
           }
         }
-      variables: { }
+      variables:
+        v0:
+          - "PET-0"
+          - "PET-1"
     # language=JSON
     response: |-
       {
@@ -172,15 +175,18 @@ serviceCalls:
   - serviceName: "bar"
     request:
       query: |
-        query {
-          humanById(ids: ["HUMAN-0", "HUMAN-1"]) {
+        query ($v0: [ID]) {
+          humanById(ids: $v0) {
             __typename
             id
             batch_hydration__data__id: id
             name
           }
         }
-      variables: { }
+      variables:
+        v0:
+          - "HUMAN-0"
+          - "HUMAN-1"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/hydration/polymorphic hydrations/batch-polymorphic-hydration-when-hook-returns-null-1.yml
+++ b/test/src/test/resources/fixtures/hydration/polymorphic hydrations/batch-polymorphic-hydration-when-hook-returns-null-1.yml
@@ -146,15 +146,17 @@ serviceCalls:
   - serviceName: "pets"
     request:
       query: |
-        query {
-          petById(ids: ["PET-0"]) {
+        query ($v0: [ID]) {
+          petById(ids: $v0) {
             __typename
             breed
             id
             batch_hydration__data__id: id
           }
         }
-      variables: { }
+      variables:
+        v0:
+          - "PET-0"
     # language=JSON
     response: |-
       {
@@ -172,15 +174,18 @@ serviceCalls:
   - serviceName: "people"
     request:
       query: |
-        query {
-          humanById(ids: ["HUMAN-0", "HUMAN-1"]) {
+        query ($v0: [ID]) {
+          humanById(ids: $v0) {
             __typename
             id
             batch_hydration__data__id: id
             name
           }
         }
-      variables: { }
+      variables:
+        v0:
+          - "HUMAN-0"
+          - "HUMAN-1"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/hydration/polymorphic hydrations/batch-polymorphic-hydration-when-hook-returns-null.yml
+++ b/test/src/test/resources/fixtures/hydration/polymorphic hydrations/batch-polymorphic-hydration-when-hook-returns-null.yml
@@ -146,15 +146,18 @@ serviceCalls:
   - serviceName: "people"
     request:
       query: |
-        query {
-          humanById(ids: ["HUMAN-0", "HUMAN-1"]) {
+        query ($v0: [ID]) {
+          humanById(ids: $v0) {
             __typename
             id
             batch_hydration__data__id: id
             name
           }
         }
-      variables: { }
+      variables:
+        v0:
+          - "HUMAN-0"
+          - "HUMAN-1"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/hydration/polymorphic hydrations/batch-polymorphic-hydration-where-only-one-type-is-queried.yml
+++ b/test/src/test/resources/fixtures/hydration/polymorphic hydrations/batch-polymorphic-hydration-where-only-one-type-is-queried.yml
@@ -150,8 +150,8 @@ serviceCalls:
   - serviceName: "pets"
     request:
       query: |
-        query {
-          petById(ids: ["DOG-0", "FISH-0", "DOG-1", "FISH-1"]) {
+        query ($v0: [ID]) {
+          petById(ids: $v0) {
             ... on Dog {
               batch_hydration__data__id: id
             }
@@ -163,7 +163,12 @@ serviceCalls:
             }
           }
         }
-      variables: { }
+      variables:
+        v0:
+          - "DOG-0"
+          - "FISH-0"
+          - "DOG-1"
+          - "FISH-1"
     # language=JSON
     response: |-
       {
@@ -193,12 +198,14 @@ serviceCalls:
   - serviceName: "people"
     request:
       query: |
-        query {
-          humanById(ids: ["HUMAN-0"]) {
+        query ($v0: [ID]) {
+          humanById(ids: $v0) {
             batch_hydration__data__id: id
           }
         }
-      variables: { }
+      variables:
+        v0:
+          - "HUMAN-0"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/hydration/polymorphic hydrations/batch-polymorphic-hydration-with-interfaces.yml
+++ b/test/src/test/resources/fixtures/hydration/polymorphic hydrations/batch-polymorphic-hydration-with-interfaces.yml
@@ -173,8 +173,8 @@ serviceCalls:
   - serviceName: "pets"
     request:
       query: |
-        query {
-          petById(ids: ["DOG-0", "FISH-0", "DOG-1", "FISH-1"]) {
+        query ($v0: [ID]) {
+          petById(ids: $v0) {
             __typename
             id
             batch_hydration__data__id: id
@@ -186,7 +186,12 @@ serviceCalls:
             }
           }
         }
-      variables: { }
+      variables:
+        v0:
+          - "DOG-0"
+          - "FISH-0"
+          - "DOG-1"
+          - "FISH-1"
     # language=JSON
     response: |-
       {
@@ -222,15 +227,17 @@ serviceCalls:
   - serviceName: "people"
     request:
       query: |
-        query {
-          humanById(ids: ["HUMAN-0"]) {
+        query ($v0: [ID]) {
+          humanById(ids: $v0) {
             __typename
             id
             batch_hydration__data__id: id
             name
           }
         }
-      variables: { }
+      variables:
+        v0:
+          - "HUMAN-0"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/hydration/polymorphic hydrations/batch-polymorphic-hydration-with-lots-of-renames.yml
+++ b/test/src/test/resources/fixtures/hydration/polymorphic hydrations/batch-polymorphic-hydration-with-lots-of-renames.yml
@@ -146,8 +146,8 @@ serviceCalls:
   - serviceName: "bar"
     request:
       query: |
-        query {
-          humanById(ids: ["HUMAN-0", "HUMAN-1"]) {
+        query ($v0: [ID]) {
+          humanById(ids: $v0) {
             __typename
             __typename__rename__id: __typename
             batch_hydration__data__hiddenId: hiddenId
@@ -155,7 +155,10 @@ serviceCalls:
             name
           }
         }
-      variables: { }
+      variables:
+        v0:
+          - "HUMAN-0"
+          - "HUMAN-1"
     # language=JSON
     response: |-
       {
@@ -181,8 +184,8 @@ serviceCalls:
   - serviceName: "bar"
     request:
       query: |
-        query {
-          petById(ids: ["PET-0", "PET-1"]) {
+        query ($v0: [ID]) {
+          petById(ids: $v0) {
             __typename
             __typename__rename__id: __typename
             __typename__rename__breed: __typename
@@ -191,7 +194,10 @@ serviceCalls:
             rename__breed__kind: kind
           }
         }
-      variables: { }
+      variables:
+        v0:
+          - "PET-0"
+          - "PET-1"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/hydration/polymorphic hydrations/batch-polymorphic-hydration-with-rename.yml
+++ b/test/src/test/resources/fixtures/hydration/polymorphic hydrations/batch-polymorphic-hydration-with-rename.yml
@@ -146,8 +146,8 @@ serviceCalls:
   - serviceName: "pets"
     request:
       query: |
-        query {
-          petById(ids: ["PET-0", "PET-1"]) {
+        query ($v0: [ID]) {
+          petById(ids: $v0) {
             __typename
             __typename__rename__breed: __typename
             id
@@ -155,7 +155,10 @@ serviceCalls:
             rename__breed__kind: kind
           }
         }
-      variables: { }
+      variables:
+        v0:
+          - "PET-0"
+          - "PET-1"
     # language=JSON
     response: |-
       {
@@ -181,15 +184,18 @@ serviceCalls:
   - serviceName: "people"
     request:
       query: |
-        query {
-          humanById(ids: ["HUMAN-0", "HUMAN-1"]) {
+        query ($v0: [ID]) {
+          humanById(ids: $v0) {
             __typename
             id
             batch_hydration__data__id: id
             name
           }
         }
-      variables: { }
+      variables:
+        v0:
+          - "HUMAN-0"
+          - "HUMAN-1"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/hydration/polymorphic hydrations/batch-polymorphic-hydration-with-unions.yml
+++ b/test/src/test/resources/fixtures/hydration/polymorphic hydrations/batch-polymorphic-hydration-with-unions.yml
@@ -169,8 +169,8 @@ serviceCalls:
   - serviceName: "pets"
     request:
       query: |
-        query {
-          petById(ids: ["DOG-0", "FISH-0", "DOG-1", "FISH-1"]) {
+        query ($v0: [ID]) {
+          petById(ids: $v0) {
             __typename
             ... on Dog {
               breed
@@ -184,7 +184,12 @@ serviceCalls:
             }
           }
         }
-      variables: { }
+      variables:
+        v0:
+          - "DOG-0"
+          - "FISH-0"
+          - "DOG-1"
+          - "FISH-1"
     # language=JSON
     response: |-
       {
@@ -220,15 +225,17 @@ serviceCalls:
   - serviceName: "people"
     request:
       query: |
-        query {
-          humanById(ids: ["HUMAN-0"]) {
+        query ($v0: [ID]) {
+          humanById(ids: $v0) {
             __typename
             id
             batch_hydration__data__id: id
             name
           }
         }
-      variables: { }
+      variables:
+        v0:
+          - "HUMAN-0"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/hydration/polymorphic hydrations/batch-polymorphic-hydration.yml
+++ b/test/src/test/resources/fixtures/hydration/polymorphic hydrations/batch-polymorphic-hydration.yml
@@ -146,15 +146,18 @@ serviceCalls:
   - serviceName: "pets"
     request:
       query: |
-        query {
-          petById(ids: ["PET-0", "PET-1"]) {
+        query ($v0: [ID]) {
+          petById(ids: $v0) {
             __typename
             breed
             id
             batch_hydration__data__id: id
           }
         }
-      variables: { }
+      variables:
+        v0:
+          - "PET-0"
+          - "PET-1"
     # language=JSON
     response: |-
       {
@@ -178,15 +181,18 @@ serviceCalls:
   - serviceName: "people"
     request:
       query: |
-        query {
-          humanById(ids: ["HUMAN-0", "HUMAN-1"]) {
+        query ($v0: [ID]) {
+          humanById(ids: $v0) {
             __typename
             id
             batch_hydration__data__id: id
             name
           }
         }
-      variables: { }
+      variables:
+        v0:
+          - "HUMAN-0"
+          - "HUMAN-1"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/hydration/polymorphic hydrations/solitary-polymorphic-hydration-when-hook-returns-null.yml
+++ b/test/src/test/resources/fixtures/hydration/polymorphic hydrations/solitary-polymorphic-hydration-when-hook-returns-null.yml
@@ -130,8 +130,8 @@ serviceCalls:
   - serviceName: "people"
     request:
       query: |
-        query {
-          humanById(id: "HUMAN-0") {
+        query ($v0: ID) {
+          humanById(id: $v0) {
             __typename
             __typename__type_filter__id: __typename
             __typename__type_filter__breed: __typename
@@ -139,7 +139,8 @@ serviceCalls:
             name
           }
         }
-      variables: { }
+      variables:
+        v0: "HUMAN-0"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/hydration/polymorphic hydrations/solitary-polymorphic-hydration.yml
+++ b/test/src/test/resources/fixtures/hydration/polymorphic hydrations/solitary-polymorphic-hydration.yml
@@ -130,8 +130,8 @@ serviceCalls:
   - serviceName: "pets"
     request:
       query: |
-        query {
-          petById(id: "PET-0") {
+        query ($v0: ID) {
+          petById(id: $v0) {
             __typename
             __typename__type_filter__id: __typename
             __typename__type_filter__name: __typename
@@ -139,7 +139,8 @@ serviceCalls:
             id
           }
         }
-      variables: { }
+      variables:
+        v0: "PET-0"
     # language=JSON
     response: |-
       {
@@ -157,8 +158,8 @@ serviceCalls:
   - serviceName: "people"
     request:
       query: |
-        query {
-          humanById(id: "HUMAN-0") {
+        query ($v0: ID) {
+          humanById(id: $v0) {
             __typename
             __typename__type_filter__id: __typename
             __typename__type_filter__breed: __typename
@@ -166,7 +167,8 @@ serviceCalls:
             name
           }
         }
-      variables: { }
+      variables:
+        v0: "HUMAN-0"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/hydration/query-with-hydrated-interfaces-work-as-expected.yml
+++ b/test/src/test/resources/fixtures/hydration/query-with-hydrated-interfaces-work-as-expected.yml
@@ -147,8 +147,8 @@ serviceCalls:
   - serviceName: "PetService"
     request:
       query: |
-        query petQ {
-          pets(isLoyal: true) {
+        query petQ($v0: Boolean) {
+          pets(isLoyal: $v0) {
             __typename__hydration__owners: __typename
             name
             ... on Cat {
@@ -159,7 +159,8 @@ serviceCalls:
             }
           }
         }
-      variables: { }
+      variables:
+        v0: true
       operationName: "petQ"
     # language=JSON
     response: |-
@@ -187,8 +188,8 @@ serviceCalls:
   - serviceName: "OwnerService"
     request:
       query: |
-        query petQ {
-          ownerById(id: "dearly") {
+        query petQ($v0: String) {
+          ownerById(id: $v0) {
             name
             ... on CaringOwner {
               givesPats
@@ -198,7 +199,8 @@ serviceCalls:
             }
           }
         }
-      variables: { }
+      variables:
+        v0: "dearly"
       operationName: "petQ"
     # language=JSON
     response: |-
@@ -214,8 +216,8 @@ serviceCalls:
   - serviceName: "OwnerService"
     request:
       query: |
-        query petQ {
-          ownerById(id: "cruella") {
+        query petQ($v0: String) {
+          ownerById(id: $v0) {
             name
             ... on CaringOwner {
               givesPats
@@ -225,7 +227,8 @@ serviceCalls:
             }
           }
         }
-      variables: { }
+      variables:
+        v0: "cruella"
       operationName: "petQ"
     # language=JSON
     response: |-

--- a/test/src/test/resources/fixtures/hydration/query-with-hydration-that-fail-with-errors-are-reflected-in-the-result.yml
+++ b/test/src/test/resources/fixtures/hydration/query-with-hydration-that-fail-with-errors-are-reflected-in-the-result.yml
@@ -79,14 +79,15 @@ serviceCalls:
   - serviceName: "Bar"
     request:
       query: |
-        query {
-          barById(id: "barId123") {
+        query ($v0: ID) {
+          barById(id: $v0) {
             __typename__hydration__nestedBar: __typename
             name
             hydration__nestedBar__nestedBarId: nestedBarId
           }
         }
-      variables: { }
+      variables:
+        v0: "barId123"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/hydration/query-with-synthetic-hydration-that-fail-with-errors-are-reflected-in-the-result.yml
+++ b/test/src/test/resources/fixtures/hydration/query-with-synthetic-hydration-that-fail-with-errors-are-reflected-in-the-result.yml
@@ -86,16 +86,17 @@ serviceCalls:
   - serviceName: "Bar"
     request:
       query: |
-        query {
+        query ($v0: ID) {
           barQuery {
-            barById(id: "barId123") {
+            barById(id: $v0) {
               __typename__hydration__nestedBar: __typename
               name
               hydration__nestedBar__nestedBarId: nestedBarId
             }
           }
         }
-      variables: { }
+      variables:
+        v0: "barId123"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/hydration/query-with-three-nested-hydrations-and-simple-data-and-lots-of-renames.yml
+++ b/test/src/test/resources/fixtures/hydration/query-with-three-nested-hydrations-and-simple-data-and-lots-of-renames.yml
@@ -165,8 +165,8 @@ serviceCalls:
   - serviceName: "Bar"
     request:
       query: |
-        query {
-          barsById(id: ["bar1"]) {
+        query ($v0: [ID]) {
+          barsById(id: $v0) {
             __typename__rename__barName: __typename
             __typename__batch_hydration__nestedBar: __typename
             batch_hydration__bar__barId: barId
@@ -174,7 +174,9 @@ serviceCalls:
             batch_hydration__nestedBar__nestedBarId: nestedBarId
           }
         }
-      variables: { }
+      variables:
+        v0:
+          - "bar1"
     # language=JSON
     response: |-
       {
@@ -194,8 +196,8 @@ serviceCalls:
   - serviceName: "Bar"
     request:
       query: |
-        query {
-          barsById(id: ["nestedBar1"]) {
+        query ($v0: [ID]) {
+          barsById(id: $v0) {
             __typename__rename__barName: __typename
             __typename__batch_hydration__nestedBar: __typename
             batch_hydration__nestedBar__barId: barId
@@ -203,7 +205,9 @@ serviceCalls:
             batch_hydration__nestedBar__nestedBarId: nestedBarId
           }
         }
-      variables: { }
+      variables:
+        v0:
+          - "nestedBar1"
     # language=JSON
     response: |-
       {
@@ -223,8 +227,8 @@ serviceCalls:
   - serviceName: "Bar"
     request:
       query: |
-        query {
-          barsById(id: ["nestedBarId456"]) {
+        query ($v0: [ID]) {
+          barsById(id: $v0) {
             __typename__rename__barName: __typename
             __typename__rename__barDetails: __typename
             batch_hydration__nestedBar__barId: barId
@@ -242,7 +246,9 @@ serviceCalls:
             rename__barName__name: name
           }
         }
-      variables: { }
+      variables:
+        v0:
+          - "nestedBarId456"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/hydration/query-with-three-nested-hydrations-and-simple-data.yml
+++ b/test/src/test/resources/fixtures/hydration/query-with-three-nested-hydrations-and-simple-data.yml
@@ -82,15 +82,17 @@ serviceCalls:
   - serviceName: "Bar"
     request:
       query: |
-        query {
-          barsById(id: ["bar1"]) {
+        query ($v0: [ID]) {
+          barsById(id: $v0) {
             __typename__batch_hydration__nestedBar: __typename
             batch_hydration__bar__barId: barId
             name
             batch_hydration__nestedBar__nestedBarId: nestedBarId
           }
         }
-      variables: { }
+      variables:
+        v0:
+          - "bar1"
     # language=JSON
     response: |-
       {
@@ -109,15 +111,17 @@ serviceCalls:
   - serviceName: "Bar"
     request:
       query: |
-        query {
-          barsById(id: ["nestedBar1"]) {
+        query ($v0: [ID]) {
+          barsById(id: $v0) {
             __typename__batch_hydration__nestedBar: __typename
             batch_hydration__nestedBar__barId: barId
             name
             batch_hydration__nestedBar__nestedBarId: nestedBarId
           }
         }
-      variables: { }
+      variables:
+        v0:
+          - "nestedBar1"
     # language=JSON
     response: |-
       {
@@ -136,13 +140,15 @@ serviceCalls:
   - serviceName: "Bar"
     request:
       query: |
-        query {
-          barsById(id: ["nestedBarId456"]) {
+        query ($v0: [ID]) {
+          barsById(id: $v0) {
             batch_hydration__nestedBar__barId: barId
             name
           }
         }
-      variables: { }
+      variables:
+        v0:
+          - "nestedBarId456"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/hydration/query-with-three-nested-hydrations-and-synthetic-fields.yml
+++ b/test/src/test/resources/fixtures/hydration/query-with-three-nested-hydrations-and-synthetic-fields.yml
@@ -97,9 +97,9 @@ serviceCalls:
   - serviceName: "Bar"
     request:
       query: |
-        query {
+        query ($v0: [ID]) {
           barsQuery {
-            barsById(id: ["bar3"]) {
+            barsById(id: $v0) {
               __typename__batch_hydration__nestedBar: __typename
               batch_hydration__bar__barId: barId
               name
@@ -107,7 +107,9 @@ serviceCalls:
             }
           }
         }
-      variables: { }
+      variables:
+        v0:
+          - "bar3"
     # language=JSON
     response: |-
       {
@@ -128,9 +130,9 @@ serviceCalls:
   - serviceName: "Bar"
     request:
       query: |
-        query {
+        query ($v0: [ID]) {
           barsQuery {
-            barsById(id: ["bar1", "bar2"]) {
+            barsById(id: $v0) {
               __typename__batch_hydration__nestedBar: __typename
               batch_hydration__bar__barId: barId
               name
@@ -138,7 +140,10 @@ serviceCalls:
             }
           }
         }
-      variables: { }
+      variables:
+        v0:
+          - "bar1"
+          - "bar2"
     # language=JSON
     response: |-
       {
@@ -165,9 +170,9 @@ serviceCalls:
   - serviceName: "Bar"
     request:
       query: |
-        query {
+        query ($v0: [ID]) {
           barsQuery {
-            barsById(id: ["nestedBar1", "nestedBar2"]) {
+            barsById(id: $v0) {
               __typename__batch_hydration__nestedBar: __typename
               batch_hydration__nestedBar__barId: barId
               name
@@ -175,7 +180,10 @@ serviceCalls:
             }
           }
         }
-      variables: { }
+      variables:
+        v0:
+          - "nestedBar1"
+          - "nestedBar2"
     # language=JSON
     response: |-
       {
@@ -196,15 +204,17 @@ serviceCalls:
   - serviceName: "Bar"
     request:
       query: |
-        query {
+        query ($v0: [ID]) {
           barsQuery {
-            barsById(id: ["nestedBarId456"]) {
+            barsById(id: $v0) {
               batch_hydration__nestedBar__barId: barId
               name
             }
           }
         }
-      variables: { }
+      variables:
+        v0:
+          - "nestedBarId456"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/hydration/query-with-three-nested-hydrations.yml
+++ b/test/src/test/resources/fixtures/hydration/query-with-three-nested-hydrations.yml
@@ -90,15 +90,17 @@ serviceCalls:
   - serviceName: "Bar"
     request:
       query: |
-        query {
-          barsById(id: ["bar3"]) {
+        query ($v0: [ID]) {
+          barsById(id: $v0) {
             __typename__batch_hydration__nestedBar: __typename
             batch_hydration__bar__barId: barId
             name
             batch_hydration__nestedBar__nestedBarId: nestedBarId
           }
         }
-      variables: { }
+      variables:
+        v0:
+          - "bar3"
     # language=JSON
     response: |-
       {
@@ -117,15 +119,18 @@ serviceCalls:
   - serviceName: "Bar"
     request:
       query: |
-        query {
-          barsById(id: ["bar1", "bar2"]) {
+        query ($v0: [ID]) {
+          barsById(id: $v0) {
             __typename__batch_hydration__nestedBar: __typename
             batch_hydration__bar__barId: barId
             name
             batch_hydration__nestedBar__nestedBarId: nestedBarId
           }
         }
-      variables: { }
+      variables:
+        v0:
+          - "bar1"
+          - "bar2"
     # language=JSON
     response: |-
       {
@@ -150,15 +155,18 @@ serviceCalls:
   - serviceName: "Bar"
     request:
       query: |
-        query {
-          barsById(id: ["nestedBar1", "nestedBar2"]) {
+        query ($v0: [ID]) {
+          barsById(id: $v0) {
             __typename__batch_hydration__nestedBar: __typename
             batch_hydration__nestedBar__barId: barId
             name
             batch_hydration__nestedBar__nestedBarId: nestedBarId
           }
         }
-      variables: { }
+      variables:
+        v0:
+          - "nestedBar1"
+          - "nestedBar2"
     # language=JSON
     response: |-
       {
@@ -177,13 +185,15 @@ serviceCalls:
   - serviceName: "Bar"
     request:
       query: |
-        query {
-          barsById(id: ["nestedBarId456"]) {
+        query ($v0: [ID]) {
+          barsById(id: $v0) {
             batch_hydration__nestedBar__barId: barId
             name
           }
         }
-      variables: { }
+      variables:
+        v0:
+          - "nestedBarId456"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/hydration/renamed-and-hydrated-query-using-same-underlying-source.yml
+++ b/test/src/test/resources/fixtures/hydration/renamed-and-hydrated-query-using-same-underlying-source.yml
@@ -83,12 +83,13 @@ serviceCalls:
   - serviceName: "Foo"
     request:
       query: |
-        query {
-          detail(detailId: "ID") {
+        query ($v0: ID) {
+          detail(detailId: $v0) {
             name
           }
         }
-      variables: { }
+      variables:
+        v0: "ID"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/hydration/repeated-hydrated-fields-on-the-same-level-overlapping-fields-in-the-query.yml
+++ b/test/src/test/resources/fixtures/hydration/repeated-hydrated-fields-on-the-same-level-overlapping-fields-in-the-query.yml
@@ -71,14 +71,15 @@ serviceCalls:
   - serviceName: "Foo"
     request:
       query: |
-        query {
-          issue(issueId: "ISSUE-1") {
+        query ($v0: ID) {
+          issue(issueId: $v0) {
             desc
             name
             summary
           }
         }
-      variables: { }
+      variables:
+        v0: "ISSUE-1"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/hydration/repeated-hydrated-fields-on-the-same-level-when-using-batch-hydration.yml
+++ b/test/src/test/resources/fixtures/hydration/repeated-hydrated-fields-on-the-same-level-when-using-batch-hydration.yml
@@ -67,14 +67,16 @@ serviceCalls:
   - serviceName: "Foo"
     request:
       query: |
-        query {
-          issues(issueIds: ["ISSUE-1"]) {
+        query ($v0: [ID!]) {
+          issues(issueIds: $v0) {
             desc
             batch_hydration__issue__id: id
             name
           }
         }
-      variables: { }
+      variables:
+        v0:
+          - "ISSUE-1"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/hydration/repeated-hydrated-fields-on-the-same-level.yml
+++ b/test/src/test/resources/fixtures/hydration/repeated-hydrated-fields-on-the-same-level.yml
@@ -67,13 +67,14 @@ serviceCalls:
   - serviceName: "Foo"
     request:
       query: |
-        query {
-          issue(issueId: "ISSUE-1") {
+        query ($v0: ID) {
+          issue(issueId: $v0) {
             desc
             name
           }
         }
-      variables: { }
+      variables:
+        v0: "ISSUE-1"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/hydration/same-source-for-2-hydrations.yml
+++ b/test/src/test/resources/fixtures/hydration/same-source-for-2-hydrations.yml
@@ -83,12 +83,13 @@ serviceCalls:
   - serviceName: "Foo"
     request:
       query: |
-        query {
-          issue(issueId: "ID") {
+        query ($v0: ID) {
+          issue(issueId: $v0) {
             field
           }
         }
-      variables: { }
+      variables:
+        v0: "ID"
     # language=JSON
     response: |-
       {
@@ -102,12 +103,13 @@ serviceCalls:
   - serviceName: "Foo"
     request:
       query: |
-        query {
-          detail(detailId: "ID") {
+        query ($v0: ID) {
+          detail(detailId: $v0) {
             name
           }
         }
-      variables: { }
+      variables:
+        v0: "ID"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/hydration/same-source-for-2-nested-hydrations-and-a-rename.yml
+++ b/test/src/test/resources/fixtures/hydration/same-source-for-2-nested-hydrations-and-a-rename.yml
@@ -101,12 +101,13 @@ serviceCalls:
   - serviceName: "Foo"
     request:
       query: |
-        query {
-          issue(issueId: "ID") {
+        query ($v0: ID) {
+          issue(issueId: $v0) {
             field
           }
         }
-      variables: { }
+      variables:
+        v0: "ID"
     # language=JSON
     response: |-
       {
@@ -120,12 +121,13 @@ serviceCalls:
   - serviceName: "Foo"
     request:
       query: |
-        query {
-          detail(detailId: "ID") {
+        query ($v0: ID) {
+          detail(detailId: $v0) {
             name
           }
         }
-      variables: { }
+      variables:
+        v0: "ID"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/hydration/simple-hydration-query-with-a-synthetic-field.yml
+++ b/test/src/test/resources/fixtures/hydration/simple-hydration-query-with-a-synthetic-field.yml
@@ -77,14 +77,15 @@ serviceCalls:
   - serviceName: "service2"
     request:
       query: |
-        query {
+        query ($v0: ID) {
           projects {
-            project(id: "project1") {
+            project(id: $v0) {
               name
             }
           }
         }
-      variables: { }
+      variables:
+        v0: "project1"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/hydration/simple-synthetic-hydration-with-one-service-and-type-renaming.yml
+++ b/test/src/test/resources/fixtures/hydration/simple-synthetic-hydration-with-one-service-and-type-renaming.yml
@@ -99,15 +99,16 @@ serviceCalls:
   - serviceName: "testing"
     request:
       query: |
-        query {
+        query ($v0: ID) {
           tests {
-            character(id: "C1") {
+            character(id: $v0) {
               id
               name
             }
           }
         }
-      variables: { }
+      variables:
+        v0: "C1"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/hydration/synthetic-hydration-batching-returns-null.yml
+++ b/test/src/test/resources/fixtures/hydration/synthetic-hydration-batching-returns-null.yml
@@ -81,15 +81,19 @@ serviceCalls:
   - serviceName: "service2"
     request:
       query: |
-        query {
+        query ($v0: [ID]) {
           barsQuery {
-            barsById(id: ["barId1", "barId2", "barId3"]) {
+            barsById(id: $v0) {
               batch_hydration__bar__id: id
               name
             }
           }
         }
-      variables: { }
+      variables:
+        v0:
+          - "barId1"
+          - "barId2"
+          - "barId3"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/hydration/synthetic-hydration-call-over-itself-within-renamed-types.yml
+++ b/test/src/test/resources/fixtures/hydration/synthetic-hydration-call-over-itself-within-renamed-types.yml
@@ -114,16 +114,19 @@ serviceCalls:
   - serviceName: "testing"
     request:
       query: |
-        query {
+        query ($v0: [ID!]!) {
           tests {
-            characters(ids: ["C2", "C3"]) {
+            characters(ids: $v0) {
               id
               batch_hydration__characters__id: id
               name
             }
           }
         }
-      variables: { }
+      variables:
+        v0:
+          - "C2"
+          - "C3"
     # language=JSON
     response: |-
       {
@@ -148,16 +151,20 @@ serviceCalls:
   - serviceName: "testing"
     request:
       query: |
-        query {
+        query ($v0: [ID!]!) {
           tests {
-            characters(ids: ["C1", "C2", "C1"]) {
+            characters(ids: $v0) {
               id
               batch_hydration__characters__id: id
               name
             }
           }
         }
-      variables: { }
+      variables:
+        v0:
+          - "C1"
+          - "C2"
+          - "C1"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/hydration/synthetic-hydration-call-with-two-argument-values-from-original-field-arguments.yml
+++ b/test/src/test/resources/fixtures/hydration/synthetic-hydration-call-with-two-argument-values-from-original-field-arguments.yml
@@ -92,15 +92,19 @@ serviceCalls:
   - serviceName: "UserService"
     request:
       query: |
-        query {
+        query ($v0: String, $v1: Int, $v2: [ID]) {
           usersQuery {
-            usersByIds(extraArg1: "extraArg1", extraArg2: 10, id: ["USER-1"]) {
+            usersByIds(extraArg1: $v0, extraArg2: $v1, id: $v2) {
               batch_hydration__author__id: id
               name
             }
           }
         }
-      variables: { }
+      variables:
+        v0: "extraArg1"
+        v1: 10
+        v2:
+          - "USER-1"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/hydration/synthetic-hydration-forwards-error.yml
+++ b/test/src/test/resources/fixtures/hydration/synthetic-hydration-forwards-error.yml
@@ -77,14 +77,15 @@ serviceCalls:
   - serviceName: "service2"
     request:
       query: |
-        query {
+        query ($v0: ID) {
           barsQuery {
-            barById(id: "barId1") {
+            barById(id: $v0) {
               name
             }
           }
         }
-      variables: { }
+      variables:
+        v0: "barId1"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/hydration/synthetic-hydration-list-with-batching-forwards-error.yml
+++ b/test/src/test/resources/fixtures/hydration/synthetic-hydration-list-with-batching-forwards-error.yml
@@ -81,15 +81,19 @@ serviceCalls:
   - serviceName: "service2"
     request:
       query: |
-        query {
+        query ($v0: [ID]) {
           barsQuery {
-            barsById(id: ["barId1", "barId2", "barId3"]) {
+            barsById(id: $v0) {
               batch_hydration__bar__id: id
               name
             }
           }
         }
-      variables: { }
+      variables:
+        v0:
+          - "barId1"
+          - "barId2"
+          - "barId3"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/hydration/synthetic-hydration-with-renamed-type.yml
+++ b/test/src/test/resources/fixtures/hydration/synthetic-hydration-with-renamed-type.yml
@@ -78,14 +78,15 @@ serviceCalls:
   - serviceName: "Bar"
     request:
       query: |
-        query {
+        query ($v0: ID!) {
           bars {
-            barById(id: "hydrated-bar") {
+            barById(id: $v0) {
               id
             }
           }
         }
-      variables: { }
+      variables:
+        v0: "hydrated-bar"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/hydration/synthetic-hydration-works-when-an-ancestor-field-has-been-renamed.yml
+++ b/test/src/test/resources/fixtures/hydration/synthetic-hydration-works-when-an-ancestor-field-has-been-renamed.yml
@@ -85,14 +85,15 @@ serviceCalls:
   - serviceName: "IssueService"
     request:
       query: |
-        query {
+        query ($v0: ID) {
           syntheticIssue {
-            issue(id: "1") {
+            issue(id: $v0) {
               id
             }
           }
         }
-      variables: { }
+      variables:
+        v0: "1"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/hydration/top-level-field-data-returns-null-in-batched-synthetic-hydration.yml
+++ b/test/src/test/resources/fixtures/hydration/top-level-field-data-returns-null-in-batched-synthetic-hydration.yml
@@ -101,15 +101,19 @@ serviceCalls:
   - serviceName: "service2"
     request:
       query: |
-        query {
+        query ($v0: [ID]) {
           users {
-            usersByIds(id: ["USER-2", "USER-4", "USER-5"]) {
+            usersByIds(id: $v0) {
               id
               batch_hydration__authors__id: id
             }
           }
         }
-      variables: { }
+      variables:
+        v0:
+          - "USER-2"
+          - "USER-4"
+          - "USER-5"
     # language=JSON
     response: |-
       {
@@ -123,15 +127,19 @@ serviceCalls:
   - serviceName: "service2"
     request:
       query: |
-        query {
+        query ($v0: [ID]) {
           users {
-            usersByIds(id: ["USER-1", "USER-2", "USER-3"]) {
+            usersByIds(id: $v0) {
               id
               batch_hydration__authors__id: id
             }
           }
         }
-      variables: { }
+      variables:
+        v0:
+          - "USER-1"
+          - "USER-2"
+          - "USER-3"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/hydration/top-level-field-data-returns-null-in-synthetic-hydration.yml
+++ b/test/src/test/resources/fixtures/hydration/top-level-field-data-returns-null-in-synthetic-hydration.yml
@@ -77,14 +77,15 @@ serviceCalls:
   - serviceName: "service2"
     request:
       query: |
-        query {
+        query ($v0: ID) {
           projects {
-            project(id: "project1") {
+            project(id: $v0) {
               name
             }
           }
         }
-      variables: { }
+      variables:
+        v0: "project1"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/hydration/top-level-field-is-null-in-batched-synthetic-hydration.yml
+++ b/test/src/test/resources/fixtures/hydration/top-level-field-is-null-in-batched-synthetic-hydration.yml
@@ -100,15 +100,19 @@ serviceCalls:
   - serviceName: "service2"
     request:
       query: |
-        query {
+        query ($v0: [ID]) {
           users {
-            usersByIds(id: ["USER-1", "USER-2", "USER-3"]) {
+            usersByIds(id: $v0) {
               id
               batch_hydration__authors__id: id
             }
           }
         }
-      variables: { }
+      variables:
+        v0:
+          - "USER-1"
+          - "USER-2"
+          - "USER-3"
     # language=JSON
     response: |-
       {
@@ -120,15 +124,19 @@ serviceCalls:
   - serviceName: "service2"
     request:
       query: |
-        query {
+        query ($v0: [ID]) {
           users {
-            usersByIds(id: ["USER-2", "USER-4", "USER-5"]) {
+            usersByIds(id: $v0) {
               id
               batch_hydration__authors__id: id
             }
           }
         }
-      variables: { }
+      variables:
+        v0:
+          - "USER-2"
+          - "USER-4"
+          - "USER-5"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/hydration/top-level-field-is-null-in-synthetic-hydration.yml
+++ b/test/src/test/resources/fixtures/hydration/top-level-field-is-null-in-synthetic-hydration.yml
@@ -77,14 +77,15 @@ serviceCalls:
   - serviceName: "service2"
     request:
       query: |
-        query {
+        query ($v0: ID) {
           projects {
-            project(id: "project1") {
+            project(id: $v0) {
               name
             }
           }
         }
-      variables: { }
+      variables:
+        v0: "project1"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/hydration/transformer-on-hydration-fields.yml
+++ b/test/src/test/resources/fixtures/hydration/transformer-on-hydration-fields.yml
@@ -69,13 +69,15 @@ serviceCalls:
       }
   - serviceName: "service2"
     request:
+      # todo: is this allowed? We're providing a String type here but barById expects ID
       query: |
-        query {
-          barById(id: "transformed-id") {
+        query ($v0: String) {
+          barById(id: $v0) {
             name
           }
         }
-      variables: { }
+      variables:
+        v0: "transformed-id"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/java-compat/java-ari-transform.yml
+++ b/test/src/test/resources/fixtures/java-compat/java-ari-transform.yml
@@ -28,13 +28,14 @@ serviceCalls:
   - serviceName: "service"
     request:
       query: |
-        query {
-          issue(id: "57") {
+        query ($v0: ID) {
+          issue(id: $v0) {
             __typename__rename__key: __typename
             rename__key__id: id
           }
         }
-      variables: { }
+      variables:
+        v0: "57"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/polymorphism/lower-level-interface-fields-get-typename-added.yml
+++ b/test/src/test/resources/fixtures/polymorphism/lower-level-interface-fields-get-typename-added.yml
@@ -137,15 +137,16 @@ serviceCalls:
   - serviceName: "PetService"
     request:
       query: |
-        query petQ {
-          pets(isLoyal: true) {
+        query petQ($v0: Boolean) {
+          pets(isLoyal: $v0) {
             collar {
               color
             }
             name
           }
         }
-      variables: { }
+      variables:
+        v0: true
       operationName: "petQ"
     # language=JSON
     response: |-

--- a/test/src/test/resources/fixtures/polymorphism/lower-level-interface-fields-which-are-renamed-get-typename-added.yml
+++ b/test/src/test/resources/fixtures/polymorphism/lower-level-interface-fields-which-are-renamed-get-typename-added.yml
@@ -137,8 +137,8 @@ serviceCalls:
   - serviceName: "PetService"
     request:
       query: |
-        query petQ {
-          pets(isLoyal: true) {
+        query petQ($v0: Boolean) {
+          pets(isLoyal: $v0) {
             __typename__rename__collarToRenamed: __typename
             name
             ... on Cat {
@@ -153,7 +153,8 @@ serviceCalls:
             }
           }
         }
-      variables: { }
+      variables:
+        v0: true
       operationName: "petQ"
     # language=JSON
     response: |-

--- a/test/src/test/resources/fixtures/polymorphism/query-with-pass-through-interfaces-and-unions-that-dont-have-typename-in-them-work-as-expected.yml
+++ b/test/src/test/resources/fixtures/polymorphism/query-with-pass-through-interfaces-and-unions-that-dont-have-typename-in-them-work-as-expected.yml
@@ -148,8 +148,8 @@ serviceCalls:
   - serviceName: "PetService"
     request:
       query: |
-        query petQ {
-          raining(isLoyal: true) {
+        query petQ($v0: Boolean) {
+          raining(isLoyal: $v0) {
             ... on Cat {
               wearsBell
             }
@@ -158,7 +158,8 @@ serviceCalls:
             }
           }
         }
-      variables: { }
+      variables:
+        v0: true
       operationName: "petQ"
     # language=JSON
     response: |-
@@ -173,8 +174,8 @@ serviceCalls:
   - serviceName: "PetService"
     request:
       query: |
-        query petQ {
-          pets(isLoyal: true) {
+        query petQ($v0: Boolean) {
+          pets(isLoyal: $v0) {
             name
             ... on Cat {
               wearsBell
@@ -184,7 +185,8 @@ serviceCalls:
             }
           }
         }
-      variables: { }
+      variables:
+        v0: true
       operationName: "petQ"
     # language=JSON
     response: |-

--- a/test/src/test/resources/fixtures/polymorphism/query-with-pass-through-interfaces-and-unions-that-have-aliased-typename-in-fragments-work-as-expected.yml
+++ b/test/src/test/resources/fixtures/polymorphism/query-with-pass-through-interfaces-and-unions-that-have-aliased-typename-in-fragments-work-as-expected.yml
@@ -144,8 +144,8 @@ serviceCalls:
   - serviceName: "PetService"
     request:
       query: |
-        query petQ {
-          pets(isLoyal: true) {
+        query petQ($v0: Boolean) {
+          pets(isLoyal: $v0) {
             name
             ... on Cat {
               aliasedCatTypeName: __typename
@@ -157,7 +157,8 @@ serviceCalls:
             }
           }
         }
-      variables: { }
+      variables:
+        v0: true
       operationName: "petQ"
     # language=JSON
     response: |-

--- a/test/src/test/resources/fixtures/polymorphism/query-with-pass-through-interfaces-and-unions-that-have-mixed-typename-in-them-work-as-expected.yml
+++ b/test/src/test/resources/fixtures/polymorphism/query-with-pass-through-interfaces-and-unions-that-have-mixed-typename-in-them-work-as-expected.yml
@@ -150,8 +150,8 @@ serviceCalls:
   - serviceName: "PetService"
     request:
       query: |
-        query petQ {
-          pets(isLoyal: true) {
+        query petQ($v0: Boolean) {
+          pets(isLoyal: $v0) {
             name
             ... on Cat {
               wearsBell
@@ -162,7 +162,8 @@ serviceCalls:
             }
           }
         }
-      variables: { }
+      variables:
+        v0: true
       operationName: "petQ"
     # language=JSON
     response: |-
@@ -185,8 +186,8 @@ serviceCalls:
   - serviceName: "PetService"
     request:
       query: |
-        query petQ {
-          raining(isLoyal: true) {
+        query petQ($v0: Boolean) {
+          raining(isLoyal: $v0) {
             __typename
             ... on Cat {
               wearsBell
@@ -196,7 +197,8 @@ serviceCalls:
             }
           }
         }
-      variables: { }
+      variables:
+        v0: true
       operationName: "petQ"
     # language=JSON
     response: |-

--- a/test/src/test/resources/fixtures/polymorphism/query-with-pass-through-interfaces-and-unions-that-have-typename-in-fragments-work-as-expected.yml
+++ b/test/src/test/resources/fixtures/polymorphism/query-with-pass-through-interfaces-and-unions-that-have-typename-in-fragments-work-as-expected.yml
@@ -158,8 +158,8 @@ serviceCalls:
   - serviceName: "PetService"
     request:
       query: |
-        query petQ {
-          pets(isLoyal: true) {
+        query petQ($v0: Boolean) {
+          pets(isLoyal: $v0) {
             __typename
             name
             ... on Cat {
@@ -170,7 +170,8 @@ serviceCalls:
             }
           }
         }
-      variables: { }
+      variables:
+        v0: true
       operationName: "petQ"
     # language=JSON
     response: |-
@@ -194,8 +195,8 @@ serviceCalls:
   - serviceName: "PetService"
     request:
       query: |
-        query petQ {
-          raining(isLoyal: true) {
+        query petQ($v0: Boolean) {
+          raining(isLoyal: $v0) {
             __typename
             ... on Cat {
               wearsBell
@@ -205,7 +206,8 @@ serviceCalls:
             }
           }
         }
-      variables: { }
+      variables:
+        v0: true
       operationName: "petQ"
     # language=JSON
     response: |-

--- a/test/src/test/resources/fixtures/polymorphism/query-with-pass-through-interfaces-and-unions-that-have-typename-in-them-work-as-expected.yml
+++ b/test/src/test/resources/fixtures/polymorphism/query-with-pass-through-interfaces-and-unions-that-have-typename-in-them-work-as-expected.yml
@@ -151,8 +151,8 @@ serviceCalls:
   - serviceName: "PetService"
     request:
       query: |
-        query petQ {
-          raining(isLoyal: true) {
+        query petQ($v0: Boolean) {
+          raining(isLoyal: $v0) {
             __typename
             ... on Cat {
               wearsBell
@@ -162,7 +162,8 @@ serviceCalls:
             }
           }
         }
-      variables: { }
+      variables:
+        v0: true
       operationName: "petQ"
     # language=JSON
     response: |-
@@ -178,8 +179,8 @@ serviceCalls:
   - serviceName: "PetService"
     request:
       query: |
-        query petQ {
-          pets(isLoyal: true) {
+        query petQ($v0: Boolean) {
+          pets(isLoyal: $v0) {
             __typename
             name
             ... on Cat {
@@ -190,7 +191,8 @@ serviceCalls:
             }
           }
         }
-      variables: { }
+      variables:
+        v0: true
       operationName: "petQ"
     # language=JSON
     response: |-

--- a/test/src/test/resources/fixtures/renames/rename-inside-hydration.yml
+++ b/test/src/test/resources/fixtures/renames/rename-inside-hydration.yml
@@ -88,13 +88,14 @@ serviceCalls:
   - serviceName: "service2"
     request:
       query: |
-        query {
-          barById(id: "barId") {
+        query ($v0: ID) {
+          barById(id: $v0) {
             __typename__rename__title: __typename
             rename__title__name: name
           }
         }
-      variables: { }
+      variables:
+        v0: "barId"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/renames/rename-inside-multiple-hydrations.yml
+++ b/test/src/test/resources/fixtures/renames/rename-inside-multiple-hydrations.yml
@@ -82,13 +82,14 @@ serviceCalls:
   - serviceName: "service2"
     request:
       query: |
-        query {
-          barById(id: "barId") {
+        query ($v0: ID) {
+          barById(id: $v0) {
             __typename__rename__title: __typename
             rename__title__name: name
           }
         }
-      variables: { }
+      variables:
+        v0: "barId"
     # language=JSON
     response: |-
       {
@@ -103,13 +104,14 @@ serviceCalls:
   - serviceName: "service2"
     request:
       query: |
-        query {
-          barById(id: "barId2") {
+        query ($v0: ID) {
+          barById(id: $v0) {
             __typename__rename__title: __typename
             rename__title__name: name
           }
         }
-      variables: { }
+      variables:
+        v0: "barId2"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/renames/rename-on-shared-abstract-type.yml
+++ b/test/src/test/resources/fixtures/renames/rename-on-shared-abstract-type.yml
@@ -58,12 +58,13 @@ serviceCalls:
   - serviceName: "worlds"
     request:
       query: |
-        query {
-          node(id: "world-1") {
+        query ($v0: ID) {
+          node(id: $v0) {
             id
           }
         }
-      variables: { }
+      variables:
+        v0: "world-1"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/renames/renamed-top-level-field-with-argument.yml
+++ b/test/src/test/resources/fixtures/renames/renamed-top-level-field-with-argument.yml
@@ -28,12 +28,13 @@ serviceCalls:
   - serviceName: "MyService"
     request:
       query: |
-        query {
-          rename__renameObject__renameObjectUnderlying: renameObjectUnderlying(id: "OBJECT-001") {
+        query ($v0: ID!) {
+          rename__renameObject__renameObjectUnderlying: renameObjectUnderlying(id: $v0) {
             name
           }
         }
-      variables: { }
+      variables:
+        v0: "OBJECT-001"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/renames/types/renamed-interface-type-is-shared.yml
+++ b/test/src/test/resources/fixtures/renames/types/renamed-interface-type-is-shared.yml
@@ -20,6 +20,9 @@ overallSchema:
     }
 underlyingSchema:
   NextgenIssues: |-
+    interface Node {
+      id: ID
+    }
     type Query {
       node(id: ID!): Node
     }
@@ -49,15 +52,14 @@ variables: { }
 serviceCalls:
   - serviceName: "NextgenIssues"
     request:
-      query: |-
-        query {
-          node(id: "ISSUE-1") {
-            ... on NextgenIssue {
-              id
-            }
+      query: |
+        query ($v0: ID!) {
+          node(id: $v0) {
+            id
           }
         }
-      variables: { }
+      variables:
+        v0: "ISSUE-1"
     # language=JSON
     response: "{}"
 # language=JSON

--- a/test/src/test/resources/fixtures/renames/types/renamed-type-inside-batch-hydration.yml
+++ b/test/src/test/resources/fixtures/renames/types/renamed-type-inside-batch-hydration.yml
@@ -95,8 +95,8 @@ serviceCalls:
   - serviceName: "IssueService"
     request:
       query: |
-        query {
-          issuesByIds(id: ["issue-1", "issue-2", "issue-3"]) {
+        query ($v0: [ID!]) {
+          issuesByIds(id: $v0) {
             details {
               __typename
               name
@@ -104,7 +104,11 @@ serviceCalls:
             batch_hydration__issue__id: id
           }
         }
-      variables: { }
+      variables:
+        v0:
+          - "issue-1"
+          - "issue-2"
+          - "issue-3"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/renames/types/renamed-type-inside-deep-rename-that-returns-null.yml
+++ b/test/src/test/resources/fixtures/renames/types/renamed-type-inside-deep-rename-that-returns-null.yml
@@ -49,8 +49,8 @@ serviceCalls:
   - serviceName: "IssueService"
     request:
       query: |
-        query {
-          issueById(id: "issue-1") {
+        query ($v0: ID!) {
+          issueById(id: $v0) {
             __typename__deep_rename__assignee: __typename
             deep_rename__assignee__details: details {
               assignee {
@@ -63,7 +63,8 @@ serviceCalls:
             }
           }
         }
-      variables: { }
+      variables:
+        v0: "issue-1"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/renames/types/renamed-type-inside-deep-rename.yml
+++ b/test/src/test/resources/fixtures/renames/types/renamed-type-inside-deep-rename.yml
@@ -49,8 +49,8 @@ serviceCalls:
   - serviceName: "IssueService"
     request:
       query: |
-        query {
-          issueById(id: "issue-1") {
+        query ($v0: ID!) {
+          issueById(id: $v0) {
             __typename__deep_rename__assignee: __typename
             deep_rename__assignee__details: details {
               assignee {
@@ -63,7 +63,8 @@ serviceCalls:
             }
           }
         }
-      variables: { }
+      variables:
+        v0: "issue-1"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/renames/types/renamed-type-inside-hydration-that-returns-null.yml
+++ b/test/src/test/resources/fixtures/renames/types/renamed-type-inside-hydration-that-returns-null.yml
@@ -84,15 +84,16 @@ serviceCalls:
   - serviceName: "IssueService"
     request:
       query: |
-        query {
-          issueById(id: "issue-2") {
+        query ($v0: ID!) {
+          issueById(id: $v0) {
             details {
               __typename
               name
             }
           }
         }
-      variables: { }
+      variables:
+        v0: "issue-2"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/renames/types/renamed-type-inside-hydration.yml
+++ b/test/src/test/resources/fixtures/renames/types/renamed-type-inside-hydration.yml
@@ -84,15 +84,16 @@ serviceCalls:
   - serviceName: "IssueService"
     request:
       query: |
-        query {
-          issueById(id: "issue-2") {
+        query ($v0: ID!) {
+          issueById(id: $v0) {
             details {
               __typename
               name
             }
           }
         }
-      variables: { }
+      variables:
+        v0: "issue-2"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/renames/types/renamed-type-is-shared-but-not-renamed-in-one-service.yml
+++ b/test/src/test/resources/fixtures/renames/types/renamed-type-is-shared-but-not-renamed-in-one-service.yml
@@ -40,13 +40,14 @@ serviceCalls:
   - serviceName: "NextgenIssues"
     request:
       query: |
-        query TestyMctest {
-          fastIssue(id: "ISSUE-1") {
+        query TestyMctest($v0: ID!) {
+          fastIssue(id: $v0) {
             type: __typename
             id
           }
         }
-      variables: { }
+      variables:
+        v0: "ISSUE-1"
       operationName: "TestyMctest"
     # language=JSON
     response: |-

--- a/test/src/test/resources/fixtures/renames/types/renamed-type-is-shared-deeper.yml
+++ b/test/src/test/resources/fixtures/renames/types/renamed-type-is-shared-deeper.yml
@@ -53,8 +53,8 @@ serviceCalls:
   - serviceName: "NextgenIssues"
     request:
       query: |
-        query {
-          issue(id: "ISSUE-1") {
+        query ($v0: ID!) {
+          issue(id: $v0) {
             __typename
             assignee {
               __typename
@@ -63,7 +63,8 @@ serviceCalls:
             id
           }
         }
-      variables: { }
+      variables:
+        v0: "ISSUE-1"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/renames/types/renamed-type-is-shared-with-random-type-name.yml
+++ b/test/src/test/resources/fixtures/renames/types/renamed-type-is-shared-with-random-type-name.yml
@@ -94,23 +94,15 @@ variables: { }
 serviceCalls:
   - serviceName: "Nextgen"
     request:
-      query: |-
+      query: |
         query {
-          ... on Query {
-            elements {
-              ... on NextgenElementConnection {
+          elements {
+            __typename
+            nodes {
+              __typename
+              other {
                 __typename
-                nodes {
-                  ... on NextgenElement {
-                    __typename
-                    other {
-                      ... on NextgenOther {
-                        __typename
-                        id
-                      }
-                    }
-                  }
-                }
+                id
               }
             }
           }
@@ -137,23 +129,15 @@ serviceCalls:
       }
   - serviceName: "Service"
     request:
-      query: |-
+      query: |
         query {
-          ... on Query {
-            old {
-              ... on ElementConnection {
+          old {
+            __typename
+            nodes {
+              __typename
+              other {
                 __typename
-                nodes {
-                  ... on Element {
-                    __typename
-                    other {
-                      ... on Other {
-                        __typename
-                        id
-                      }
-                    }
-                  }
-                }
+                id
               }
             }
           }

--- a/test/src/test/resources/fixtures/renames/types/renamed-type-is-shared.yml
+++ b/test/src/test/resources/fixtures/renames/types/renamed-type-is-shared.yml
@@ -40,13 +40,14 @@ serviceCalls:
   - serviceName: "NextgenIssues"
     request:
       query: |
-        query {
-          fastIssue(id: "ISSUE-1") {
+        query ($v0: ID!) {
+          fastIssue(id: $v0) {
             __typename
             id
           }
         }
-      variables: { }
+      variables:
+        v0: "ISSUE-1"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/renames/types/renamed-type-shared-page-info.yml
+++ b/test/src/test/resources/fixtures/renames/types/renamed-type-shared-page-info.yml
@@ -68,22 +68,14 @@ serviceCalls:
     request:
       query: |
         query {
-          ... on Query {
-            issues {
-              ... on IssueConnection {
-                __typename
-                nodes {
-                  ... on Issue {
-                    id
-                  }
-                }
-                pageInfo {
-                  ... on IssuePageInfo {
-                    __typename
-                    endCursor
-                  }
-                }
-              }
+          issues {
+            __typename
+            nodes {
+              id
+            }
+            pageInfo {
+              __typename
+              endCursor
             }
           }
         }

--- a/test/src/test/resources/fixtures/renames/types/repeated-fragments-with-renamed-types.yml
+++ b/test/src/test/resources/fixtures/renames/types/repeated-fragments-with-renamed-types.yml
@@ -128,8 +128,8 @@ serviceCalls:
   - serviceName: "Users"
     request:
       query: |
-        query {
-          service(id: "service-1") {
+        query ($v0: ID!) {
+          service(id: $v0) {
             __typename
             dependedOn {
               __typename
@@ -315,7 +315,8 @@ serviceCalls:
             name
           }
         }
-      variables: { }
+      variables:
+        v0: "service-1"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/renames/variable-referenced-input-types-rename-works-as-expected.yml
+++ b/test/src/test/resources/fixtures/renames/variable-referenced-input-types-rename-works-as-expected.yml
@@ -98,10 +98,12 @@ serviceCalls:
   - serviceName: "MyService"
     request:
       query: |
-        query X {
-          renameInput(arg1: {inputVal : "x"})
+        query X($v0: InputUnderlying!) {
+          renameInput(arg1: $v0)
         }
-      variables: { }
+      variables:
+        v0:
+          inputVal: "x"
       operationName: "X"
     # language=JSON
     response: |-

--- a/test/src/test/resources/fixtures/scalars/date-time-scalar-as-input-type.yml
+++ b/test/src/test/resources/fixtures/scalars/date-time-scalar-as-input-type.yml
@@ -31,12 +31,13 @@ serviceCalls:
   - serviceName: "service"
     request:
       query: |
-        query {
-          foo(input: "2022-03-09T05:01:50Z") {
+        query ($v0: DateTime) {
+          foo(input: $v0) {
             thing
           }
         }
-      variables: { }
+      variables:
+        v0: "2022-03-09T05:01:50Z"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/scalars/hydrating-json-data.yml
+++ b/test/src/test/resources/fixtures/scalars/hydrating-json-data.yml
@@ -77,12 +77,13 @@ serviceCalls:
   - serviceName: "Baz"
     request:
       query: |
-        query {
-          otherFoo(id: "10000") {
+        query ($v0: ID!) {
+          otherFoo(id: $v0) {
             id
           }
         }
-      variables: { }
+      variables:
+        v0: "10000"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/scalars/hydrating-using-date-time-as-arg.yml
+++ b/test/src/test/resources/fixtures/scalars/hydrating-using-date-time-as-arg.yml
@@ -58,12 +58,13 @@ serviceCalls:
   - serviceName: "service"
     request:
       query: |
-        query {
-          successor(after: "2022-03-09T05:01:50Z") {
+        query ($v0: DateTime) {
+          successor(after: $v0) {
             id
           }
         }
-      variables: { }
+      variables:
+        v0: "2022-03-09T05:01:50Z"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/scalars/hydrating-using-long-as-arg.yml
+++ b/test/src/test/resources/fixtures/scalars/hydrating-using-long-as-arg.yml
@@ -58,12 +58,13 @@ serviceCalls:
   - serviceName: "service"
     request:
       query: |
-        query {
-          successor(after: 3000000000) {
+        query ($v0: Long) {
+          successor(after: $v0) {
             id
           }
         }
-      variables: { }
+      variables:
+        v0: 3000000000
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/scalars/hydrating-using-url-as-arg.yml
+++ b/test/src/test/resources/fixtures/scalars/hydrating-using-url-as-arg.yml
@@ -74,14 +74,15 @@ serviceCalls:
   - serviceName: "service"
     request:
       query: |
-        query {
-          lookup(url: "https://github.com/atlassian-labs/nadel") {
+        query ($v0: URL) {
+          lookup(url: $v0) {
             baseUrl
             createdAt
             owner
           }
         }
-      variables: { }
+      variables:
+        v0: "https://github.com/atlassian-labs/nadel"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/scalars/long-scalar-as-input-type.yml
+++ b/test/src/test/resources/fixtures/scalars/long-scalar-as-input-type.yml
@@ -31,12 +31,13 @@ serviceCalls:
   - serviceName: "service"
     request:
       query: |
-        query {
-          foo(input: 3000000000) {
+        query ($v0: Long) {
+          foo(input: $v0) {
             thing
           }
         }
-      variables: { }
+      variables:
+        v0: 3000000000
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/scalars/url-scalar-as-input-type.yml
+++ b/test/src/test/resources/fixtures/scalars/url-scalar-as-input-type.yml
@@ -31,12 +31,13 @@ serviceCalls:
   - serviceName: "service"
     request:
       query: |
-        query {
-          foo(input: "https://atlassian.com") {
+        query ($v0: URL) {
+          foo(input: $v0) {
             thing
           }
         }
-      variables: { }
+      variables:
+        v0: "https://atlassian.com"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/skip-include-fields/hydration/handles-include-directive-field-with-hydrated-parent.yml
+++ b/test/src/test/resources/fixtures/skip-include-fields/hydration/handles-include-directive-field-with-hydrated-parent.yml
@@ -60,12 +60,13 @@ serviceCalls:
   - serviceName: "service"
     request:
       query: |
-        query {
-          fooById(id: "Foo-1") {
+        query ($v0: ID) {
+          fooById(id: $v0) {
             __typename__skip_include____skip: __typename
           }
         }
-      variables: { }
+      variables:
+        v0: "Foo-1"
     # language=JSON
     response: |-
       {

--- a/test/src/test/resources/fixtures/skip-include-fields/hydration/handles-include-directive-on-field-with-batch-hydrated-parent.yml
+++ b/test/src/test/resources/fixtures/skip-include-fields/hydration/handles-include-directive-on-field-with-batch-hydrated-parent.yml
@@ -72,13 +72,16 @@ serviceCalls:
   - serviceName: "service"
     request:
       query: |
-        query {
-          tests(ids: ["Foo-3", "Foo-4"]) {
+        query ($v0: [ID]) {
+          tests(ids: $v0) {
             __typename__skip_include____skip: __typename
             batch_hydration__test__id: id
           }
         }
-      variables: { }
+      variables:
+        v0:
+          - "Foo-3"
+          - "Foo-4"
     # language=JSON
     response: |-
       {


### PR DESCRIPTION
Builds on #418 to feed all the queries through `ExecutableNormalizedOperationFactory` and then dump the updated queries back out to use all variables.

Not sure when we should merge this, I don't think we'll be deploying this feature flag soon due to conflicts in input types we found… Leaving it as as draft for now.