### PR TITLE
add user context to polymorphic hydration hook

### DIFF
--- a/lib/src/main/java/graphql/nadel/engine/NadelEngineExecutionHooks.kt
+++ b/lib/src/main/java/graphql/nadel/engine/NadelEngineExecutionHooks.kt
@@ -10,7 +10,8 @@ interface NadelEngineExecutionHooks : ServiceExecutionHooks {
     fun <T : NadelGenericHydrationInstruction> getHydrationInstruction(
         instructions: List<T>,
         parentNode: JsonNode,
-        aliasHelper: NadelAliasHelper
+        aliasHelper: NadelAliasHelper,
+        userContext: Any?
     ): T?
 
     /**

--- a/lib/src/main/java/graphql/nadel/engine/transform/hydration/batch/NadelBatchHydrator.kt
+++ b/lib/src/main/java/graphql/nadel/engine/transform/hydration/batch/NadelBatchHydrator.kt
@@ -173,7 +173,8 @@ internal class NadelBatchHydrator(
         return state.executionContext.hooks.getHydrationInstruction(
             instructions,
             parentNode,
-            state.aliasHelper
+            state.aliasHelper,
+            state.executionContext.userContext
         )
     }
 }

--- a/test/src/test/kotlin/graphql/nadel/tests/hooks/batching-of-hydration-list-with-partition.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/hooks/batching-of-hydration-list-with-partition.kt
@@ -13,7 +13,8 @@ private class BatchHydrationHooks : NadelEngineExecutionHooks {
     override fun <T : NadelGenericHydrationInstruction> getHydrationInstruction(
         instructions: List<T>,
         parentNode: JsonNode,
-        aliasHelper: NadelAliasHelper
+        aliasHelper: NadelAliasHelper,
+        userContext: Any?
     ): T {
         return instructions[0]
     }

--- a/test/src/test/kotlin/graphql/nadel/tests/hooks/polymorphic-hydration-hook-using-alias-helper.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/hooks/polymorphic-hydration-hook-using-alias-helper.kt
@@ -15,7 +15,8 @@ private class PolymorphicHydrationHookUsingAliasHelper : NadelEngineExecutionHoo
     override fun <T : NadelGenericHydrationInstruction> getHydrationInstruction(
         instructions: List<T>,
         parentNode: JsonNode,
-        aliasHelper: NadelAliasHelper
+        aliasHelper: NadelAliasHelper,
+        userContext: Any?
     ): T? {
         return instructions.firstOrNull {
             val (_, _, valueSource) = it.actorInputValueDefs.single()

--- a/test/src/test/kotlin/graphql/nadel/tests/hooks/polymorphic-hydration-hooks.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/hooks/polymorphic-hydration-hooks.kt
@@ -15,7 +15,8 @@ private class PolymorphicHydrationHooks : NadelEngineExecutionHooks {
     override fun <T : NadelGenericHydrationInstruction> getHydrationInstruction(
         instructions: List<T>,
         parentNode: JsonNode,
-        aliasHelper: NadelAliasHelper
+        aliasHelper: NadelAliasHelper,
+        userContext: Any?
     ): T? {
 
         val dataIdFieldName = if (instructions.any { it is NadelHydrationFieldInstruction })


### PR DESCRIPTION
Please make sure you consider the following:

- [x] Add tests that use __typename in queries
- [x] Does this change work with all nadel transformations (rename, type rename, hydration, etc)? Add tests for this.
- [x] Is it worth using hints for this change in order to be able to enable a percentage rollout?
- [x] Do we need to add integration tests for this change in the graphql gateway?
- [x] Do we need a pollinator check for this?
