### PR TITLE
fix selection of source fields for batch hydration using input

### DIFF
--- a/test/src/test/resources/fixtures/hydration/complex identified by/complex-identified-by-doesnt-use-all-input-fields-in-the-input-identified-by-argument.yml
+++ b/test/src/test/resources/fixtures/hydration/complex identified by/complex-identified-by-doesnt-use-all-input-fields-in-the-input-identified-by-argument.yml
@@ -1,0 +1,224 @@
+name: "complex identified by doesnt use all input fields in the inputIdentifiedBy argument"
+enabled: true
+overallSchema:
+  Activity: |
+    type Query {
+      activities: [Activity]
+    }
+    
+    type Activity {
+      id: ID
+      issue: Issue @hydrated(
+        service: "Issue"
+        field: "issues"
+        arguments: [{name: "issuesInput" value: "$source.context.issueHydrationInput"}]
+        inputIdentifiedBy: [
+          {sourceId: "context.issueHydrationInput.id" resultId: "issueId"}
+        ]
+      )
+    }
+  Issue: |
+    type Query {
+      issues(issuesInput: IssueInput!): [Issue]
+    }
+    
+    type Issue {
+      issueId: ID
+      description: String
+    }
+    
+    input IssueInput {
+      id: ID!
+      site: ID!
+    }
+underlyingSchema:
+  Activity: |
+    type Query {
+      activities: [Activity]
+    }
+    
+    type Activity {
+      id: ID
+      context: HydrationContext
+    }
+    
+    type HydrationContext {
+      issueHydrationInput: IssueHydrationInput
+    }
+    
+    type IssueHydrationInput {
+      id: ID!
+      site: ID!
+    }
+  Issue: |
+    type Query {
+      issues(issuesInput: IssueInput!): [Issue]
+    }
+    
+    type Issue {
+      issueId: ID
+      description: String
+    }
+    
+    input IssueInput {
+      id: ID!
+      site: ID!
+    }
+query: |
+  query {
+    activities {
+      id
+      issue {
+        issueId
+        description
+      }
+    }
+  }
+variables: { }
+serviceCalls:
+  - serviceName: "Activity"
+    request:
+      query: |
+        {
+          activities {
+            __typename__batch_hydration__issue: __typename
+            batch_hydration__issue__context: context {
+              issueHydrationInput {
+                id
+              }
+            }
+            batch_hydration__issue__context: context {
+              issueHydrationInput {
+                site
+              }
+            }
+            id
+          }
+        }
+      variables: { }
+    # language=JSON
+    response: |-
+      {
+        "data": {
+          "activities": [
+            {
+              "__typename__batch_hydration__issue": "Activity",
+              "batch_hydration__issue__context": {
+                "issueHydrationInput": {
+                  "id": "ISSUE-0",
+                  "site": "CLOUD-0"
+                }
+              },
+              "id": "ACTIVITY-0"
+            },
+            {
+              "__typename__batch_hydration__issue": "Activity",
+              "batch_hydration__issue__context": {
+                "issueHydrationInput": {
+                  "id": "ISSUE-1",
+                  "site": "CLOUD-0"
+                }
+              },
+              "id": "ACTIVITY-1"
+            },
+            {
+              "__typename__batch_hydration__issue": "Activity",
+              "batch_hydration__issue__context": {
+                "issueHydrationInput": {
+                  "id": "ISSUE-2",
+                  "site": "CLOUD-0"
+                }
+              },
+              "id": "ACTIVITY-2"
+            },
+            {
+              "__typename__batch_hydration__issue": "Activity",
+              "batch_hydration__issue__context": {
+                "issueHydrationInput": {
+                  "id": "ISSUE-3",
+                  "site": "CLOUD-0"
+                }
+              },
+              "id": "ACTIVITY-3"
+            }
+          ]
+        },
+        "extensions": {}
+      }
+  - serviceName: "Issue"
+    request:
+      query: |
+        {
+          issues(issuesInput: [{id : "ISSUE-0", site : "CLOUD-0"}, {id : "ISSUE-1", site : "CLOUD-0"}, {id : "ISSUE-2", site : "CLOUD-0"}, {id : "ISSUE-3", site : "CLOUD-0"}]) {
+            description
+            issueId
+            batch_hydration__issue__issueId: issueId
+          }
+        }
+      variables: { }
+    # language=JSON
+    response: |-
+      {
+        "data": {
+          "issues": [
+            {
+              "batch_hydration__issue__issueId": "ISSUE-0",
+              "issueId": "ISSUE-0",
+              "description": "fix A"
+            },
+            {
+              "batch_hydration__issue__issueId": "ISSUE-1",
+              "issueId": "ISSUE-1",
+              "description": "fix B"
+            },
+            {
+              "batch_hydration__issue__issueId": "ISSUE-2",
+              "issueId": "ISSUE-2",
+              "description": "fix C"
+            },
+            {
+              "batch_hydration__issue__issueId": "ISSUE-3",
+              "issueId": "ISSUE-3",
+              "description": "fix D"
+            }
+          ]
+        },
+        "extensions": {}
+      }
+# language=JSON
+response: |-
+  {
+    "data": {
+      "activities": [
+        {
+          "id": "ACTIVITY-0",
+          "issue": {
+            "issueId": "ISSUE-0",
+            "description": "fix A"
+          }
+        },
+        {
+          "id": "ACTIVITY-1",
+          "issue": {
+            "issueId": "ISSUE-1",
+            "description": "fix B"
+          }
+        },
+        {
+          "id": "ACTIVITY-2",
+          "issue": {
+            "issueId": "ISSUE-2",
+            "description": "fix C"
+          }
+        },
+        {
+          "id": "ACTIVITY-3",
+          "issue": {
+            "issueId": "ISSUE-3",
+            "description": "fix D"
+          }
+        }
+      ]
+    },
+    "errors": []
+  }

--- a/test/src/test/resources/fixtures/hydration/complex identified by/complex-identified-by-with-indexed-hydration.yml
+++ b/test/src/test/resources/fixtures/hydration/complex identified by/complex-identified-by-with-indexed-hydration.yml
@@ -1,0 +1,217 @@
+name: "complex identified by with indexed hydration"
+enabled: true
+overallSchema:
+  Activity: |
+    type Query {
+      activities: [Activity]
+    }
+    
+    type Activity {
+      id: ID
+      issue: Issue @hydrated(
+        service: "Issue"
+        field: "issues"
+        arguments: [{name: "issuesInput" value: "$source.context.issueHydrationInput"}]
+        indexed: true
+      )
+    }
+  Issue: |
+    type Query {
+      issues(issuesInput: IssueInput!): [Issue]
+    }
+    
+    type Issue {
+      issueId: ID
+      description: String
+    }
+    
+    input IssueInput {
+      id: ID!
+      site: ID!
+    }
+underlyingSchema:
+  Activity: |
+    type Query {
+      activities: [Activity]
+    }
+    
+    type Activity {
+      id: ID
+      context: HydrationContext
+    }
+    
+    type HydrationContext {
+      issueHydrationInput: IssueHydrationInput
+    }
+    
+    type IssueHydrationInput {
+      id: ID!
+      site: ID!
+    }
+  Issue: |
+    type Query {
+      issues(issuesInput: IssueInput!): [Issue]
+    }
+    
+    type Issue {
+      issueId: ID
+      description: String
+    }
+    
+    input IssueInput {
+      id: ID!
+      site: ID!
+    }
+query: |
+  query {
+    activities {
+      id
+      issue {
+        issueId
+        description
+      }
+    }
+  }
+variables: { }
+serviceCalls:
+  - serviceName: "Activity"
+    request:
+      query: |
+        {
+          activities {
+            __typename__batch_hydration__issue: __typename
+            batch_hydration__issue__context: context {
+              issueHydrationInput {
+                id
+              }
+            }
+            batch_hydration__issue__context: context {
+              issueHydrationInput {
+                site
+              }
+            }
+            id
+          }
+        }
+      variables: { }
+    # language=JSON
+    response: |-
+      {
+        "data": {
+          "activities": [
+            {
+              "__typename__batch_hydration__issue": "Activity",
+              "batch_hydration__issue__context": {
+                "issueHydrationInput": {
+                  "id": "ISSUE-0",
+                  "site": "CLOUD-0"
+                }
+              },
+              "id": "ACTIVITY-0"
+            },
+            {
+              "__typename__batch_hydration__issue": "Activity",
+              "batch_hydration__issue__context": {
+                "issueHydrationInput": {
+                  "id": "ISSUE-1",
+                  "site": "CLOUD-0"
+                }
+              },
+              "id": "ACTIVITY-1"
+            },
+            {
+              "__typename__batch_hydration__issue": "Activity",
+              "batch_hydration__issue__context": {
+                "issueHydrationInput": {
+                  "id": "ISSUE-2",
+                  "site": "CLOUD-0"
+                }
+              },
+              "id": "ACTIVITY-2"
+            },
+            {
+              "__typename__batch_hydration__issue": "Activity",
+              "batch_hydration__issue__context": {
+                "issueHydrationInput": {
+                  "id": "ISSUE-3",
+                  "site": "CLOUD-0"
+                }
+              },
+              "id": "ACTIVITY-3"
+            }
+          ]
+        },
+        "extensions": {}
+      }
+  - serviceName: "Issue"
+    request:
+      query: |
+        {
+          issues(issuesInput: [{id : "ISSUE-0", site : "CLOUD-0"}, {id : "ISSUE-1", site : "CLOUD-0"}, {id : "ISSUE-2", site : "CLOUD-0"}, {id : "ISSUE-3", site : "CLOUD-0"}]) {
+            description
+            issueId
+          }
+        }
+      variables: { }
+    # language=JSON
+    response: |-
+      {
+        "data": {
+          "issues": [
+            {
+              "issueId": "ISSUE-0",
+              "description": "fix A"
+            },
+            {
+              "issueId": "ISSUE-1",
+              "description": "fix B"
+            },
+            {
+              "issueId": "ISSUE-2",
+              "description": "fix C"
+            },
+            {
+              "issueId": "ISSUE-3",
+              "description": "fix D"
+            }
+          ]
+        },
+        "extensions": {}
+      }
+# language=JSON
+response: |-
+  {
+    "data": {
+      "activities": [
+        {
+          "id": "ACTIVITY-0",
+          "issue": {
+            "issueId": "ISSUE-0",
+            "description": "fix A"
+          }
+        },
+        {
+          "id": "ACTIVITY-1",
+          "issue": {
+            "issueId": "ISSUE-1",
+            "description": "fix B"
+          }
+        },
+        {
+          "id": "ACTIVITY-2",
+          "issue": {
+            "issueId": "ISSUE-2",
+            "description": "fix C"
+          }
+        },
+        {
+          "id": "ACTIVITY-3",
+          "issue": {
+            "issueId": "ISSUE-3",
+            "description": "fix D"
+          }
+        }
+      ]
+    },
+    "errors": []
+  }


### PR DESCRIPTION
Please make sure you consider the following:

- [ ] Add tests that use __typename in queries
- [ ] Does this change work with all nadel transformations (rename, type rename, hydration, etc)? Add tests for this.
- [ ] Is it worth using hints for this change in order to be able to enable a percentage rollout?
- [ ] Do we need to add integration tests for this change in the graphql gateway?
- [ ] Do we need a pollinator check for this?
