### PR TITLE
remove hint removeHydrationSpecificExecutionCode

### DIFF
--- a/lib/src/main/java/graphql/nadel/NadelExecutionHints.kt
+++ b/lib/src/main/java/graphql/nadel/NadelExecutionHints.kt
@@ -6,7 +6,6 @@ import graphql.nadel.hints.LegacyOperationNamesHint
 data class NadelExecutionHints constructor(
     val legacyOperationNames: LegacyOperationNamesHint,
     val allDocumentVariablesHint: AllDocumentVariablesHint,
-    val removeHydrationSpecificExecutionCode: Boolean,
 ) {
     /**
      * Returns a builder with the same field values as this object.
@@ -21,14 +20,12 @@ data class NadelExecutionHints constructor(
     class Builder {
         private var legacyOperationNames: LegacyOperationNamesHint = LegacyOperationNamesHint { false }
         private var allDocumentVariablesHint: AllDocumentVariablesHint = AllDocumentVariablesHint { false }
-        private var removeHydrationSpecificExecutionCode: Boolean = false
 
         constructor()
 
         constructor(nadelExecutionHints: NadelExecutionHints) {
             legacyOperationNames = nadelExecutionHints.legacyOperationNames
             allDocumentVariablesHint = nadelExecutionHints.allDocumentVariablesHint
-            removeHydrationSpecificExecutionCode = nadelExecutionHints.removeHydrationSpecificExecutionCode
         }
 
         fun legacyOperationNames(flag: LegacyOperationNamesHint): Builder {
@@ -41,16 +38,10 @@ data class NadelExecutionHints constructor(
             return this
         }
 
-        fun removeHydrationSpecificExecutionCode(flag: Boolean): Builder {
-            removeHydrationSpecificExecutionCode = flag
-            return this
-        }
-
         fun build(): NadelExecutionHints {
             return NadelExecutionHints(
                 legacyOperationNames,
                 allDocumentVariablesHint,
-                removeHydrationSpecificExecutionCode,
             )
         }
     }

--- a/lib/src/main/java/graphql/nadel/NextgenEngine.kt
+++ b/lib/src/main/java/graphql/nadel/NextgenEngine.kt
@@ -17,12 +17,10 @@ import graphql.nadel.engine.plan.NadelExecutionPlanFactory
 import graphql.nadel.engine.transform.NadelTransform
 import graphql.nadel.engine.transform.query.DynamicServiceResolution
 import graphql.nadel.engine.transform.query.NadelFieldToService
-import graphql.nadel.engine.transform.query.NadelQueryPath
 import graphql.nadel.engine.transform.query.NadelQueryTransformer
 import graphql.nadel.engine.transform.result.NadelResultTransformer
 import graphql.nadel.engine.util.beginExecute
 import graphql.nadel.engine.util.copy
-import graphql.nadel.engine.util.fold
 import graphql.nadel.engine.util.getOperationKind
 import graphql.nadel.engine.util.mergeResults
 import graphql.nadel.engine.util.newExecutionResult
@@ -32,7 +30,6 @@ import graphql.nadel.engine.util.newServiceExecutionResult
 import graphql.nadel.engine.util.provide
 import graphql.nadel.engine.util.singleOfType
 import graphql.nadel.engine.util.strictAssociateBy
-import graphql.nadel.engine.util.toBuilder
 import graphql.nadel.hooks.ServiceExecutionHooks
 import graphql.nadel.instrumentation.parameters.NadelInstrumentationTimingParameters.RootStep
 import graphql.nadel.util.LogKit.getLogger
@@ -228,75 +225,6 @@ class NextgenEngine @JvmOverloads constructor(
         }
 
         return transformedResult
-    }
-
-    internal suspend fun executeHydration(
-        service: Service,
-        topLevelField: ExecutableNormalizedField,
-        pathToActorField: NadelQueryPath,
-        executionContext: NadelExecutionContext,
-        serviceHydrationDetails: ServiceExecutionHydrationDetails,
-    ): ServiceExecutionResult {
-        val actorField = fold(initial = topLevelField, count = pathToActorField.segments.size - 1) {
-            it.children.single()
-        }
-
-        val (transformResult, executionPlan) = transformHydrationQuery(
-            service,
-            executionContext,
-            actorField,
-            serviceHydrationDetails
-        )
-
-        // Get to the top level field again using .parent N times on the new actor field
-        val transformedQuery: ExecutableNormalizedField = fold(
-            initial = transformResult.result.single(),
-            count = pathToActorField.segments.size - 1,
-        ) {
-            it.parent ?: error("No parent")
-        }
-
-        val result = executeService(
-            service,
-            transformedQuery,
-            executionContext,
-            serviceHydrationDetails,
-        )
-
-        return resultTransformer.transform(
-            executionContext = executionContext,
-            executionPlan = executionPlan,
-            artificialFields = transformResult.artificialFields,
-            overallToUnderlyingFields = transformResult.overallToUnderlyingFields,
-            service = service,
-            result = result,
-        )
-    }
-
-    private suspend fun transformHydrationQuery(
-        service: Service,
-        executionContext: NadelExecutionContext,
-        actorField: ExecutableNormalizedField,
-        serviceHydrationDetails: ServiceExecutionHydrationDetails,
-    ): Pair<NadelQueryTransformer.TransformResult, NadelExecutionPlan> {
-        val executionPlan = executionPlanner.create(
-            executionContext,
-            services,
-            service,
-            rootField = actorField,
-            serviceHydrationDetails,
-        )
-
-        val queryTransform = transformQuery(service, executionContext, executionPlan, actorField)
-
-        // Fix parent of the actor field
-        if (actorField.parent != null) {
-            val fixedParent = actorField.parent.toBuilder().children(queryTransform.result).build()
-            val queryTransformResult = queryTransform.result.single()
-            queryTransformResult.replaceParent(fixedParent)
-        }
-
-        return Pair(queryTransform, executionPlan)
     }
 
     private suspend fun executeService(

--- a/lib/src/main/java/graphql/nadel/engine/transform/hydration/NadelHydrationTransform.kt
+++ b/lib/src/main/java/graphql/nadel/engine/transform/hydration/NadelHydrationTransform.kt
@@ -212,22 +212,12 @@ internal class NadelHydrationTransform(
                         hydrationSourceField = instruction.location,
                         hydrationActorField = hydrationActorField
                     )
-                    if (executionContext.hints.removeHydrationSpecificExecutionCode) {
-                        engine.executeTopLevelField(
-                            service = instruction.actorService,
-                            topLevelField = actorQuery,
-                            executionContext = executionContext,
-                            serviceHydrationDetails = serviceHydrationDetails
-                        )
-                    } else {
-                        engine.executeHydration(
-                            service = instruction.actorService,
-                            topLevelField = actorQuery,
-                            pathToActorField = instruction.queryPathToActorField,
-                            executionContext = executionContext,
-                            serviceHydrationDetails = serviceHydrationDetails
-                        )
-                    }
+                    engine.executeTopLevelField(
+                        service = instruction.actorService,
+                        topLevelField = actorQuery,
+                        executionContext = executionContext,
+                        serviceHydrationDetails = serviceHydrationDetails
+                    )
                 }
             }.awaitAll()
         }
@@ -253,6 +243,7 @@ internal class NadelHydrationTransform(
                     ),
                 ) + errors
             }
+
             is NadelHydrationStrategy.ManyToOne -> {
                 val data = actorQueryResults.map { result ->
                     JsonNodeExtractor.getNodesAt(

--- a/lib/src/main/java/graphql/nadel/engine/transform/hydration/batch/NadelBatchHydrator.kt
+++ b/lib/src/main/java/graphql/nadel/engine/transform/hydration/batch/NadelBatchHydrator.kt
@@ -65,6 +65,7 @@ internal class NadelBatchHydrator(
                                 newValue = null,
                             )
                         }
+
                         else -> hydrate(executionBlueprint, state, instruction, parentNodes)
                     }
                 }
@@ -93,6 +94,7 @@ internal class NadelBatchHydrator(
                 parentNodes = parentNodes,
                 batches = batches,
             )
+
             is NadelBatchHydrationMatchStrategy.MatchObjectIdentifier -> getHydrateInstructionsMatchingObjectId(
                 executionBlueprint = executionBlueprint,
                 state = state,
@@ -101,6 +103,7 @@ internal class NadelBatchHydrator(
                 batches = batches,
                 matchStrategy = matchStrategy,
             )
+
             is NadelBatchHydrationMatchStrategy.MatchObjectIdentifiers -> getHydrateInstructionsMatchingObjectIds(
                 executionBlueprint = executionBlueprint,
                 state = state,
@@ -142,22 +145,12 @@ internal class NadelBatchHydrator(
                             hydrationSourceField = instruction.location,
                             hydrationActorField = hydrationActorField
                         )
-                        if (state.executionContext.hints.removeHydrationSpecificExecutionCode) {
-                            engine.executeTopLevelField(
-                                service = instruction.actorService,
-                                topLevelField = actorQuery,
-                                executionContext = state.executionContext,
-                                serviceHydrationDetails = serviceHydrationDetails
-                            )
-                        } else {
-                            engine.executeHydration(
-                                service = instruction.actorService,
-                                topLevelField = actorQuery,
-                                pathToActorField = instruction.queryPathToActorField,
-                                executionContext = state.executionContext,
-                                serviceHydrationDetails = serviceHydrationDetails
-                            )
-                        }
+                        engine.executeTopLevelField(
+                            service = instruction.actorService,
+                            topLevelField = actorQuery,
+                            executionContext = state.executionContext,
+                            serviceHydrationDetails = serviceHydrationDetails
+                        )
                     }
                 }
                 .awaitAll()

--- a/test/src/test/kotlin/graphql/nadel/tests/hooks/all-hydration-fields-are-seen-by-transformer.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/hooks/all-hydration-fields-are-seen-by-transformer.kt
@@ -23,11 +23,6 @@ class `all-hydration-fields-are-seen-by-transformer` : EngineTestHook {
     private val transformField = synchronizedSet(mutableSetOf<String>())
     private val getResultInstructions = synchronizedSet(mutableSetOf<String>())
 
-    override fun makeExecutionHints(builder: NadelExecutionHints.Builder): NadelExecutionHints.Builder {
-        return builder
-            .removeHydrationSpecificExecutionCode(true)
-    }
-
     override val customTransforms: List<NadelTransform<out Any>>
         get() = listOf(
             object : NadelTransform<Unit> {
@@ -72,28 +67,34 @@ class `all-hydration-fields-are-seen-by-transformer` : EngineTestHook {
         )
 
     override fun assertResult(result: ExecutionResult) {
-        assert(isApplicable == setOf(
-            "service1.foo",
-            "service1.bar",
-            "service1.name",
-            "service2.bars",
-            "service2.barById",
-            "service2.name",
-        ))
+        assert(
+            isApplicable == setOf(
+                "service1.foo",
+                "service1.bar",
+                "service1.name",
+                "service2.bars",
+                "service2.barById",
+                "service2.name",
+            )
+        )
         // service1.name is missing because it's removed as part of the hydration query
-        assert(transformField == setOf(
-            "service1.foo",
-            "service1.bar",
-            "service2.bars",
-            "service2.barById",
-            "service2.name",
-        ))
-        assert(getResultInstructions == setOf(
-            "service1.foo",
-            "service1.bar",
-            "service2.bars",
-            "service2.barById",
-            "service2.name",
-        ))
+        assert(
+            transformField == setOf(
+                "service1.foo",
+                "service1.bar",
+                "service2.bars",
+                "service2.barById",
+                "service2.name",
+            )
+        )
+        assert(
+            getResultInstructions == setOf(
+                "service1.foo",
+                "service1.bar",
+                "service2.bars",
+                "service2.barById",
+                "service2.name",
+            )
+        )
     }
 }


### PR DESCRIPTION
Please make sure you consider the following:

- [x] Add tests that use __typename in queries
- [x] Does this change work with all nadel transformations (rename, type rename, hydration, etc)? Add tests for this.
- [x] Is it worth using hints for this change in order to be able to enable a percentage rollout?
- [x] Do we need to add integration tests for this change in the graphql gateway?
- [x] Do we need a pollinator check for this?
