### PR TITLE
Remove hydration specific execute path

### DIFF
--- a/lib/src/main/java/graphql/nadel/NadelExecutionHints.kt
+++ b/lib/src/main/java/graphql/nadel/NadelExecutionHints.kt
@@ -28,6 +28,7 @@ data class NadelExecutionHints constructor(
         constructor(nadelExecutionHints: NadelExecutionHints) {
             legacyOperationNames = nadelExecutionHints.legacyOperationNames
             allDocumentVariablesHint = nadelExecutionHints.allDocumentVariablesHint
+            removeHydrationSpecificExecutionCode = nadelExecutionHints.removeHydrationSpecificExecutionCode
         }
 
         fun legacyOperationNames(flag: LegacyOperationNamesHint): Builder {

--- a/lib/src/main/java/graphql/nadel/NextgenEngine.kt
+++ b/lib/src/main/java/graphql/nadel/NextgenEngine.kt
@@ -17,12 +17,9 @@ import graphql.nadel.engine.plan.NadelExecutionPlanFactory
 import graphql.nadel.engine.transform.NadelTransform
 import graphql.nadel.engine.transform.query.DynamicServiceResolution
 import graphql.nadel.engine.transform.query.NadelFieldToService
-import graphql.nadel.engine.transform.query.NadelQueryPath
 import graphql.nadel.engine.transform.query.NadelQueryTransformer
 import graphql.nadel.engine.transform.result.NadelResultTransformer
 import graphql.nadel.engine.util.beginExecute
-import graphql.nadel.engine.util.copy
-import graphql.nadel.engine.util.fold
 import graphql.nadel.engine.util.getOperationKind
 import graphql.nadel.engine.util.mergeResults
 import graphql.nadel.engine.util.newExecutionErrorResult
@@ -32,8 +29,8 @@ import graphql.nadel.engine.util.newServiceExecutionResult
 import graphql.nadel.engine.util.provide
 import graphql.nadel.engine.util.singleOfType
 import graphql.nadel.engine.util.strictAssociateBy
-import graphql.nadel.engine.util.toBuilder
 import graphql.nadel.engine.instrumentation.NadelInstrumentationTimer
+import graphql.nadel.engine.util.copy
 import graphql.nadel.hooks.ServiceExecutionHooks
 import graphql.nadel.instrumentation.parameters.NadelInstrumentationTimingParameters.RootStep
 import graphql.nadel.util.ErrorUtil
@@ -193,16 +190,28 @@ class NextgenEngine @JvmOverloads constructor(
         topLevelField: ExecutableNormalizedField,
         service: Service,
         executionContext: NadelExecutionContext,
+        serviceHydrationDetails: ServiceExecutionHydrationDetails?=null,
     ): ExecutionResult {
         val timer = executionContext.timer
         val executionPlan = timer.time(step = RootStep.ExecutionPlanning) {
-            executionPlanner.create(executionContext, services, service, topLevelField)
+            executionPlanner.create(
+                executionContext = executionContext,
+                services = services,
+                service = service,
+                rootField = topLevelField,
+                serviceHydrationDetails = serviceHydrationDetails,
+            )
         }
         val queryTransform = timer.time(step = RootStep.QueryTransforming) {
             transformQuery(service, executionContext, executionPlan, topLevelField)
         }
         val transformedQuery = queryTransform.result.single()
-        val result: ServiceExecutionResult = executeService(service, transformedQuery, executionContext)
+        val result: ServiceExecutionResult = executeService(
+            service = service,
+            transformedQuery = transformedQuery,
+            executionContext = executionContext,
+            executionHydrationDetails = serviceHydrationDetails
+        )
         val transformedResult: ServiceExecutionResult = when {
             topLevelField.name.startsWith("__") -> result
             else -> timer.time(step = RootStep.ResultTransforming) {
@@ -223,75 +232,6 @@ class NextgenEngine @JvmOverloads constructor(
             .errors(ErrorUtil.createGraphQLErrorsFromRawErrors(transformedResult.errors))
             .extensions(transformedResult.extensions as Map<Any, Any>)
             .build()
-    }
-
-    internal suspend fun executeHydration(
-        service: Service,
-        topLevelField: ExecutableNormalizedField,
-        pathToActorField: NadelQueryPath,
-        executionContext: NadelExecutionContext,
-        serviceHydrationDetails: ServiceExecutionHydrationDetails,
-    ): ServiceExecutionResult {
-        val actorField = fold(initial = topLevelField, count = pathToActorField.segments.size - 1) {
-            it.children.single()
-        }
-
-        val (transformResult, executionPlan) = transformHydrationQuery(
-            service,
-            executionContext,
-            actorField,
-            serviceHydrationDetails
-        )
-
-        // Get to the top level field again using .parent N times on the new actor field
-        val transformedQuery: ExecutableNormalizedField = fold(
-            initial = transformResult.result.single(),
-            count = pathToActorField.segments.size - 1,
-        ) {
-            it.parent ?: error("No parent")
-        }
-
-        val result = executeService(
-            service,
-            transformedQuery,
-            executionContext,
-            serviceHydrationDetails,
-        )
-
-        return resultTransformer.transform(
-            executionContext = executionContext,
-            executionPlan = executionPlan,
-            artificialFields = transformResult.artificialFields,
-            overallToUnderlyingFields = transformResult.overallToUnderlyingFields,
-            service = service,
-            result = result,
-        )
-    }
-
-    private suspend fun transformHydrationQuery(
-        service: Service,
-        executionContext: NadelExecutionContext,
-        actorField: ExecutableNormalizedField,
-        serviceHydrationDetails: ServiceExecutionHydrationDetails,
-    ): Pair<NadelQueryTransformer.TransformResult, NadelExecutionPlan> {
-        val executionPlan = executionPlanner.create(
-            executionContext,
-            services,
-            service,
-            rootField = actorField,
-            serviceHydrationDetails,
-        )
-
-        val queryTransform = transformQuery(service, executionContext, executionPlan, actorField)
-
-        // Fix parent of the actor field
-        if (actorField.parent != null) {
-            val fixedParent = actorField.parent.toBuilder().children(queryTransform.result).build()
-            val queryTransformResult = queryTransform.result.single()
-            queryTransformResult.replaceParent(fixedParent)
-        }
-
-        return Pair(queryTransform, executionPlan)
     }
 
     private suspend fun executeService(

--- a/lib/src/main/java/graphql/nadel/engine/plan/NadelExecutionPlanFactory.kt
+++ b/lib/src/main/java/graphql/nadel/engine/plan/NadelExecutionPlanFactory.kt
@@ -37,7 +37,7 @@ internal class NadelExecutionPlanFactory(
         services: Map<String, Service>,
         service: Service,
         rootField: ExecutableNormalizedField,
-        serviceHydrationDetails: ServiceExecutionHydrationDetails? = null,
+        serviceHydrationDetails: ServiceExecutionHydrationDetails?,
     ): NadelExecutionPlan {
         val executionSteps = mutableListOf<AnyNadelExecutionPlanStep>()
 

--- a/lib/src/main/java/graphql/nadel/engine/transform/hydration/NadelHydrationTransform.kt
+++ b/lib/src/main/java/graphql/nadel/engine/transform/hydration/NadelHydrationTransform.kt
@@ -201,10 +201,9 @@ internal class NadelHydrationTransform(
             ).map { actorQuery ->
                 async {
                     val hydrationSourceService = executionBlueprint.getServiceOwning(instruction.location)!!
-                    engine.executeHydration(
+                    engine.execute(
                         service = instruction.actorService,
                         topLevelField = actorQuery,
-                        pathToActorField = instruction.queryPathToActorField,
                         executionContext = executionContext,
                         serviceHydrationDetails = ServiceExecutionHydrationDetails(
                             instruction.timeout,

--- a/lib/src/main/java/graphql/nadel/engine/transform/hydration/NadelHydrationTransform.kt
+++ b/lib/src/main/java/graphql/nadel/engine/transform/hydration/NadelHydrationTransform.kt
@@ -201,7 +201,7 @@ internal class NadelHydrationTransform(
             ).map { actorQuery ->
                 async {
                     val hydrationSourceService = executionBlueprint.getServiceOwning(instruction.location)!!
-                    engine.execute(
+                    engine.executeTopLevelField(
                         service = instruction.actorService,
                         topLevelField = actorQuery,
                         executionContext = executionContext,

--- a/lib/src/main/java/graphql/nadel/engine/transform/hydration/batch/NadelBatchHydrator.kt
+++ b/lib/src/main/java/graphql/nadel/engine/transform/hydration/batch/NadelBatchHydrator.kt
@@ -131,10 +131,9 @@ internal class NadelBatchHydrator(
                 .map { actorQuery ->
                     async { // This async executes the batches in parallel i.e. executes hydration as Deferred/Future
                         val hydrationSourceService = executionBlueprint.getServiceOwning(instruction.location)!!
-                        engine.executeHydration(
+                        engine.execute(
                             service = instruction.actorService,
                             topLevelField = actorQuery,
-                            pathToActorField = instruction.queryPathToActorField,
                             executionContext = state.executionContext,
                             serviceHydrationDetails = ServiceExecutionHydrationDetails(
                                 instruction.timeout,

--- a/lib/src/main/java/graphql/nadel/engine/transform/hydration/batch/NadelBatchHydrator.kt
+++ b/lib/src/main/java/graphql/nadel/engine/transform/hydration/batch/NadelBatchHydrator.kt
@@ -131,7 +131,7 @@ internal class NadelBatchHydrator(
                 .map { actorQuery ->
                     async { // This async executes the batches in parallel i.e. executes hydration as Deferred/Future
                         val hydrationSourceService = executionBlueprint.getServiceOwning(instruction.location)!!
-                        engine.execute(
+                        engine.executeTopLevelField(
                             service = instruction.actorService,
                             topLevelField = actorQuery,
                             executionContext = state.executionContext,

--- a/lib/src/main/java/graphql/nadel/util/ErrorUtil.kt
+++ b/lib/src/main/java/graphql/nadel/util/ErrorUtil.kt
@@ -5,7 +5,7 @@ import graphql.GraphQLError
 import graphql.GraphqlErrorBuilder
 import graphql.language.SourceLocation
 
-typealias  GraphQLErrorBuilder = GraphqlErrorBuilder<*>
+typealias GraphQLErrorBuilder = GraphqlErrorBuilder<*>
 
 /**
  * A helper class that can to deal with graphql errors

--- a/test/src/test/kotlin/graphql/nadel/tests/hooks/all-hydration-fields-are-seen-by-transformer.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/hooks/all-hydration-fields-are-seen-by-transformer.kt
@@ -1,6 +1,7 @@
 package graphql.nadel.tests.hooks
 
 import graphql.ExecutionResult
+import graphql.nadel.NadelExecutionHints
 import graphql.nadel.Service
 import graphql.nadel.ServiceExecutionHydrationDetails
 import graphql.nadel.ServiceExecutionResult
@@ -20,6 +21,11 @@ class `all-hydration-fields-are-seen-by-transformer` : EngineTestHook {
     private val isApplicable = mutableListOf<String>()
     private val transformField = mutableListOf<String>()
     private val getResultInstructions = mutableListOf<String>()
+
+    override fun makeExecutionHints(builder: NadelExecutionHints.Builder): NadelExecutionHints.Builder {
+        return builder
+            .removeHydrationSpecificExecutionCode(true)
+    }
 
     override val customTransforms: List<NadelTransform<out Any>>
         get() = listOf(

--- a/test/src/test/kotlin/graphql/nadel/tests/hooks/all-hydration-fields-are-seen-by-transformer.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/hooks/all-hydration-fields-are-seen-by-transformer.kt
@@ -1,0 +1,73 @@
+package graphql.nadel.tests.hooks
+
+import graphql.ExecutionResult
+import graphql.nadel.Service
+import graphql.nadel.ServiceExecutionHydrationDetails
+import graphql.nadel.ServiceExecutionResult
+import graphql.nadel.engine.NadelExecutionContext
+import graphql.nadel.engine.blueprint.NadelOverallExecutionBlueprint
+import graphql.nadel.engine.transform.NadelTransform
+import graphql.nadel.engine.transform.NadelTransformFieldResult
+import graphql.nadel.engine.transform.query.NadelQueryTransformer
+import graphql.nadel.engine.transform.result.NadelResultInstruction
+import graphql.nadel.engine.transform.result.json.JsonNodes
+import graphql.nadel.tests.EngineTestHook
+import graphql.nadel.tests.UseHook
+import graphql.normalized.ExecutableNormalizedField
+
+@UseHook
+class `all-hydration-fields-are-seen-by-transformer` : EngineTestHook {
+    private val isApplicable = mutableListOf<String>()
+    private val transformField = mutableListOf<String>()
+    private val getResultInstructions = mutableListOf<String>()
+
+    override val customTransforms: List<NadelTransform<out Any>>
+        get() = listOf(
+            object : NadelTransform<Unit> {
+                override suspend fun isApplicable(
+                    executionContext: NadelExecutionContext,
+                    executionBlueprint: NadelOverallExecutionBlueprint,
+                    services: Map<String, Service>,
+                    service: Service,
+                    overallField: ExecutableNormalizedField,
+                    hydrationDetails: ServiceExecutionHydrationDetails?,
+                ): Unit? {
+                    isApplicable.add(overallField.resultKey)
+                    return Unit
+                }
+
+                override suspend fun transformField(
+                    executionContext: NadelExecutionContext,
+                    transformer: NadelQueryTransformer,
+                    executionBlueprint: NadelOverallExecutionBlueprint,
+                    service: Service,
+                    field: ExecutableNormalizedField,
+                    state: Unit,
+                ): NadelTransformFieldResult {
+                    transformField.add(field.resultKey)
+                    return NadelTransformFieldResult.unmodified(field)
+                }
+
+                override suspend fun getResultInstructions(
+                    executionContext: NadelExecutionContext,
+                    executionBlueprint: NadelOverallExecutionBlueprint,
+                    service: Service,
+                    overallField: ExecutableNormalizedField,
+                    underlyingParentField: ExecutableNormalizedField?,
+                    result: ServiceExecutionResult,
+                    state: Unit,
+                    nodes: JsonNodes,
+                ): List<NadelResultInstruction> {
+                    getResultInstructions.add(overallField.resultKey)
+                    return emptyList()
+                }
+            },
+        )
+
+    override fun assertResult(result: ExecutionResult) {
+        assert(isApplicable == listOf("foo", "bar", "name", "bars", "barById", "name"))
+        // // name is missing because it's removed as part of the hydration query
+        assert(transformField == listOf("foo", "bar", "bars", "barById", "name"))
+        assert(getResultInstructions == listOf("foo", "bar", "bars", "barById", "name"))
+    }
+}

--- a/test/src/test/resources/fixtures/hydration/all-hydration-fields-are-seen-by-transformer.yml
+++ b/test/src/test/resources/fixtures/hydration/all-hydration-fields-are-seen-by-transformer.yml
@@ -1,0 +1,115 @@
+name: "all hydration fields are seen by transformer"
+enabled: true
+overallSchema:
+  service2: |
+    type Query {
+      bars: BarQuery
+    }
+    type BarQuery {
+      barById(id: ID): Bar
+    }
+    type Bar {
+      id: ID
+      name: String
+    }
+  service1: |
+    type Query {
+      foo: Foo
+    }
+    type Foo {
+      id: ID
+      bar: Bar @hydrated(service: "service2" field: "bars.barById" arguments: [{name: "id" value: "$source.barId"}])
+    }
+underlyingSchema:
+  service2: |
+    type Bar {
+      id: ID
+      name: String
+    }
+
+    type Query {
+      bars: BarQuery
+    }
+    type BarQuery {
+      barById(id: ID): Bar
+    }
+  service1: |
+    type Foo {
+      barId: ID
+      fooDetails: FooDetails
+      id: ID
+    }
+
+    type FooDetails {
+      externalBarId: ID
+    }
+
+    type Query {
+      foo: Foo
+    }
+query: |
+  query {
+    foo {
+      bar {
+        name
+      }
+    }
+  }
+variables: { }
+serviceCalls:
+  - serviceName: "service1"
+    request:
+      query: |
+        query {
+          foo {
+            __typename__hydration__bar: __typename
+            hydration__bar__barId: barId
+          }
+        }
+      variables: { }
+    # language=JSON
+    response: |-
+      {
+        "data": {
+          "foo": {
+            "hydration__bar__barId": "barId",
+            "__typename__hydration__bar": "Foo"
+          }
+        },
+        "extensions": {}
+      }
+  - serviceName: "service2"
+    request:
+      query: |
+        query {
+          bars {
+            barById(id: "barId") {
+              name
+            }
+          }
+        }
+      variables: { }
+    # language=JSON
+    response: |-
+      {
+        "data": {
+          "bars": {
+            "barById": {
+              "name": "Bar1"
+            }
+          }
+        },
+        "extensions": {}
+      }
+# language=JSON
+response: |-
+  {
+    "data": {
+      "foo": {
+        "bar": {
+          "name": "Bar1"
+        }
+      }
+    },
+    "extensions": {}
+  }


### PR DESCRIPTION
So this code path used to exist because we didn't have all fields in the overall schema. Now we do, so we can pass _all_ the fields to the transforms.

We should remove the separate code path so there's less chance of bugs like today.

Not sure when we should merge. Maybe can't right now? Will double check tomorrow.