### PR TITLE
Add support for default argument values in hydration

### DIFF
--- a/lib/src/main/java/graphql/nadel/engine/blueprint/hydration/NadelHydrationActorInputDef.kt
+++ b/lib/src/main/java/graphql/nadel/engine/blueprint/hydration/NadelHydrationActorInputDef.kt
@@ -1,6 +1,7 @@
 package graphql.nadel.engine.blueprint.hydration
 
 import graphql.nadel.engine.transform.query.NadelQueryPath
+import graphql.normalized.NormalizedInputValue
 import graphql.schema.GraphQLArgument
 import graphql.schema.GraphQLFieldDefinition
 
@@ -41,6 +42,7 @@ data class NadelHydrationActorInputDef(
         data class ArgumentValue(
             val argumentName: String,
             val argumentDefinition: GraphQLArgument,
+            val defaultValue: NormalizedInputValue?,
         ) : ValueSource()
     }
 }

--- a/lib/src/main/java/graphql/nadel/engine/transform/hydration/NadelHydrationInputBuilder.kt
+++ b/lib/src/main/java/graphql/nadel/engine/transform/hydration/NadelHydrationInputBuilder.kt
@@ -122,7 +122,7 @@ internal class NadelHydrationInputBuilder private constructor(
         inputDef: NadelHydrationActorInputDef,
     ): NormalizedInputValue? {
         return when (val valueSource = inputDef.valueSource) {
-            is ValueSource.ArgumentValue -> fieldToHydrate.getNormalizedArgument(valueSource.argumentName)
+            is ValueSource.ArgumentValue -> getArgumentValue(valueSource)
             is ValueSource.FieldResultValue -> makeInputValue(
                 inputDef,
                 value = getResultValue(valueSource),
@@ -138,6 +138,12 @@ internal class NadelHydrationInputBuilder private constructor(
             type = inputDef.actorArgumentDef.type,
             value = javaValueToAstValue(value),
         )
+    }
+
+    private fun getArgumentValue(
+        valueSource: ValueSource.ArgumentValue,
+    ): NormalizedInputValue? {
+        return fieldToHydrate.getNormalizedArgument(valueSource.argumentName) ?: valueSource.defaultValue
     }
 
     private fun getResultValue(

--- a/lib/src/main/java/graphql/nadel/engine/transform/hydration/batch/NadelBatchHydrationInputBuilder.kt
+++ b/lib/src/main/java/graphql/nadel/engine/transform/hydration/batch/NadelBatchHydrationInputBuilder.kt
@@ -44,9 +44,12 @@ internal object NadelBatchHydrationInputBuilder {
             instruction.actorInputValueDefs.mapNotNull { actorFieldArg ->
                 when (val valueSource = actorFieldArg.valueSource) {
                     is NadelHydrationActorInputDef.ValueSource.ArgumentValue -> {
-                        when (val argValue = hydrationField.normalizedArguments[valueSource.argumentName]) {
-                            null -> null
-                            else -> actorFieldArg to argValue
+                        val argValue = hydrationField.normalizedArguments[valueSource.argumentName]
+                            ?: valueSource.defaultValue
+                        if (argValue != null) {
+                            actorFieldArg to argValue
+                        } else {
+                            null
                         }
                     }
                     // These are batch values, ignore them

--- a/test/src/test/resources/fixtures/hydration/basic-hydration-with-default-array-argument-values.yml
+++ b/test/src/test/resources/fixtures/hydration/basic-hydration-with-default-array-argument-values.yml
@@ -1,0 +1,114 @@
+name: "basic hydration with default array argument values"
+enabled: true
+overallSchema:
+  # language=GraphQL
+  service2: |
+    type Query {
+      barById(id: ID, test: [String]): Bar
+    }
+    type Bar {
+      id: ID
+      name: String
+    }
+  # language=GraphQL
+  service1: |
+    type Query {
+      foo: Foo
+    }
+    type Foo {
+      id: ID
+      bar(test: [String] = ["Hello", "World"]): Bar @hydrated(
+        service: "service2"
+        field: "barById"
+        arguments: [
+          {name: "id" value: "$source.barId"}
+          {name: "test" value: "$argument.test"}
+        ]
+      )
+    }
+underlyingSchema:
+  # language=GraphQL
+  service2: |
+    type Bar {
+      id: ID
+      name: String
+    }
+
+    type Query {
+      barById(id: ID, test: [String]): Bar
+    }
+  # language=GraphQL
+  service1: |
+    type Foo {
+      barId: ID
+      id: ID
+    }
+
+    type Query {
+      foo: Foo
+    }
+# language=GraphQL
+query: |
+  query {
+    foo {
+      bar {
+        name
+      }
+    }
+  }
+variables: { }
+serviceCalls:
+  - serviceName: "service1"
+    request:
+      # language=GraphQL
+      query: |
+        query {
+          foo {
+            __typename__hydration__bar: __typename
+            hydration__bar__barId: barId
+          }
+        }
+      variables: { }
+    # language=JSON
+    response: |-
+      {
+        "data": {
+          "foo": {
+            "hydration__bar__barId": "barId",
+            "__typename__hydration__bar": "Foo"
+          }
+        },
+        "extensions": {}
+      }
+  - serviceName: "service2"
+    request:
+      # language=GraphQL
+      query: |
+        query {
+          barById(id: "barId" test: ["Hello", "World"]) {
+            name
+          }
+        }
+      variables: { }
+    # language=JSON
+    response: |-
+      {
+        "data": {
+          "barById": {
+            "name": "Bar1"
+          }
+        },
+        "extensions": {}
+      }
+# language=JSON
+response: |-
+  {
+    "data": {
+      "foo": {
+        "bar": {
+          "name": "Bar1"
+        }
+      }
+    },
+    "extensions": {}
+  }

--- a/test/src/test/resources/fixtures/hydration/basic-hydration-with-default-boolean-argument-values.yml
+++ b/test/src/test/resources/fixtures/hydration/basic-hydration-with-default-boolean-argument-values.yml
@@ -1,0 +1,114 @@
+name: "basic hydration with default boolean argument values"
+enabled: true
+overallSchema:
+  # language=GraphQL
+  service2: |
+    type Query {
+      barById(id: ID, test: Boolean): Bar
+    }
+    type Bar {
+      id: ID
+      name: String
+    }
+  # language=GraphQL
+  service1: |
+    type Query {
+      foo: Foo
+    }
+    type Foo {
+      id: ID
+      bar(test: Boolean = false): Bar @hydrated(
+        service: "service2"
+        field: "barById"
+        arguments: [
+          {name: "id" value: "$source.barId"}
+          {name: "test" value: "$argument.test"}
+        ]
+      )
+    }
+underlyingSchema:
+  # language=GraphQL
+  service2: |
+    type Bar {
+      id: ID
+      name: String
+    }
+
+    type Query {
+      barById(id: ID, test: Boolean): Bar
+    }
+  # language=GraphQL
+  service1: |
+    type Foo {
+      barId: ID
+      id: ID
+    }
+
+    type Query {
+      foo: Foo
+    }
+# language=GraphQL
+query: |
+  query {
+    foo {
+      bar {
+        name
+      }
+    }
+  }
+variables: { }
+serviceCalls:
+  - serviceName: "service1"
+    request:
+      # language=GraphQL
+      query: |
+        query {
+          foo {
+            __typename__hydration__bar: __typename
+            hydration__bar__barId: barId
+          }
+        }
+      variables: { }
+    # language=JSON
+    response: |-
+      {
+        "data": {
+          "foo": {
+            "hydration__bar__barId": "barId",
+            "__typename__hydration__bar": "Foo"
+          }
+        },
+        "extensions": {}
+      }
+  - serviceName: "service2"
+    request:
+      # language=GraphQL
+      query: |
+        query {
+          barById(id: "barId" test: false) {
+            name
+          }
+        }
+      variables: { }
+    # language=JSON
+    response: |-
+      {
+        "data": {
+          "barById": {
+            "name": "Bar1"
+          }
+        },
+        "extensions": {}
+      }
+# language=JSON
+response: |-
+  {
+    "data": {
+      "foo": {
+        "bar": {
+          "name": "Bar1"
+        }
+      }
+    },
+    "extensions": {}
+  }

--- a/test/src/test/resources/fixtures/hydration/basic-hydration-with-default-int-argument-values.yml
+++ b/test/src/test/resources/fixtures/hydration/basic-hydration-with-default-int-argument-values.yml
@@ -1,0 +1,114 @@
+name: "basic hydration with default int argument values"
+enabled: true
+overallSchema:
+  # language=GraphQL
+  service2: |
+    type Query {
+      barById(id: ID, test: Int): Bar
+    }
+    type Bar {
+      id: ID
+      name: String
+    }
+  # language=GraphQL
+  service1: |
+    type Query {
+      foo: Foo
+    }
+    type Foo {
+      id: ID
+      bar(test: Int = 10): Bar @hydrated(
+        service: "service2"
+        field: "barById"
+        arguments: [
+          {name: "id" value: "$source.barId"}
+          {name: "test" value: "$argument.test"}
+        ]
+      )
+    }
+underlyingSchema:
+  # language=GraphQL
+  service2: |
+    type Bar {
+      id: ID
+      name: String
+    }
+
+    type Query {
+      barById(id: ID, test: Int): Bar
+    }
+  # language=GraphQL
+  service1: |
+    type Foo {
+      barId: ID
+      id: ID
+    }
+
+    type Query {
+      foo: Foo
+    }
+# language=GraphQL
+query: |
+  query {
+    foo {
+      bar {
+        name
+      }
+    }
+  }
+variables: { }
+serviceCalls:
+  - serviceName: "service1"
+    request:
+      # language=GraphQL
+      query: |
+        query {
+          foo {
+            __typename__hydration__bar: __typename
+            hydration__bar__barId: barId
+          }
+        }
+      variables: { }
+    # language=JSON
+    response: |-
+      {
+        "data": {
+          "foo": {
+            "hydration__bar__barId": "barId",
+            "__typename__hydration__bar": "Foo"
+          }
+        },
+        "extensions": {}
+      }
+  - serviceName: "service2"
+    request:
+      # language=GraphQL
+      query: |
+        query {
+          barById(id: "barId" test: 10) {
+            name
+          }
+        }
+      variables: { }
+    # language=JSON
+    response: |-
+      {
+        "data": {
+          "barById": {
+            "name": "Bar1"
+          }
+        },
+        "extensions": {}
+      }
+# language=JSON
+response: |-
+  {
+    "data": {
+      "foo": {
+        "bar": {
+          "name": "Bar1"
+        }
+      }
+    },
+    "extensions": {}
+  }

--- a/test/src/test/resources/fixtures/hydration/basic-hydration-with-default-null-argument-values.yml
+++ b/test/src/test/resources/fixtures/hydration/basic-hydration-with-default-null-argument-values.yml
@@ -1,0 +1,114 @@
+name: "basic hydration with default null argument values"
+enabled: true
+overallSchema:
+  # language=GraphQL
+  service2: |
+    type Query {
+      barById(id: ID, test: Boolean = true): Bar
+    }
+    type Bar {
+      id: ID
+      name: String
+    }
+  # language=GraphQL
+  service1: |
+    type Query {
+      foo: Foo
+    }
+    type Foo {
+      id: ID
+      bar(test: Boolean = null): Bar @hydrated(
+        service: "service2"
+        field: "barById"
+        arguments: [
+          {name: "id" value: "$source.barId"}
+          {name: "test" value: "$argument.test"}
+        ]
+      )
+    }
+underlyingSchema:
+  # language=GraphQL
+  service2: |
+    type Bar {
+      id: ID
+      name: String
+    }
+
+    type Query {
+      barById(id: ID, test: Boolean = true): Bar
+    }
+  # language=GraphQL
+  service1: |
+    type Foo {
+      barId: ID
+      id: ID
+    }
+
+    type Query {
+      foo: Foo
+    }
+# language=GraphQL
+query: |
+  query {
+    foo {
+      bar {
+        name
+      }
+    }
+  }
+variables: { }
+serviceCalls:
+  - serviceName: "service1"
+    request:
+      # language=GraphQL
+      query: |
+        query {
+          foo {
+            __typename__hydration__bar: __typename
+            hydration__bar__barId: barId
+          }
+        }
+      variables: { }
+    # language=JSON
+    response: |-
+      {
+        "data": {
+          "foo": {
+            "hydration__bar__barId": "barId",
+            "__typename__hydration__bar": "Foo"
+          }
+        },
+        "extensions": {}
+      }
+  - serviceName: "service2"
+    request:
+      # language=GraphQL
+      query: |
+        query {
+          barById(id: "barId" test: null) {
+            name
+          }
+        }
+      variables: { }
+    # language=JSON
+    response: |-
+      {
+        "data": {
+          "barById": {
+            "name": "Bar1"
+          }
+        },
+        "extensions": {}
+      }
+# language=JSON
+response: |-
+  {
+    "data": {
+      "foo": {
+        "bar": {
+          "name": "Bar1"
+        }
+      }
+    },
+    "extensions": {}
+  }

--- a/test/src/test/resources/fixtures/hydration/basic-hydration-with-default-object-argument-values.yml
+++ b/test/src/test/resources/fixtures/hydration/basic-hydration-with-default-object-argument-values.yml
@@ -1,0 +1,129 @@
+name: "basic hydration with default object argument values"
+enabled: true
+overallSchema:
+  # language=GraphQL
+  service2: |
+    type Query {
+      barById(id: ID, test: Test): Bar
+    }
+    type Bar {
+      id: ID
+      name: String
+    }
+    input Test {
+      string: String = "Test"
+      int: Int = 42
+      bool: Boolean = false
+      number: Int
+      echo: String
+    }
+  # language=GraphQL
+  service1: |
+    type Query {
+      foo: Foo
+    }
+    type Foo {
+      id: ID
+      bar(test: Test = {echo: "Hello World"}): Bar @hydrated(
+        service: "service2"
+        field: "barById"
+        arguments: [
+          {name: "id" value: "$source.barId"}
+          {name: "test" value: "$argument.test"}
+        ]
+      )
+    }
+underlyingSchema:
+  # language=GraphQL
+  service2: |
+    type Bar {
+      id: ID
+      name: String
+    }
+
+    type Query {
+      barById(id: ID, test: Test = {}): Bar
+    }
+   
+    input Test {
+      string: String = "Test"
+      int: Int = 42
+      bool: Boolean = false
+      number: Int
+      echo: String
+    }
+  # language=GraphQL
+  service1: |
+    type Foo {
+      barId: ID
+      id: ID
+    }
+
+    type Query {
+      foo: Foo
+    }
+# language=GraphQL
+query: |
+  query {
+    foo {
+      bar {
+        name
+      }
+    }
+  }
+variables: { }
+serviceCalls:
+  - serviceName: "service1"
+    request:
+      # language=GraphQL
+      query: |
+        query {
+          foo {
+            __typename__hydration__bar: __typename
+            hydration__bar__barId: barId
+          }
+        }
+      variables: { }
+    # language=JSON
+    response: |-
+      {
+        "data": {
+          "foo": {
+            "hydration__bar__barId": "barId",
+            "__typename__hydration__bar": "Foo"
+          }
+        },
+        "extensions": {}
+      }
+  - serviceName: "service2"
+    request:
+      # language=GraphQL
+      query: |
+        query {
+          barById(id: "barId" test: {echo: "Hello World"}) {
+            name
+          }
+        }
+      variables: { }
+    # language=JSON
+    response: |-
+      {
+        "data": {
+          "barById": {
+            "name": "Bar1"
+          }
+        },
+        "extensions": {}
+      }
+# language=JSON
+response: |-
+  {
+    "data": {
+      "foo": {
+        "bar": {
+          "name": "Bar1"
+        }
+      }
+    },
+    "extensions": {}
+  }

--- a/test/src/test/resources/fixtures/hydration/basic-hydration-with-default-string-argument-values.yml
+++ b/test/src/test/resources/fixtures/hydration/basic-hydration-with-default-string-argument-values.yml
@@ -1,0 +1,114 @@
+name: "basic hydration with default string argument values"
+enabled: true
+overallSchema:
+  # language=GraphQL
+  service2: |
+    type Query {
+      barById(id: ID, test: String): Bar
+    }
+    type Bar {
+      id: ID
+      name: String
+    }
+  # language=GraphQL
+  service1: |
+    type Query {
+      foo: Foo
+    }
+    type Foo {
+      id: ID
+      bar(test: String = "Hello World"): Bar @hydrated(
+        service: "service2"
+        field: "barById"
+        arguments: [
+          {name: "id" value: "$source.barId"}
+          {name: "test" value: "$argument.test"}
+        ]
+      )
+    }
+underlyingSchema:
+  # language=GraphQL
+  service2: |
+    type Bar {
+      id: ID
+      name: String
+    }
+
+    type Query {
+      barById(id: ID, test: String): Bar
+    }
+  # language=GraphQL
+  service1: |
+    type Foo {
+      barId: ID
+      id: ID
+    }
+
+    type Query {
+      foo: Foo
+    }
+# language=GraphQL
+query: |
+  query {
+    foo {
+      bar {
+        name
+      }
+    }
+  }
+variables: { }
+serviceCalls:
+  - serviceName: "service1"
+    request:
+      # language=GraphQL
+      query: |
+        query {
+          foo {
+            __typename__hydration__bar: __typename
+            hydration__bar__barId: barId
+          }
+        }
+      variables: { }
+    # language=JSON
+    response: |-
+      {
+        "data": {
+          "foo": {
+            "hydration__bar__barId": "barId",
+            "__typename__hydration__bar": "Foo"
+          }
+        },
+        "extensions": {}
+      }
+  - serviceName: "service2"
+    request:
+      # language=GraphQL
+      query: |
+        query {
+          barById(id: "barId" test: "Hello World") {
+            name
+          }
+        }
+      variables: { }
+    # language=JSON
+    response: |-
+      {
+        "data": {
+          "barById": {
+            "name": "Bar1"
+          }
+        },
+        "extensions": {}
+      }
+# language=JSON
+response: |-
+  {
+    "data": {
+      "foo": {
+        "bar": {
+          "name": "Bar1"
+        }
+      }
+    },
+    "extensions": {}
+  }

--- a/test/src/test/resources/fixtures/hydration/batched-hydration-with-default-array-argument-values.yml
+++ b/test/src/test/resources/fixtures/hydration/batched-hydration-with-default-array-argument-values.yml
@@ -1,0 +1,212 @@
+name: "batched hydration with default array argument values"
+enabled: true
+overallSchema:
+  # language=GraphQL
+  UserService: |
+    type Query {
+      usersByIds(id: [ID], test: [String]): [User]
+    }
+    type User {
+      id: ID
+    }
+  # language=GraphQL
+  Issues: |
+    type Query {
+      issues: [Issue]
+    }
+    type Issue {
+      id: ID
+      authors(test: [String] = ["Hello", "World"]): [User] @hydrated(
+        service: "UserService"
+        field: "usersByIds"
+        arguments: [
+          {name: "id" value: "$source.authorIds"}
+          {name: "test" value: "$argument.test"}
+        ]
+        identifiedBy: "id"
+        batchSize: 3
+      )
+    }
+underlyingSchema:
+  # language=GraphQL
+  UserService: |
+    type Query {
+      usersByIds(id: [ID], test: [String]): [User]
+    }
+
+    type User {
+      id: ID
+    }
+  # language=GraphQL
+  Issues: |
+    type Issue {
+      authorIds: [ID]
+      id: ID
+    }
+
+    type Query {
+      issues: [Issue]
+    }
+# language=GraphQL
+query: |
+  query {
+    issues {
+      id
+      authors {
+        id
+      }
+    }
+  }
+variables: { }
+serviceCalls:
+  - serviceName: "Issues"
+    request:
+      # language=GraphQL
+      query: |
+        query {
+          issues {
+            __typename__batch_hydration__authors: __typename
+            batch_hydration__authors__authorIds: authorIds
+            id
+          }
+        }
+      variables: { }
+    # language=JSON
+    response: |-
+      {
+        "data": {
+          "issues": [
+            {
+              "__typename__batch_hydration__authors": "Issue",
+              "batch_hydration__authors__authorIds": [
+                "USER-1",
+                "USER-2"
+              ],
+              "id": "ISSUE-1"
+            },
+            {
+              "__typename__batch_hydration__authors": "Issue",
+              "batch_hydration__authors__authorIds": [
+                "USER-3"
+              ],
+              "id": "ISSUE-2"
+            },
+            {
+              "__typename__batch_hydration__authors": "Issue",
+              "batch_hydration__authors__authorIds": [
+                "USER-2",
+                "USER-4",
+                "USER-5"
+              ],
+              "id": "ISSUE-3"
+            }
+          ]
+        },
+        "extensions": {}
+      }
+  - serviceName: "UserService"
+    request:
+      # language=GraphQL
+      query: |
+        query {
+          usersByIds(id: ["USER-1", "USER-2", "USER-3"], test: ["Hello", "World"]) {
+            id
+            batch_hydration__authors__id: id
+          }
+        }
+      variables: { }
+    # language=JSON
+    response: |-
+      {
+        "data": {
+          "usersByIds": [
+            {
+              "id": "USER-1",
+              "batch_hydration__authors__id": "USER-1"
+            },
+            {
+              "id": "USER-2",
+              "batch_hydration__authors__id": "USER-2"
+            },
+            {
+              "id": "USER-3",
+              "batch_hydration__authors__id": "USER-3"
+            }
+          ]
+        },
+        "extensions": {}
+      }
+  - serviceName: "UserService"
+    request:
+      # language=GraphQL
+      query: |
+        query {
+          usersByIds(id: ["USER-2", "USER-4", "USER-5"], test: ["Hello", "World"]) {
+            id
+            batch_hydration__authors__id: id
+          }
+        }
+      variables: { }
+    # language=JSON
+    response: |-
+      {
+        "data": {
+          "usersByIds": [
+            {
+              "id": "USER-2",
+              "batch_hydration__authors__id": "USER-2"
+            },
+            {
+              "id": "USER-4",
+              "batch_hydration__authors__id": "USER-4"
+            },
+            {
+              "id": "USER-5",
+              "batch_hydration__authors__id": "USER-5"
+            }
+          ]
+        },
+        "extensions": {}
+      }
+# language=JSON
+response: |-
+  {
+    "data": {
+      "issues": [
+        {
+          "id": "ISSUE-1",
+          "authors": [
+            {
+              "id": "USER-1"
+            },
+            {
+              "id": "USER-2"
+            }
+          ]
+        },
+        {
+          "id": "ISSUE-2",
+          "authors": [
+            {
+              "id": "USER-3"
+            }
+          ]
+        },
+        {
+          "id": "ISSUE-3",
+          "authors": [
+            {
+              "id": "USER-2"
+            },
+            {
+              "id": "USER-4"
+            },
+            {
+              "id": "USER-5"
+            }
+          ]
+        }
+      ]
+    },
+    "extensions": {}
+  }

--- a/test/src/test/resources/fixtures/hydration/batched-hydration-with-default-boolean-argument-values.yml
+++ b/test/src/test/resources/fixtures/hydration/batched-hydration-with-default-boolean-argument-values.yml
@@ -1,0 +1,212 @@
+name: "batched hydration with default boolean argument values"
+enabled: true
+overallSchema:
+  # language=GraphQL
+  UserService: |
+    type Query {
+      usersByIds(id: [ID], test: Boolean): [User]
+    }
+    type User {
+      id: ID
+    }
+  # language=GraphQL
+  Issues: |
+    type Query {
+      issues: [Issue]
+    }
+    type Issue {
+      id: ID
+      authors(test: Boolean = true): [User] @hydrated(
+        service: "UserService"
+        field: "usersByIds"
+        arguments: [
+          {name: "id" value: "$source.authorIds"}
+          {name: "test" value: "$argument.test"}
+        ]
+        identifiedBy: "id"
+        batchSize: 3
+      )
+    }
+underlyingSchema:
+  # language=GraphQL
+  UserService: |
+    type Query {
+      usersByIds(id: [ID], test: Boolean): [User]
+    }
+
+    type User {
+      id: ID
+    }
+  # language=GraphQL
+  Issues: |
+    type Issue {
+      authorIds: [ID]
+      id: ID
+    }
+
+    type Query {
+      issues: [Issue]
+    }
+# language=GraphQL
+query: |
+  query {
+    issues {
+      id
+      authors {
+        id
+      }
+    }
+  }
+variables: { }
+serviceCalls:
+  - serviceName: "Issues"
+    request:
+      # language=GraphQL
+      query: |
+        query {
+          issues {
+            __typename__batch_hydration__authors: __typename
+            batch_hydration__authors__authorIds: authorIds
+            id
+          }
+        }
+      variables: { }
+    # language=JSON
+    response: |-
+      {
+        "data": {
+          "issues": [
+            {
+              "__typename__batch_hydration__authors": "Issue",
+              "batch_hydration__authors__authorIds": [
+                "USER-1",
+                "USER-2"
+              ],
+              "id": "ISSUE-1"
+            },
+            {
+              "__typename__batch_hydration__authors": "Issue",
+              "batch_hydration__authors__authorIds": [
+                "USER-3"
+              ],
+              "id": "ISSUE-2"
+            },
+            {
+              "__typename__batch_hydration__authors": "Issue",
+              "batch_hydration__authors__authorIds": [
+                "USER-2",
+                "USER-4",
+                "USER-5"
+              ],
+              "id": "ISSUE-3"
+            }
+          ]
+        },
+        "extensions": {}
+      }
+  - serviceName: "UserService"
+    request:
+      # language=GraphQL
+      query: |
+        query {
+          usersByIds(id: ["USER-1", "USER-2", "USER-3"], test: true) {
+            id
+            batch_hydration__authors__id: id
+          }
+        }
+      variables: { }
+    # language=JSON
+    response: |-
+      {
+        "data": {
+          "usersByIds": [
+            {
+              "id": "USER-1",
+              "batch_hydration__authors__id": "USER-1"
+            },
+            {
+              "id": "USER-2",
+              "batch_hydration__authors__id": "USER-2"
+            },
+            {
+              "id": "USER-3",
+              "batch_hydration__authors__id": "USER-3"
+            }
+          ]
+        },
+        "extensions": {}
+      }
+  - serviceName: "UserService"
+    request:
+      # language=GraphQL
+      query: |
+        query {
+          usersByIds(id: ["USER-2", "USER-4", "USER-5"], test: true) {
+            id
+            batch_hydration__authors__id: id
+          }
+        }
+      variables: { }
+    # language=JSON
+    response: |-
+      {
+        "data": {
+          "usersByIds": [
+            {
+              "id": "USER-2",
+              "batch_hydration__authors__id": "USER-2"
+            },
+            {
+              "id": "USER-4",
+              "batch_hydration__authors__id": "USER-4"
+            },
+            {
+              "id": "USER-5",
+              "batch_hydration__authors__id": "USER-5"
+            }
+          ]
+        },
+        "extensions": {}
+      }
+# language=JSON
+response: |-
+  {
+    "data": {
+      "issues": [
+        {
+          "id": "ISSUE-1",
+          "authors": [
+            {
+              "id": "USER-1"
+            },
+            {
+              "id": "USER-2"
+            }
+          ]
+        },
+        {
+          "id": "ISSUE-2",
+          "authors": [
+            {
+              "id": "USER-3"
+            }
+          ]
+        },
+        {
+          "id": "ISSUE-3",
+          "authors": [
+            {
+              "id": "USER-2"
+            },
+            {
+              "id": "USER-4"
+            },
+            {
+              "id": "USER-5"
+            }
+          ]
+        }
+      ]
+    },
+    "extensions": {}
+  }

--- a/test/src/test/resources/fixtures/hydration/batched-hydration-with-default-int-argument-values.yml
+++ b/test/src/test/resources/fixtures/hydration/batched-hydration-with-default-int-argument-values.yml
@@ -1,0 +1,212 @@
+name: "batched hydration with default int argument values"
+enabled: true
+overallSchema:
+  # language=GraphQL
+  UserService: |
+    type Query {
+      usersByIds(id: [ID], test: Int): [User]
+    }
+    type User {
+      id: ID
+    }
+  # language=GraphQL
+  Issues: |
+    type Query {
+      issues: [Issue]
+    }
+    type Issue {
+      id: ID
+      authors(test: Int = 42): [User] @hydrated(
+        service: "UserService"
+        field: "usersByIds"
+        arguments: [
+          {name: "id" value: "$source.authorIds"}
+          {name: "test" value: "$argument.test"}
+        ]
+        identifiedBy: "id"
+        batchSize: 3
+      )
+    }
+underlyingSchema:
+  # language=GraphQL
+  UserService: |
+    type Query {
+      usersByIds(id: [ID], test: Int): [User]
+    }
+
+    type User {
+      id: ID
+    }
+  # language=GraphQL
+  Issues: |
+    type Issue {
+      authorIds: [ID]
+      id: ID
+    }
+
+    type Query {
+      issues: [Issue]
+    }
+# language=GraphQL
+query: |
+  query {
+    issues {
+      id
+      authors {
+        id
+      }
+    }
+  }
+variables: { }
+serviceCalls:
+  - serviceName: "Issues"
+    request:
+      # language=GraphQL
+      query: |
+        query {
+          issues {
+            __typename__batch_hydration__authors: __typename
+            batch_hydration__authors__authorIds: authorIds
+            id
+          }
+        }
+      variables: { }
+    # language=JSON
+    response: |-
+      {
+        "data": {
+          "issues": [
+            {
+              "__typename__batch_hydration__authors": "Issue",
+              "batch_hydration__authors__authorIds": [
+                "USER-1",
+                "USER-2"
+              ],
+              "id": "ISSUE-1"
+            },
+            {
+              "__typename__batch_hydration__authors": "Issue",
+              "batch_hydration__authors__authorIds": [
+                "USER-3"
+              ],
+              "id": "ISSUE-2"
+            },
+            {
+              "__typename__batch_hydration__authors": "Issue",
+              "batch_hydration__authors__authorIds": [
+                "USER-2",
+                "USER-4",
+                "USER-5"
+              ],
+              "id": "ISSUE-3"
+            }
+          ]
+        },
+        "extensions": {}
+      }
+  - serviceName: "UserService"
+    request:
+      # language=GraphQL
+      query: |
+        query {
+          usersByIds(id: ["USER-1", "USER-2", "USER-3"], test: 42) {
+            id
+            batch_hydration__authors__id: id
+          }
+        }
+      variables: { }
+    # language=JSON
+    response: |-
+      {
+        "data": {
+          "usersByIds": [
+            {
+              "id": "USER-1",
+              "batch_hydration__authors__id": "USER-1"
+            },
+            {
+              "id": "USER-2",
+              "batch_hydration__authors__id": "USER-2"
+            },
+            {
+              "id": "USER-3",
+              "batch_hydration__authors__id": "USER-3"
+            }
+          ]
+        },
+        "extensions": {}
+      }
+  - serviceName: "UserService"
+    request:
+      # language=GraphQL
+      query: |
+        query {
+          usersByIds(id: ["USER-2", "USER-4", "USER-5"], test: 42) {
+            id
+            batch_hydration__authors__id: id
+          }
+        }
+      variables: { }
+    # language=JSON
+    response: |-
+      {
+        "data": {
+          "usersByIds": [
+            {
+              "id": "USER-2",
+              "batch_hydration__authors__id": "USER-2"
+            },
+            {
+              "id": "USER-4",
+              "batch_hydration__authors__id": "USER-4"
+            },
+            {
+              "id": "USER-5",
+              "batch_hydration__authors__id": "USER-5"
+            }
+          ]
+        },
+        "extensions": {}
+      }
+# language=JSON
+response: |-
+  {
+    "data": {
+      "issues": [
+        {
+          "id": "ISSUE-1",
+          "authors": [
+            {
+              "id": "USER-1"
+            },
+            {
+              "id": "USER-2"
+            }
+          ]
+        },
+        {
+          "id": "ISSUE-2",
+          "authors": [
+            {
+              "id": "USER-3"
+            }
+          ]
+        },
+        {
+          "id": "ISSUE-3",
+          "authors": [
+            {
+              "id": "USER-2"
+            },
+            {
+              "id": "USER-4"
+            },
+            {
+              "id": "USER-5"
+            }
+          ]
+        }
+      ]
+    },
+    "extensions": {}
+  }

--- a/test/src/test/resources/fixtures/hydration/batched-hydration-with-default-null-argument-values.yml
+++ b/test/src/test/resources/fixtures/hydration/batched-hydration-with-default-null-argument-values.yml
@@ -1,0 +1,212 @@
+name: "batched hydration with default null argument values"
+enabled: true
+overallSchema:
+  # language=GraphQL
+  UserService: |
+    type Query {
+      usersByIds(id: [ID], test: String = "Hello World"): [User]
+    }
+    type User {
+      id: ID
+    }
+  # language=GraphQL
+  Issues: |
+    type Query {
+      issues: [Issue]
+    }
+    type Issue {
+      id: ID
+      authors(test: String = null): [User] @hydrated(
+        service: "UserService"
+        field: "usersByIds"
+        arguments: [
+          {name: "id" value: "$source.authorIds"}
+          {name: "test" value: "$argument.test"}
+        ]
+        identifiedBy: "id"
+        batchSize: 3
+      )
+    }
+underlyingSchema:
+  # language=GraphQL
+  UserService: |
+    type Query {
+      usersByIds(id: [ID], test: String = "Hello World"): [User]
+    }
+
+    type User {
+      id: ID
+    }
+  # language=GraphQL
+  Issues: |
+    type Issue {
+      authorIds: [ID]
+      id: ID
+    }
+
+    type Query {
+      issues: [Issue]
+    }
+# language=GraphQL
+query: |
+  query {
+    issues {
+      id
+      authors {
+        id
+      }
+    }
+  }
+variables: { }
+serviceCalls:
+  - serviceName: "Issues"
+    request:
+      # language=GraphQL
+      query: |
+        query {
+          issues {
+            __typename__batch_hydration__authors: __typename
+            batch_hydration__authors__authorIds: authorIds
+            id
+          }
+        }
+      variables: { }
+    # language=JSON
+    response: |-
+      {
+        "data": {
+          "issues": [
+            {
+              "__typename__batch_hydration__authors": "Issue",
+              "batch_hydration__authors__authorIds": [
+                "USER-1",
+                "USER-2"
+              ],
+              "id": "ISSUE-1"
+            },
+            {
+              "__typename__batch_hydration__authors": "Issue",
+              "batch_hydration__authors__authorIds": [
+                "USER-3"
+              ],
+              "id": "ISSUE-2"
+            },
+            {
+              "__typename__batch_hydration__authors": "Issue",
+              "batch_hydration__authors__authorIds": [
+                "USER-2",
+                "USER-4",
+                "USER-5"
+              ],
+              "id": "ISSUE-3"
+            }
+          ]
+        },
+        "extensions": {}
+      }
+  - serviceName: "UserService"
+    request:
+      # language=GraphQL
+      query: |
+        query {
+          usersByIds(id: ["USER-1", "USER-2", "USER-3"], test: null) {
+            id
+            batch_hydration__authors__id: id
+          }
+        }
+      variables: { }
+    # language=JSON
+    response: |-
+      {
+        "data": {
+          "usersByIds": [
+            {
+              "id": "USER-1",
+              "batch_hydration__authors__id": "USER-1"
+            },
+            {
+              "id": "USER-2",
+              "batch_hydration__authors__id": "USER-2"
+            },
+            {
+              "id": "USER-3",
+              "batch_hydration__authors__id": "USER-3"
+            }
+          ]
+        },
+        "extensions": {}
+      }
+  - serviceName: "UserService"
+    request:
+      # language=GraphQL
+      query: |
+        query {
+          usersByIds(id: ["USER-2", "USER-4", "USER-5"], test: null) {
+            id
+            batch_hydration__authors__id: id
+          }
+        }
+      variables: { }
+    # language=JSON
+    response: |-
+      {
+        "data": {
+          "usersByIds": [
+            {
+              "id": "USER-2",
+              "batch_hydration__authors__id": "USER-2"
+            },
+            {
+              "id": "USER-4",
+              "batch_hydration__authors__id": "USER-4"
+            },
+            {
+              "id": "USER-5",
+              "batch_hydration__authors__id": "USER-5"
+            }
+          ]
+        },
+        "extensions": {}
+      }
+# language=JSON
+response: |-
+  {
+    "data": {
+      "issues": [
+        {
+          "id": "ISSUE-1",
+          "authors": [
+            {
+              "id": "USER-1"
+            },
+            {
+              "id": "USER-2"
+            }
+          ]
+        },
+        {
+          "id": "ISSUE-2",
+          "authors": [
+            {
+              "id": "USER-3"
+            }
+          ]
+        },
+        {
+          "id": "ISSUE-3",
+          "authors": [
+            {
+              "id": "USER-2"
+            },
+            {
+              "id": "USER-4"
+            },
+            {
+              "id": "USER-5"
+            }
+          ]
+        }
+      ]
+    },
+    "extensions": {}
+  }

--- a/test/src/test/resources/fixtures/hydration/batched-hydration-with-default-object-argument-values.yml
+++ b/test/src/test/resources/fixtures/hydration/batched-hydration-with-default-object-argument-values.yml
@@ -1,0 +1,226 @@
+name: "batched hydration with default object argument values"
+enabled: true
+overallSchema:
+  # language=GraphQL
+  UserService: |
+    type Query {
+      usersByIds(id: [ID], test: Test): [User]
+    }
+    type User {
+      id: ID
+    }
+    input Test {
+      string: String = "Test"
+      int: Int = 42
+      bool: Boolean = false
+      number: Int
+      echo: String
+    }
+  # language=GraphQL
+  Issues: |
+    type Query {
+      issues: [Issue]
+    }
+    type Issue {
+      id: ID
+      authors(test: Test = {echo: "Hello World"}): [User] @hydrated(
+        service: "UserService"
+        field: "usersByIds"
+        arguments: [
+          {name: "id" value: "$source.authorIds"}
+          {name: "test" value: "$argument.test"}
+        ]
+        identifiedBy: "id"
+        batchSize: 3
+      )
+    }
+underlyingSchema:
+  # language=GraphQL
+  UserService: |
+    type Query {
+      usersByIds(id: [ID], test: Test): [User]
+    }
+
+    type User {
+      id: ID
+    }
+    input Test {
+      string: String = "Test"
+      int: Int = 42
+      bool: Boolean = false
+      number: Int
+      echo: String
+    }
+  # language=GraphQL
+  Issues: |
+    type Issue {
+      authorIds: [ID]
+      id: ID
+    }
+
+    type Query {
+      issues: [Issue]
+    }
+# language=GraphQL
+query: |
+  query {
+    issues {
+      id
+      authors {
+        id
+      }
+    }
+  }
+variables: { }
+serviceCalls:
+  - serviceName: "Issues"
+    request:
+      # language=GraphQL
+      query: |
+        query {
+          issues {
+            __typename__batch_hydration__authors: __typename
+            batch_hydration__authors__authorIds: authorIds
+            id
+          }
+        }
+      variables: { }
+    # language=JSON
+    response: |-
+      {
+        "data": {
+          "issues": [
+            {
+              "__typename__batch_hydration__authors": "Issue",
+              "batch_hydration__authors__authorIds": [
+                "USER-1",
+                "USER-2"
+              ],
+              "id": "ISSUE-1"
+            },
+            {
+              "__typename__batch_hydration__authors": "Issue",
+              "batch_hydration__authors__authorIds": [
+                "USER-3"
+              ],
+              "id": "ISSUE-2"
+            },
+            {
+              "__typename__batch_hydration__authors": "Issue",
+              "batch_hydration__authors__authorIds": [
+                "USER-2",
+                "USER-4",
+                "USER-5"
+              ],
+              "id": "ISSUE-3"
+            }
+          ]
+        },
+        "extensions": {}
+      }
+  - serviceName: "UserService"
+    request:
+      # language=GraphQL
+      query: |
+        query {
+          usersByIds(id: ["USER-1", "USER-2", "USER-3"], test: {echo: "Hello World"}) {
+            id
+            batch_hydration__authors__id: id
+          }
+        }
+      variables: { }
+    # language=JSON
+    response: |-
+      {
+        "data": {
+          "usersByIds": [
+            {
+              "id": "USER-1",
+              "batch_hydration__authors__id": "USER-1"
+            },
+            {
+              "id": "USER-2",
+              "batch_hydration__authors__id": "USER-2"
+            },
+            {
+              "id": "USER-3",
+              "batch_hydration__authors__id": "USER-3"
+            }
+          ]
+        },
+        "extensions": {}
+      }
+  - serviceName: "UserService"
+    request:
+      # language=GraphQL
+      query: |
+        query {
+          usersByIds(id: ["USER-2", "USER-4", "USER-5"], test: {echo: "Hello World"}) {
+            id
+            batch_hydration__authors__id: id
+          }
+        }
+      variables: { }
+    # language=JSON
+    response: |-
+      {
+        "data": {
+          "usersByIds": [
+            {
+              "id": "USER-2",
+              "batch_hydration__authors__id": "USER-2"
+            },
+            {
+              "id": "USER-4",
+              "batch_hydration__authors__id": "USER-4"
+            },
+            {
+              "id": "USER-5",
+              "batch_hydration__authors__id": "USER-5"
+            }
+          ]
+        },
+        "extensions": {}
+      }
+# language=JSON
+response: |-
+  {
+    "data": {
+      "issues": [
+        {
+          "id": "ISSUE-1",
+          "authors": [
+            {
+              "id": "USER-1"
+            },
+            {
+              "id": "USER-2"
+            }
+          ]
+        },
+        {
+          "id": "ISSUE-2",
+          "authors": [
+            {
+              "id": "USER-3"
+            }
+          ]
+        },
+        {
+          "id": "ISSUE-3",
+          "authors": [
+            {
+              "id": "USER-2"
+            },
+            {
+              "id": "USER-4"
+            },
+            {
+              "id": "USER-5"
+            }
+          ]
+        }
+      ]
+    },
+    "extensions": {}
+  }

--- a/test/src/test/resources/fixtures/hydration/batched-hydration-with-default-string-argument-values.yml
+++ b/test/src/test/resources/fixtures/hydration/batched-hydration-with-default-string-argument-values.yml
@@ -1,0 +1,212 @@
+name: "batched hydration with default string argument values"
+enabled: true
+overallSchema:
+  # language=GraphQL
+  UserService: |
+    type Query {
+      usersByIds(id: [ID], test: String): [User]
+    }
+    type User {
+      id: ID
+    }
+  # language=GraphQL
+  Issues: |
+    type Query {
+      issues: [Issue]
+    }
+    type Issue {
+      id: ID
+      authors(test: String = "Hello World"): [User] @hydrated(
+        service: "UserService"
+        field: "usersByIds"
+        arguments: [
+          {name: "id" value: "$source.authorIds"}
+          {name: "test" value: "$argument.test"}
+        ]
+        identifiedBy: "id"
+        batchSize: 3
+      )
+    }
+underlyingSchema:
+  # language=GraphQL
+  UserService: |
+    type Query {
+      usersByIds(id: [ID], test: String): [User]
+    }
+
+    type User {
+      id: ID
+    }
+  # language=GraphQL
+  Issues: |
+    type Issue {
+      authorIds: [ID]
+      id: ID
+    }
+
+    type Query {
+      issues: [Issue]
+    }
+# language=GraphQL
+query: |
+  query {
+    issues {
+      id
+      authors {
+        id
+      }
+    }
+  }
+variables: { }
+serviceCalls:
+  - serviceName: "Issues"
+    request:
+      # language=GraphQL
+      query: |
+        query {
+          issues {
+            __typename__batch_hydration__authors: __typename
+            batch_hydration__authors__authorIds: authorIds
+            id
+          }
+        }
+      variables: { }
+    # language=JSON
+    response: |-
+      {
+        "data": {
+          "issues": [
+            {
+              "__typename__batch_hydration__authors": "Issue",
+              "batch_hydration__authors__authorIds": [
+                "USER-1",
+                "USER-2"
+              ],
+              "id": "ISSUE-1"
+            },
+            {
+              "__typename__batch_hydration__authors": "Issue",
+              "batch_hydration__authors__authorIds": [
+                "USER-3"
+              ],
+              "id": "ISSUE-2"
+            },
+            {
+              "__typename__batch_hydration__authors": "Issue",
+              "batch_hydration__authors__authorIds": [
+                "USER-2",
+                "USER-4",
+                "USER-5"
+              ],
+              "id": "ISSUE-3"
+            }
+          ]
+        },
+        "extensions": {}
+      }
+  - serviceName: "UserService"
+    request:
+      # language=GraphQL
+      query: |
+        query {
+          usersByIds(id: ["USER-1", "USER-2", "USER-3"], test: "Hello World") {
+            id
+            batch_hydration__authors__id: id
+          }
+        }
+      variables: { }
+    # language=JSON
+    response: |-
+      {
+        "data": {
+          "usersByIds": [
+            {
+              "id": "USER-1",
+              "batch_hydration__authors__id": "USER-1"
+            },
+            {
+              "id": "USER-2",
+              "batch_hydration__authors__id": "USER-2"
+            },
+            {
+              "id": "USER-3",
+              "batch_hydration__authors__id": "USER-3"
+            }
+          ]
+        },
+        "extensions": {}
+      }
+  - serviceName: "UserService"
+    request:
+      # language=GraphQL
+      query: |
+        query {
+          usersByIds(id: ["USER-2", "USER-4", "USER-5"], test: "Hello World") {
+            id
+            batch_hydration__authors__id: id
+          }
+        }
+      variables: { }
+    # language=JSON
+    response: |-
+      {
+        "data": {
+          "usersByIds": [
+            {
+              "id": "USER-2",
+              "batch_hydration__authors__id": "USER-2"
+            },
+            {
+              "id": "USER-4",
+              "batch_hydration__authors__id": "USER-4"
+            },
+            {
+              "id": "USER-5",
+              "batch_hydration__authors__id": "USER-5"
+            }
+          ]
+        },
+        "extensions": {}
+      }
+# language=JSON
+response: |-
+  {
+    "data": {
+      "issues": [
+        {
+          "id": "ISSUE-1",
+          "authors": [
+            {
+              "id": "USER-1"
+            },
+            {
+              "id": "USER-2"
+            }
+          ]
+        },
+        {
+          "id": "ISSUE-2",
+          "authors": [
+            {
+              "id": "USER-3"
+            }
+          ]
+        },
+        {
+          "id": "ISSUE-3",
+          "authors": [
+            {
+              "id": "USER-2"
+            },
+            {
+              "id": "USER-4"
+            },
+            {
+              "id": "USER-5"
+            }
+          ]
+        }
+      ]
+    },
+    "extensions": {}
+  }


### PR DESCRIPTION
Please make sure you consider the following:
  
  - [X] Add tests that use __typename in queries. N/A
  - [X] Does this change work with all Nadel transformations (rename, type rename, hydration, etc)? Add tests for this. N/A
  - [X] Is it worth using hints for this change in order to be able to enable a percentage rollout? No
  - [X] Do we need to add integration tests for this change in the GraphQL Gateway? No
  - [X] Do we need a pollinator check for this? No
