### PR TITLE
Don't bypass field validation in extended operation types

### DIFF
--- a/lib/src/main/java/graphql/nadel/validation/NadelTypeValidation.kt
+++ b/lib/src/main/java/graphql/nadel/validation/NadelTypeValidation.kt
@@ -256,7 +256,7 @@ internal class NadelTypeValidation(
             .filterIsInstance<AnyNamedNode>()
             .filter { def ->
                 if (def.isExtensionDef) {
-                    isNamespacedOperationType(typeName = def.name)
+                    isNamespacedOperationType(typeName = def.name) || isOperationType(typeName = def.name)
                 } else {
                     true
                 }
@@ -265,6 +265,7 @@ internal class NadelTypeValidation(
                 it.name
             }
             .toSet() - namesToIgnore
+
 
         // If it can be reached by using your service, you must own it to return it!
         val referencedTypes = getReachableTypeNames(overallSchema, service, definitionNames)
@@ -276,9 +277,13 @@ internal class NadelTypeValidation(
         return overallSchema.operationTypes.any { operationType ->
             operationType.fields.any { field ->
                 field.hasAppliedDirective(NadelDirectives.namespacedDirectiveDefinition.name) &&
-                    field.type.unwrapAll().name == typeName
+                        field.type.unwrapAll().name == typeName
             }
         }
+    }
+
+    private fun isOperationType(typeName: String): Boolean {
+        return overallSchema.operationTypes.map { it.name }.contains(typeName)
     }
 
     private fun visitElement(schemaElement: NadelServiceSchemaElement): Boolean {


### PR DESCRIPTION
We have a couple of services in the central-schema that are using the `extend type Query` and/or `extend type Mutation` syntax.  Event though it is not necessary to extend operation types, this is something we still support.

Another possible fix is to write a validation that prevents people from using `extend type Query/Mutation` -> but this fix in Nadel was quick and simple, and allow for more flexibility in the schema definitions.



Please make sure you consider the following:

- [x ] Add tests that use __typename in queries
- [ x] Does this change work with all nadel transformations (rename, type rename, hydration, etc)? Add tests for this.
- [ x] Is it worth using hints for this change in order to be able to enable a percentage rollout?
- [ x] Do we need to add integration tests for this change in the graphql gateway?
- [ x] Do we need a pollinator check for this?
