### PR TITLE
Remove logging when service call throws exception

### DIFF
--- a/lib/src/main/java/graphql/nadel/NextgenEngine.kt
+++ b/lib/src/main/java/graphql/nadel/NextgenEngine.kt
@@ -31,6 +31,8 @@ import graphql.nadel.engine.util.provide
 import graphql.nadel.engine.util.singleOfType
 import graphql.nadel.engine.util.strictAssociateBy
 import graphql.nadel.hooks.ServiceExecutionHooks
+import graphql.nadel.instrumentation.parameters.ExecutionErrorData
+import graphql.nadel.instrumentation.parameters.OnServiceExecutionErrorParameters
 import graphql.nadel.instrumentation.parameters.NadelInstrumentationTimingParameters.RootStep
 import graphql.nadel.util.OperationNameUtil
 import graphql.normalized.ExecutableNormalizedField
@@ -262,6 +264,12 @@ class NextgenEngine @JvmOverloads constructor(
             val errorMessage = "An exception occurred invoking the service '${service.name}'"
             val errorMessageNotSafe = "$errorMessage: ${e.message}"
             val executionId = serviceExecParams.executionId.toString()
+
+            instrumentation.onError(OnServiceExecutionErrorParameters(
+                message = errorMessage,
+                exception = e,
+                errorData = ExecutionErrorData(executionId)
+            ))
 
             newServiceExecutionResult(
                 errors = mutableListOf(

--- a/lib/src/main/java/graphql/nadel/NextgenEngine.kt
+++ b/lib/src/main/java/graphql/nadel/NextgenEngine.kt
@@ -32,13 +32,12 @@ import graphql.nadel.engine.util.singleOfType
 import graphql.nadel.engine.util.strictAssociateBy
 import graphql.nadel.hooks.ServiceExecutionHooks
 import graphql.nadel.instrumentation.parameters.NadelInstrumentationTimingParameters.RootStep
-import graphql.nadel.util.LogKit.getLogger
-import graphql.nadel.util.LogKit.getNotPrivacySafeLogger
 import graphql.nadel.util.OperationNameUtil
 import graphql.normalized.ExecutableNormalizedField
 import graphql.normalized.ExecutableNormalizedOperationFactory.createExecutableNormalizedOperationWithRawVariables
 import graphql.normalized.ExecutableNormalizedOperationToAstCompiler.compileToDocument
 import graphql.normalized.VariablePredicate
+import java.util.concurrent.CompletableFuture
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -51,15 +50,12 @@ import kotlinx.coroutines.future.asCompletableFuture
 import kotlinx.coroutines.future.asDeferred
 import kotlinx.coroutines.future.await
 import kotlinx.coroutines.launch
-import java.util.concurrent.CompletableFuture
 
 class NextgenEngine @JvmOverloads constructor(
     nadel: Nadel,
     transforms: List<NadelTransform<out Any>> = emptyList(),
     introspectionRunnerFactory: NadelIntrospectionRunnerFactory = NadelIntrospectionRunnerFactory(::NadelDefaultIntrospectionRunner),
 ) : NadelExecutionEngine {
-    private val logNotSafe = getNotPrivacySafeLogger<NextgenEngine>()
-    private val log = getLogger<NextgenEngine>()
 
     private val coroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
     private val services: Map<String, Service> = nadel.services.strictAssociateBy { it.name }
@@ -266,8 +262,6 @@ class NextgenEngine @JvmOverloads constructor(
             val errorMessage = "An exception occurred invoking the service '${service.name}'"
             val errorMessageNotSafe = "$errorMessage: ${e.message}"
             val executionId = serviceExecParams.executionId.toString()
-            logNotSafe.error("$errorMessageNotSafe. Execution ID '$executionId'", e)
-            log.error("$errorMessage. Execution ID '$executionId'", e)
 
             newServiceExecutionResult(
                 errors = mutableListOf(

--- a/lib/src/main/java/graphql/nadel/NextgenEngine.kt
+++ b/lib/src/main/java/graphql/nadel/NextgenEngine.kt
@@ -31,6 +31,7 @@ import graphql.nadel.engine.util.provide
 import graphql.nadel.engine.util.singleOfType
 import graphql.nadel.engine.util.strictAssociateBy
 import graphql.nadel.hooks.ServiceExecutionHooks
+import graphql.nadel.instrumentation.parameters.ErrorType.ServiceExecutionError
 import graphql.nadel.instrumentation.parameters.NadelInstrumentationOnErrorParameters
 import graphql.nadel.instrumentation.parameters.NadelInstrumentationTimingParameters.RootStep
 import graphql.nadel.instrumentation.parameters.OnServiceExecutionErrorData
@@ -278,6 +279,7 @@ class NextgenEngine @JvmOverloads constructor(
                     message = errorMessage,
                     exception = e,
                     instrumentationState = instrumentationState,
+                    errorType = ServiceExecutionError,
                     errorData = OnServiceExecutionErrorData(
                         executionId = executionId,
                         serviceName = service.name

--- a/lib/src/main/java/graphql/nadel/NextgenEngine.kt
+++ b/lib/src/main/java/graphql/nadel/NextgenEngine.kt
@@ -31,10 +31,10 @@ import graphql.nadel.engine.util.provide
 import graphql.nadel.engine.util.singleOfType
 import graphql.nadel.engine.util.strictAssociateBy
 import graphql.nadel.hooks.ServiceExecutionHooks
+import graphql.nadel.instrumentation.parameters.ErrorData
 import graphql.nadel.instrumentation.parameters.ErrorType.ServiceExecutionError
 import graphql.nadel.instrumentation.parameters.NadelInstrumentationOnErrorParameters
 import graphql.nadel.instrumentation.parameters.NadelInstrumentationTimingParameters.RootStep
-import graphql.nadel.instrumentation.parameters.OnServiceExecutionErrorData
 import graphql.nadel.util.OperationNameUtil
 import graphql.normalized.ExecutableNormalizedField
 import graphql.normalized.ExecutableNormalizedOperationFactory.createExecutableNormalizedOperationWithRawVariables
@@ -161,7 +161,6 @@ class NextgenEngine @JvmOverloads constructor(
                                             topLevelField = field,
                                             service = resolvedService,
                                             executionContext = executionContext,
-                                            instrumentationState = instrumentationState
                                         )
                                     } catch (e: Throwable) {
                                         when (e) {
@@ -192,7 +191,6 @@ class NextgenEngine @JvmOverloads constructor(
         topLevelField: ExecutableNormalizedField,
         service: Service,
         executionContext: NadelExecutionContext,
-        instrumentationState: InstrumentationState?,
         serviceHydrationDetails: ServiceExecutionHydrationDetails? = null,
     ): ServiceExecutionResult {
         val timer = executionContext.timer
@@ -214,7 +212,6 @@ class NextgenEngine @JvmOverloads constructor(
             transformedQuery = transformedQuery,
             executionContext = executionContext,
             executionHydrationDetails = serviceHydrationDetails,
-            instrumentationState = instrumentationState,
         )
         val transformedResult: ServiceExecutionResult = when {
             topLevelField.name.startsWith("__") -> result
@@ -237,7 +234,6 @@ class NextgenEngine @JvmOverloads constructor(
         service: Service,
         transformedQuery: ExecutableNormalizedField,
         executionContext: NadelExecutionContext,
-        instrumentationState: InstrumentationState?,
         executionHydrationDetails: ServiceExecutionHydrationDetails? = null,
     ): ServiceExecutionResult {
         val executionInput = executionContext.executionInput
@@ -278,9 +274,9 @@ class NextgenEngine @JvmOverloads constructor(
                 NadelInstrumentationOnErrorParameters(
                     message = errorMessage,
                     exception = e,
-                    instrumentationState = instrumentationState,
+                    instrumentationState = executionContext.instrumentationState,
                     errorType = ServiceExecutionError,
-                    errorData = OnServiceExecutionErrorData(
+                    errorData = ErrorData.ServiceExecutionErrorData(
                         executionId = executionId,
                         serviceName = service.name
                     )

--- a/lib/src/main/java/graphql/nadel/engine/transform/hydration/NadelHydrationTransform.kt
+++ b/lib/src/main/java/graphql/nadel/engine/transform/hydration/NadelHydrationTransform.kt
@@ -216,7 +216,8 @@ internal class NadelHydrationTransform(
                         service = instruction.actorService,
                         topLevelField = actorQuery,
                         executionContext = executionContext,
-                        serviceHydrationDetails = serviceHydrationDetails
+                        serviceHydrationDetails = serviceHydrationDetails,
+                        instrumentationState = executionContext.instrumentationState
                     )
                 }
             }.awaitAll()

--- a/lib/src/main/java/graphql/nadel/engine/transform/hydration/NadelHydrationTransform.kt
+++ b/lib/src/main/java/graphql/nadel/engine/transform/hydration/NadelHydrationTransform.kt
@@ -217,7 +217,6 @@ internal class NadelHydrationTransform(
                         topLevelField = actorQuery,
                         executionContext = executionContext,
                         serviceHydrationDetails = serviceHydrationDetails,
-                        instrumentationState = executionContext.instrumentationState
                     )
                 }
             }.awaitAll()

--- a/lib/src/main/java/graphql/nadel/engine/transform/hydration/batch/NadelBatchHydrator.kt
+++ b/lib/src/main/java/graphql/nadel/engine/transform/hydration/batch/NadelBatchHydrator.kt
@@ -149,7 +149,8 @@ internal class NadelBatchHydrator(
                             service = instruction.actorService,
                             topLevelField = actorQuery,
                             executionContext = state.executionContext,
-                            serviceHydrationDetails = serviceHydrationDetails
+                            serviceHydrationDetails = serviceHydrationDetails,
+                            instrumentationState = state.executionContext.instrumentationState
                         )
                     }
                 }

--- a/lib/src/main/java/graphql/nadel/engine/transform/hydration/batch/NadelBatchHydrator.kt
+++ b/lib/src/main/java/graphql/nadel/engine/transform/hydration/batch/NadelBatchHydrator.kt
@@ -150,7 +150,6 @@ internal class NadelBatchHydrator(
                             topLevelField = actorQuery,
                             executionContext = state.executionContext,
                             serviceHydrationDetails = serviceHydrationDetails,
-                            instrumentationState = state.executionContext.instrumentationState
                         )
                     }
                 }

--- a/lib/src/main/java/graphql/nadel/instrumentation/ChainedNadelInstrumentation.kt
+++ b/lib/src/main/java/graphql/nadel/instrumentation/ChainedNadelInstrumentation.kt
@@ -50,7 +50,7 @@ class ChainedNadelInstrumentation(
         }
     }
 
-    override fun  onError(parameters: NadelInstrumentationOnErrorParameters) {
+    override fun onError(parameters: NadelInstrumentationOnErrorParameters) {
         instrumentations.forEach { instrumentation: NadelInstrumentation ->
             val state = getStateFor(instrumentation, parameters.getInstrumentationState()!!)
             instrumentation.onError(parameters.copy(instrumentationState = state))

--- a/lib/src/main/java/graphql/nadel/instrumentation/ChainedNadelInstrumentation.kt
+++ b/lib/src/main/java/graphql/nadel/instrumentation/ChainedNadelInstrumentation.kt
@@ -7,6 +7,7 @@ import graphql.execution.instrumentation.InstrumentationState
 import graphql.language.Document
 import graphql.nadel.instrumentation.parameters.NadelInstrumentationCreateStateParameters
 import graphql.nadel.instrumentation.parameters.NadelInstrumentationExecuteOperationParameters
+import graphql.nadel.instrumentation.parameters.NadelInstrumentationOnErrorParameters
 import graphql.nadel.instrumentation.parameters.NadelInstrumentationQueryExecutionParameters
 import graphql.nadel.instrumentation.parameters.NadelInstrumentationQueryValidationParameters
 import graphql.nadel.instrumentation.parameters.NadelInstrumentationTimingParameters
@@ -46,6 +47,13 @@ class ChainedNadelInstrumentation(
         instrumentations.forEach { instrumentation: NadelInstrumentation ->
             val state = getStateFor(instrumentation, parameters.getInstrumentationState()!!)
             instrumentation.onStepTimed(parameters.copy(instrumentationState = state))
+        }
+    }
+
+    override fun  onError(parameters: NadelInstrumentationOnErrorParameters) {
+        instrumentations.forEach { instrumentation: NadelInstrumentation ->
+            val state = getStateFor(instrumentation, parameters.getInstrumentationState()!!)
+            instrumentation.onError(parameters.copy(instrumentationState = state))
         }
     }
 

--- a/lib/src/main/java/graphql/nadel/instrumentation/NadelInstrumentation.kt
+++ b/lib/src/main/java/graphql/nadel/instrumentation/NadelInstrumentation.kt
@@ -102,6 +102,13 @@ interface NadelInstrumentation {
         return CompletableFuture.completedFuture(executionResult)
     }
 
+    /**
+     * Called when Nadel encounters an error that can be useful for the caller code - for logging or metrics, for example.
+     *
+     * The nature of the error can be obtained by looking at the value of [NadelInstrumentationOnErrorParameters.errorType].
+     *
+     *  @param parameters to this step
+     */
     fun onError(parameters: NadelInstrumentationOnErrorParameters) {
     }
 }

--- a/lib/src/main/java/graphql/nadel/instrumentation/NadelInstrumentation.kt
+++ b/lib/src/main/java/graphql/nadel/instrumentation/NadelInstrumentation.kt
@@ -102,6 +102,6 @@ interface NadelInstrumentation {
         return CompletableFuture.completedFuture(executionResult)
     }
 
-    fun onError(parameters: NadelInstrumentationOnErrorParameters<*>) {
+    fun onError(parameters: NadelInstrumentationOnErrorParameters) {
     }
 }

--- a/lib/src/main/java/graphql/nadel/instrumentation/NadelInstrumentation.kt
+++ b/lib/src/main/java/graphql/nadel/instrumentation/NadelInstrumentation.kt
@@ -7,6 +7,7 @@ import graphql.execution.instrumentation.SimpleInstrumentationContext.noOp
 import graphql.language.Document
 import graphql.nadel.instrumentation.parameters.NadelInstrumentationCreateStateParameters
 import graphql.nadel.instrumentation.parameters.NadelInstrumentationExecuteOperationParameters
+import graphql.nadel.instrumentation.parameters.NadelInstrumentationOnErrorParameters
 import graphql.nadel.instrumentation.parameters.NadelInstrumentationQueryExecutionParameters
 import graphql.nadel.instrumentation.parameters.NadelInstrumentationQueryValidationParameters
 import graphql.nadel.instrumentation.parameters.NadelInstrumentationTimingParameters
@@ -99,5 +100,8 @@ interface NadelInstrumentation {
         parameters: NadelInstrumentationQueryExecutionParameters,
     ): CompletableFuture<ExecutionResult> {
         return CompletableFuture.completedFuture(executionResult)
+    }
+
+    fun onError(parameters: NadelInstrumentationOnErrorParameters<*>) {
     }
 }

--- a/lib/src/main/java/graphql/nadel/instrumentation/parameters/NadelInstrumentationOnErrorParameters.kt
+++ b/lib/src/main/java/graphql/nadel/instrumentation/parameters/NadelInstrumentationOnErrorParameters.kt
@@ -1,0 +1,19 @@
+package graphql.nadel.instrumentation.parameters
+
+open class NadelInstrumentationOnErrorParameters(
+    val message: String,
+    val exception: Throwable,
+)
+
+class OnServiceExecutionErrorParameters(
+    message: String,
+    exception: Throwable,
+    val errorData: ExecutionErrorData
+) : NadelInstrumentationOnErrorParameters(
+    message, exception
+)
+
+data class ExecutionErrorData(
+    val executionId: String
+)
+

--- a/lib/src/main/java/graphql/nadel/instrumentation/parameters/NadelInstrumentationOnErrorParameters.kt
+++ b/lib/src/main/java/graphql/nadel/instrumentation/parameters/NadelInstrumentationOnErrorParameters.kt
@@ -5,6 +5,7 @@ import graphql.execution.instrumentation.InstrumentationState
 data class NadelInstrumentationOnErrorParameters(
     val message: String,
     val exception: Throwable,
+    val errorType: ErrorType,
     val errorData: Any?,
     private val instrumentationState: InstrumentationState?,
 ) {
@@ -18,3 +19,7 @@ data class OnServiceExecutionErrorData(
     val executionId: String,
     val serviceName: String
 )
+
+enum class ErrorType {
+    ServiceExecutionError
+}

--- a/lib/src/main/java/graphql/nadel/instrumentation/parameters/NadelInstrumentationOnErrorParameters.kt
+++ b/lib/src/main/java/graphql/nadel/instrumentation/parameters/NadelInstrumentationOnErrorParameters.kt
@@ -6,7 +6,7 @@ data class NadelInstrumentationOnErrorParameters(
     val message: String,
     val exception: Throwable,
     val errorType: ErrorType,
-    val errorData: Any?,
+    val errorData: ErrorData,
     private val instrumentationState: InstrumentationState?,
 ) {
     fun <T : InstrumentationState?> getInstrumentationState(): T? {
@@ -15,10 +15,12 @@ data class NadelInstrumentationOnErrorParameters(
     }
 }
 
-data class OnServiceExecutionErrorData(
-    val executionId: String,
-    val serviceName: String
-)
+sealed interface ErrorData {
+    data class ServiceExecutionErrorData(
+        val executionId: String,
+        val serviceName: String,
+    ) : ErrorData
+}
 
 enum class ErrorType {
     ServiceExecutionError

--- a/lib/src/main/java/graphql/nadel/instrumentation/parameters/NadelInstrumentationOnErrorParameters.kt
+++ b/lib/src/main/java/graphql/nadel/instrumentation/parameters/NadelInstrumentationOnErrorParameters.kt
@@ -1,19 +1,20 @@
 package graphql.nadel.instrumentation.parameters
 
-open class NadelInstrumentationOnErrorParameters(
+import graphql.execution.instrumentation.InstrumentationState
+
+data class NadelInstrumentationOnErrorParameters(
     val message: String,
     val exception: Throwable,
-)
+    val errorData: Any?,
+    private val instrumentationState: InstrumentationState?,
+) {
+    fun <T : InstrumentationState?> getInstrumentationState(): T? {
+        @Suppress("UNCHECKED_CAST") // trust the caller
+        return instrumentationState as T?
+    }
+}
 
-class OnServiceExecutionErrorParameters(
-    message: String,
-    exception: Throwable,
-    val errorData: ExecutionErrorData
-) : NadelInstrumentationOnErrorParameters(
-    message, exception
+data class OnServiceExecutionErrorData(
+    val executionId: String,
+    val serviceName: String
 )
-
-data class ExecutionErrorData(
-    val executionId: String
-)
-

--- a/lib/src/test/kotlin/graphql/nadel/instrumentation/ChainedNadelInstrumentationTest.kt
+++ b/lib/src/test/kotlin/graphql/nadel/instrumentation/ChainedNadelInstrumentationTest.kt
@@ -327,7 +327,7 @@ class ChainedNadelInstrumentationTest : DescribeSpec({
                 } returns chainedState
 
                 every {
-                    params.copy(any(), any(), any(), any())
+                    params.copy(any(), any(), any(), any(), any())
                 } answers { copyCall ->
                     val newState = copyCall.invocation.args.singleOfType<InstrumentationState>()
                     mock { newParams ->
@@ -492,7 +492,7 @@ class ChainedNadelInstrumentationTest : DescribeSpec({
             val paramsCopy = mock<NadelInstrumentationOnErrorParameters>()
             val params = mock<NadelInstrumentationOnErrorParameters> { params ->
                 every { params.getInstrumentationState<InstrumentationState>() } returns chainedState
-                every { params.copy(any(), any(), any(), any() ) } returns paramsCopy
+                every { params.copy(any(), any(), any(), any(), any()) } returns paramsCopy
             }
 
             // when

--- a/lib/src/test/kotlin/graphql/nadel/instrumentation/ChainedNadelInstrumentationTest.kt
+++ b/lib/src/test/kotlin/graphql/nadel/instrumentation/ChainedNadelInstrumentationTest.kt
@@ -8,6 +8,7 @@ import graphql.nadel.engine.util.singleOfType
 import graphql.nadel.instrumentation.ChainedNadelInstrumentation.ChainedInstrumentationState
 import graphql.nadel.instrumentation.parameters.NadelInstrumentationCreateStateParameters
 import graphql.nadel.instrumentation.parameters.NadelInstrumentationExecuteOperationParameters
+import graphql.nadel.instrumentation.parameters.NadelInstrumentationOnErrorParameters
 import graphql.nadel.instrumentation.parameters.NadelInstrumentationQueryExecutionParameters
 import graphql.nadel.instrumentation.parameters.NadelInstrumentationQueryValidationParameters
 import graphql.nadel.instrumentation.parameters.NadelInstrumentationTimingParameters
@@ -317,6 +318,41 @@ class ChainedNadelInstrumentationTest : DescribeSpec({
                     assert(params.captured.getInstrumentationState<State>()?.something == instrumentation.key)
                 }
         }
+
+        it("passes on correct state for onError") {
+            // when
+            chainedInstrumentation.onError(mock { params ->
+                every {
+                    params.getInstrumentationState<InstrumentationState>()
+                } returns chainedState
+
+                every {
+                    params.copy(any(), any(), any(), any())
+                } answers { copyCall ->
+                    val newState = copyCall.invocation.args.singleOfType<InstrumentationState>()
+                    mock { newParams ->
+                        every {
+                            newParams.getInstrumentationState<InstrumentationState>()
+                        } answers {
+                            newState
+                        }
+                    }
+                }
+            })
+
+            // then
+            chainedInstrumentation.getInstrumentations()
+                .map { it as TestInstrumentation }
+                .forEach { instrumentation ->
+                    val params = slot<NadelInstrumentationOnErrorParameters>()
+                    verify(exactly = 1) {
+                        instrumentation.onError(capture(params))
+                    }
+
+                    assert(params.isCaptured)
+                    assert(params.captured.getInstrumentationState<State>()?.something == instrumentation.key)
+                }
+        }
     }
 
     describe("parameter delegation") {
@@ -447,6 +483,26 @@ class ChainedNadelInstrumentationTest : DescribeSpec({
                 .forEach { instrumentation ->
                     verify(exactly = 1) {
                         instrumentation.instrumentExecutionResult(any(), paramsCopy)
+                    }
+                }
+        }
+
+        it("passes on correct parameters for onError") {
+            // given
+            val paramsCopy = mock<NadelInstrumentationOnErrorParameters>()
+            val params = mock<NadelInstrumentationOnErrorParameters> { params ->
+                every { params.getInstrumentationState<InstrumentationState>() } returns chainedState
+                every { params.copy(any(), any(), any(), any() ) } returns paramsCopy
+            }
+
+            // when
+            chainedInstrumentation.onError(params)
+
+            // then
+            chainedInstrumentation.getInstrumentations()
+                .forEach { instrumentation ->
+                    verify(exactly = 1) {
+                        instrumentation.onError(paramsCopy)
                     }
                 }
         }

--- a/test/src/test/kotlin/graphql/nadel/tests/hooks/exceptions-in-service-execution-call-result-in-graphql-errors-and-call-onerror-instrumentation.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/hooks/exceptions-in-service-execution-call-result-in-graphql-errors-and-call-onerror-instrumentation.kt
@@ -5,8 +5,8 @@ import graphql.nadel.Nadel
 import graphql.nadel.ServiceExecution
 import graphql.nadel.ServiceExecutionFactory
 import graphql.nadel.instrumentation.NadelInstrumentation
+import graphql.nadel.instrumentation.parameters.ErrorData
 import graphql.nadel.instrumentation.parameters.NadelInstrumentationOnErrorParameters
-import graphql.nadel.instrumentation.parameters.OnServiceExecutionErrorData
 import graphql.nadel.tests.EngineTestHook
 import graphql.nadel.tests.UseHook
 import graphql.nadel.tests.assertJsonKeys
@@ -19,11 +19,11 @@ import strikt.assertions.get
 import strikt.assertions.isEqualTo
 import strikt.assertions.isNotNull
 import strikt.assertions.isNull
-import strikt.assertions.isTrue
 import strikt.assertions.single
 
 @UseHook
-class `exceptions-in-service-execution-call-result-in-graphql-errors-and-call-onerror-instrumentation` : EngineTestHook {
+class `exceptions-in-service-execution-call-result-in-graphql-errors-and-call-onerror-instrumentation` :
+    EngineTestHook {
     var serviceName: String? = null
     var errorMessage: String? = null
     override fun makeNadel(builder: Nadel.Builder): Nadel.Builder {
@@ -35,9 +35,9 @@ class `exceptions-in-service-execution-call-result-in-graphql-errors-and-call-on
                     }
                 }
             })
-            .instrumentation(object: NadelInstrumentation {
+            .instrumentation(object : NadelInstrumentation {
                 override fun onError(parameters: NadelInstrumentationOnErrorParameters) {
-                    serviceName = (parameters.errorData as OnServiceExecutionErrorData).serviceName
+                    serviceName = (parameters.errorData as ErrorData.ServiceExecutionErrorData).serviceName
                     errorMessage = parameters.message
                 }
             })

--- a/test/src/test/kotlin/graphql/nadel/tests/hooks/exceptions-in-service-execution-call-result-in-graphql-errors-and-call-onerror-instrumentation.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/hooks/exceptions-in-service-execution-call-result-in-graphql-errors-and-call-onerror-instrumentation.kt
@@ -4,22 +4,28 @@ import graphql.ExecutionResult
 import graphql.nadel.Nadel
 import graphql.nadel.ServiceExecution
 import graphql.nadel.ServiceExecutionFactory
+import graphql.nadel.instrumentation.NadelInstrumentation
+import graphql.nadel.instrumentation.parameters.NadelInstrumentationOnErrorParameters
+import graphql.nadel.instrumentation.parameters.OnServiceExecutionErrorData
 import graphql.nadel.tests.EngineTestHook
 import graphql.nadel.tests.UseHook
 import graphql.nadel.tests.assertJsonKeys
 import graphql.nadel.tests.util.data
 import graphql.nadel.tests.util.errors
 import graphql.nadel.tests.util.message
-import graphql.nadel.tests.util.serviceExecutionFactory
 import strikt.api.expectThat
 import strikt.assertions.contains
 import strikt.assertions.get
+import strikt.assertions.isEqualTo
 import strikt.assertions.isNotNull
 import strikt.assertions.isNull
+import strikt.assertions.isTrue
 import strikt.assertions.single
 
 @UseHook
-class `exceptions-in-service-execution-call-result-in-graphql-errors` : EngineTestHook {
+class `exceptions-in-service-execution-call-result-in-graphql-errors-and-call-onerror-instrumentation` : EngineTestHook {
+    var serviceName: String? = null
+    var errorMessage: String? = null
     override fun makeNadel(builder: Nadel.Builder): Nadel.Builder {
         return builder
             .serviceExecutionFactory(object : ServiceExecutionFactory {
@@ -27,6 +33,12 @@ class `exceptions-in-service-execution-call-result-in-graphql-errors` : EngineTe
                     return ServiceExecution {
                         throw RuntimeException("Pop goes the weasel")
                     }
+                }
+            })
+            .instrumentation(object: NadelInstrumentation {
+                override fun onError(parameters: NadelInstrumentationOnErrorParameters) {
+                    serviceName = (parameters.errorData as OnServiceExecutionErrorData).serviceName
+                    errorMessage = parameters.message
                 }
             })
     }
@@ -40,5 +52,8 @@ class `exceptions-in-service-execution-call-result-in-graphql-errors` : EngineTe
             .single()
             .message
             .contains("Pop goes the weasel")
+
+        expectThat(serviceName).isEqualTo("MyService")
+        expectThat(errorMessage).isEqualTo("An exception occurred invoking the service 'MyService'")
     }
 }

--- a/test/src/test/resources/fixtures/errors/exceptions-in-service-execution-call-result-in-graphql-errors-and-call-onerror-instrumentation.yml
+++ b/test/src/test/resources/fixtures/errors/exceptions-in-service-execution-call-result-in-graphql-errors-and-call-onerror-instrumentation.yml
@@ -1,4 +1,4 @@
-name: "exceptions in service execution call result in graphql errors"
+name: "exceptions in service execution call result in graphql errors and call onerror instrumentation"
 enabled: true
 overallSchema:
   MyService: |


### PR DESCRIPTION
WIP


---
Please make sure you consider the following:

- [x] Add tests that use __typename in queries
- [x] Does this change work with all nadel transformations (rename, type rename, hydration, etc)? Add tests for this.
- [x] Is it worth using hints for this change in order to be able to enable a percentage rollout?
- [x] Do we need to add integration tests for this change in the graphql gateway?
- [x] Do we need a pollinator check for this?
