### PR TITLE
add extensions to execution input

### DIFF
--- a/lib/src/main/java/graphql/nadel/Nadel.kt
+++ b/lib/src/main/java/graphql/nadel/Nadel.kt
@@ -18,7 +18,6 @@ import graphql.nadel.instrumentation.NadelInstrumentation
 import graphql.nadel.instrumentation.parameters.NadelInstrumentationCreateStateParameters
 import graphql.nadel.instrumentation.parameters.NadelInstrumentationQueryExecutionParameters
 import graphql.nadel.instrumentation.parameters.NadelInstrumentationQueryValidationParameters
-import graphql.nadel.schema.NeverWiringFactory
 import graphql.nadel.schema.QuerySchemaGenerator
 import graphql.nadel.schema.SchemaTransformationHook
 import graphql.nadel.util.LogKit
@@ -54,6 +53,7 @@ class Nadel private constructor(
             .operationName(nadelExecutionInput.operationName)
             .context(nadelExecutionInput.context)
             .variables(nadelExecutionInput.variables)
+            .extensions(nadelExecutionInput.extensions)
             .executionId(nadelExecutionInput.executionId)
             .build()
 

--- a/lib/src/main/java/graphql/nadel/NadelExecutionInput.kt
+++ b/lib/src/main/java/graphql/nadel/NadelExecutionInput.kt
@@ -7,6 +7,7 @@ class NadelExecutionInput private constructor(
     val operationName: String?,
     val context: Any?,
     val variables: Map<String, Any?>,
+    val extensions: Map<String, Any?>,
     val executionId: ExecutionId?,
     val nadelExecutionHints: NadelExecutionHints,
 ) {
@@ -15,6 +16,7 @@ class NadelExecutionInput private constructor(
         private var operationName: String? = null
         private var context: Any? = null
         private var variables: Map<String, Any?> = LinkedHashMap()
+        private var extensions: Map<String, Any?> = LinkedHashMap()
         private var executionId: ExecutionId? = null
         private var executionHints = NadelExecutionHints.newHints().build()
 
@@ -35,6 +37,11 @@ class NadelExecutionInput private constructor(
 
         fun variables(variables: Map<String, Any?>?): Builder {
             this.variables = variables ?: emptyMap()
+            return this
+        }
+
+        fun extensions(extensions: Map<String, Any?>?): Builder {
+            this.extensions = extensions ?: emptyMap()
             return this
         }
 
@@ -61,6 +68,7 @@ class NadelExecutionInput private constructor(
                 operationName = operationName,
                 context = context,
                 variables = variables,
+                extensions = extensions,
                 executionId = executionId,
                 nadelExecutionHints = executionHints,
             )


### PR DESCRIPTION
Please make sure you consider the following:

- [x] Add tests that use __typename in queries
- [x] Does this change work with all nadel transformations (rename, type rename, hydration, etc)? Add tests for this.
- [x] Is it worth using hints for this change in order to be able to enable a percentage rollout?
- [x] Do we need to add integration tests for this change in the graphql gateway?
- [x] Do we need a pollinator check for this?
