### PR TITLE
Faster introspection

### DIFF
--- a/lib/src/main/java/graphql/nadel/engine/blueprint/IntrospectionService.kt
+++ b/lib/src/main/java/graphql/nadel/engine/blueprint/IntrospectionService.kt
@@ -184,7 +184,7 @@ open class NadelDefaultIntrospectionRunner(
         children: List<ExecutableNormalizedField>,
         value: Any?,
     ): Any {
-        val data: MutableJsonMap = LinkedHashMap()
+        val data: MutableJsonMap = LinkedHashMap(children.size)
         children.forEach { child ->
             data[child.name] = getValue(field = child, parentValue = value)
         }

--- a/lib/src/main/java/graphql/nadel/engine/blueprint/IntrospectionService.kt
+++ b/lib/src/main/java/graphql/nadel/engine/blueprint/IntrospectionService.kt
@@ -1,16 +1,40 @@
 package graphql.nadel.engine.blueprint
 
-import graphql.ExecutionInput
-import graphql.GraphQL
-import graphql.GraphqlErrorHelper.toSpecification
-import graphql.language.AstPrinter
+import graphql.GraphQLContext
+import graphql.cachecontrol.CacheControl
+import graphql.execution.ExecutionId
+import graphql.execution.ExecutionStepInfo
+import graphql.execution.MergedField
+import graphql.execution.directives.QueryDirectives
+import graphql.introspection.Introspection
+import graphql.language.Document
+import graphql.language.Field
+import graphql.language.FragmentDefinition
+import graphql.language.OperationDefinition
 import graphql.nadel.NadelDefinitionRegistry
 import graphql.nadel.Service
 import graphql.nadel.ServiceExecution
 import graphql.nadel.ServiceExecutionParameters
 import graphql.nadel.ServiceExecutionResult
+import graphql.nadel.engine.util.AnyIterable
+import graphql.nadel.engine.util.MutableJsonMap
+import graphql.nadel.engine.util.makeFieldCoordinates
+import graphql.nadel.engine.util.newServiceExecutionResult
+import graphql.normalized.ExecutableNormalizedField
+import graphql.schema.DataFetcher
+import graphql.schema.DataFetchingEnvironment
+import graphql.schema.DataFetchingFieldSelectionSet
+import graphql.schema.FieldCoordinates
+import graphql.schema.GraphQLFieldDefinition
+import graphql.schema.GraphQLOutputType
 import graphql.schema.GraphQLSchema
+import graphql.schema.GraphQLType
+import graphql.schema.PropertyDataFetcher
+import org.dataloader.DataLoader
+import org.dataloader.DataLoaderRegistry
+import java.util.Locale
 import java.util.concurrent.CompletableFuture
+import graphql.introspection.IntrospectionDataFetcher as GraphQLIntrospectionDataFetcher
 
 internal class IntrospectionService constructor(
     schema: GraphQLSchema,
@@ -25,22 +49,233 @@ fun interface NadelIntrospectionRunnerFactory {
     fun make(schema: GraphQLSchema): ServiceExecution
 }
 
-open class NadelDefaultIntrospectionRunner(schema: GraphQLSchema) : ServiceExecution {
-    private val graphQL = GraphQL.newGraphQL(schema).build()
+typealias IntrospectionDataFetcher = GraphQLIntrospectionDataFetcher<*>
+
+open class NadelDefaultIntrospectionRunner(
+    private val schema: GraphQLSchema,
+) : ServiceExecution {
+    private val dataFetchers: Map<FieldCoordinates, IntrospectionDataFetcher> = run {
+        Introspection::class.java.getDeclaredField("introspectionDataFetchers")
+            .also {
+                it.isAccessible = true
+            }
+            .get(null)
+            .let { original ->
+                original as Map<FieldCoordinates, IntrospectionDataFetcher>
+                original.toMutableMap()
+                    .also { copy ->
+                        // todo: add other system coordinate ones
+                        copy[makeFieldCoordinates(schema.queryType.name, "__schema")] =
+                            Introspection.SchemaMetaFieldDefDataFetcher
+                        copy[makeFieldCoordinates(schema.queryType.name, "__type")] =
+                            Introspection.TypeMetaFieldDefDataFetcher
+                        copy[makeFieldCoordinates(schema.queryType.name, "__typename")] =
+                            GraphQLIntrospectionDataFetcher<Any> {
+                                schema.queryType.name
+                            }
+                    }
+            }
+    }
 
     override fun execute(serviceExecutionParameters: ServiceExecutionParameters): CompletableFuture<ServiceExecutionResult> {
-        return graphQL
-            .executeAsync(
-                ExecutionInput.newExecutionInput()
-                    .query(AstPrinter.printAstCompact(serviceExecutionParameters.query))
-                    .variables(serviceExecutionParameters.variables)
-                    .build()
+        return CompletableFuture.completedFuture(
+            gottaGoFast(serviceExecutionParameters.executableNormalizedField)
+        )
+    }
+
+    private fun gottaGoFast(
+        field: ExecutableNormalizedField,
+    ): ServiceExecutionResult {
+        val data: MutableJsonMap = LinkedHashMap()
+        data[field.name] = getValue(field, schema)
+        return newServiceExecutionResult(data = data)
+    }
+
+    private fun getValue(
+        field: ExecutableNormalizedField,
+        parentValue: Any?,
+    ): Any? {
+        val dataFetcher = getDataFetcher(field)
+
+        val value = dataFetcher.get(
+            StubDataFetchingEnvironment(
+                schema,
+                field,
+                parentValue
             )
-            .thenApply {
-                ServiceExecutionResult(
-                    data = it.getData() ?: mutableMapOf(),
-                    errors = it.errors.mapTo(ArrayList(), ::toSpecification),
-                )
+        )
+
+        return evaluateValue(field, value)
+    }
+
+    private fun getDataFetcher(
+        field: ExecutableNormalizedField,
+    ): DataFetcher<Any?> {
+        val coords = makeFieldCoordinates(
+            typeName = field.objectTypeNames.single(),
+            fieldName = field.name,
+        )
+
+        return (dataFetchers[coords] as DataFetcher<Any?>?)
+            ?: PropertyDataFetcher(field.name)
+    }
+
+    private fun evaluateValue(
+        field: ExecutableNormalizedField,
+        value: Any?,
+    ): Any? {
+        return when {
+            value == null -> null
+
+            // Array
+            value is AnyIterable -> {
+                value
+                    .map {
+                        evaluateValue(field, value = it)
+                    }
             }
+
+            // Object
+            field.children.isNotEmpty() -> {
+                getObjectValue(field.children, value)
+            }
+
+            else -> {
+                value
+            }
+        }
+    }
+
+    private fun getObjectValue(
+        children: List<ExecutableNormalizedField>,
+        value: Any?,
+    ): Any {
+        val data: MutableJsonMap = LinkedHashMap()
+        children.forEach { child ->
+            data[child.name] = getValue(field = child, parentValue = value)
+        }
+        return data
+    }
+}
+
+class StubDataFetchingEnvironment(
+    private val schema: GraphQLSchema,
+    private val field: ExecutableNormalizedField,
+    private val source: Any?,
+) : DataFetchingEnvironment {
+    override fun <T : Any?> getSource(): T {
+        return source as T
+    }
+
+    override fun getArguments(): MutableMap<String, Any> {
+        return field.resolvedArguments
+    }
+
+    override fun getGraphQLSchema(): GraphQLSchema {
+        return schema
+    }
+
+    override fun <T : Any?> getArgument(name: String): T? {
+        return field.resolvedArguments[name] as T?
+    }
+
+    override fun getParentType(): GraphQLType {
+        throw UnsupportedOperationException()
+    }
+
+    override fun containsArgument(name: String): Boolean {
+        return field.resolvedArguments.contains(name)
+    }
+
+    override fun <T : Any?> getArgumentOrDefault(name: String, defaultValue: T): T? {
+        return if (containsArgument(name)) {
+            getArgument<T>(name)
+        } else {
+            defaultValue
+        }
+    }
+
+    override fun <T : Any?> getContext(): T {
+        throw UnsupportedOperationException()
+    }
+
+    override fun getGraphQlContext(): GraphQLContext {
+        throw UnsupportedOperationException()
+    }
+
+    override fun <T : Any?> getLocalContext(): T {
+        throw UnsupportedOperationException()
+    }
+
+    override fun <T : Any?> getRoot(): T {
+        throw UnsupportedOperationException()
+    }
+
+    override fun getFieldDefinition(): GraphQLFieldDefinition {
+        throw UnsupportedOperationException()
+    }
+
+    override fun getFields(): MutableList<Field> {
+        throw UnsupportedOperationException()
+    }
+
+    override fun getMergedField(): MergedField {
+        throw UnsupportedOperationException()
+    }
+
+    override fun getField(): Field {
+        throw UnsupportedOperationException()
+    }
+
+    override fun getFieldType(): GraphQLOutputType {
+        return field.getFieldDefinitions(schema).single().type
+    }
+
+    override fun getExecutionStepInfo(): ExecutionStepInfo {
+        throw UnsupportedOperationException()
+    }
+
+    override fun getFragmentsByName(): MutableMap<String, FragmentDefinition> {
+        throw UnsupportedOperationException()
+    }
+
+    override fun getExecutionId(): ExecutionId {
+        throw UnsupportedOperationException()
+    }
+
+    override fun getSelectionSet(): DataFetchingFieldSelectionSet {
+        throw UnsupportedOperationException()
+    }
+
+    override fun getQueryDirectives(): QueryDirectives {
+        throw UnsupportedOperationException()
+    }
+
+    override fun <K : Any?, V : Any?> getDataLoader(dataLoaderName: String): DataLoader<K, V> {
+        throw UnsupportedOperationException()
+    }
+
+    override fun getDataLoaderRegistry(): DataLoaderRegistry {
+        throw UnsupportedOperationException()
+    }
+
+    override fun getCacheControl(): CacheControl {
+        throw UnsupportedOperationException()
+    }
+
+    override fun getLocale(): Locale {
+        throw UnsupportedOperationException()
+    }
+
+    override fun getOperationDefinition(): OperationDefinition {
+        throw UnsupportedOperationException()
+    }
+
+    override fun getDocument(): Document {
+        throw UnsupportedOperationException()
+    }
+
+    override fun getVariables(): MutableMap<String, Any> {
+        throw UnsupportedOperationException()
     }
 }

--- a/test/src/test/resources/fixtures/introspection/full-introspection-query.yml
+++ b/test/src/test/resources/fixtures/introspection/full-introspection-query.yml
@@ -1,0 +1,2340 @@
+name: "full introspection query"
+enabled: true
+overallSchema:
+  # language=GraphQL
+  PetService: |
+    type Query {
+      pets(isLoyal: Boolean): [Pet]
+      raining(isLoyal: Boolean): CatsAndDogs
+    }
+    interface Pet {
+      name: String
+      collar: Collar
+      collarToRenamed: Collar @renamed(from: "collar")
+    }
+    type Cat implements Pet {
+      name: String
+      wearsBell: Boolean
+      collar: Collar
+      collarToRenamed: Collar @renamed(from: "collar")
+    }
+    type Dog implements Pet {
+      name: String
+      wearsCollar: Boolean
+      collar: Collar
+      collarToRenamed: Collar @renamed(from: "collar")
+    }
+    union CatsAndDogs = Cat | Dog
+    interface Collar {
+      color: String
+      size: String
+    }
+    type DogCollar implements Collar {
+      color: String
+      size: String
+    }
+    type CatCollar implements Collar {
+      color: String
+      size: String
+    }
+  # language=GraphQL
+  OwnerService: |
+    type Query {
+      owner(id: String): Owner
+    }
+    interface Owner {
+      name: String
+    }
+    type CaringOwner implements Owner {
+      name: String
+      givesPats: Boolean
+    }
+    type CruelOwner implements Owner {
+      name: String
+      givesSmacks: Boolean
+    }
+underlyingSchema:
+  # language=GraphQL
+  PetService: |
+    interface Collar {
+      color: String
+      size: String
+    }
+
+    interface Pet {
+      collar: Collar
+      name: String
+      ownerIds: [String]
+    }
+
+    union CatsAndDogs = Cat | Dog
+
+    type Cat implements Pet {
+      collar: Collar
+      name: String
+      ownerIds: [String]
+      wearsBell: Boolean
+    }
+
+    type CatCollar implements Collar {
+      color: String
+      size: String
+    }
+
+    type Dog implements Pet {
+      collar: Collar
+      name: String
+      ownerIds: [String]
+      wearsCollar: Boolean
+    }
+
+    type DogCollar implements Collar {
+      color: String
+      size: String
+    }
+
+    type Mutation {
+      hello: String
+    }
+
+    type Query {
+      hello: World
+      pets(isLoyal: Boolean): [Pet]
+      raining(isLoyal: Boolean): CatsAndDogs
+    }
+
+    type World {
+      id: ID
+      name: String
+    }
+  # language=GraphQL
+  OwnerService: |
+    interface Owner {
+      name: String
+    }
+
+    type CaringOwner implements Owner {
+      givesPats: Boolean
+      name: String
+    }
+
+    type CruelOwner implements Owner {
+      givesSmacks: Boolean
+      name: String
+    }
+
+    type Query {
+      owner(id: String): Owner
+    }
+# language=GraphQL
+query: |
+  query IntrospectionQuery {
+    __schema {
+      queryType { name }
+      mutationType { name }
+      subscriptionType { name }
+      types {
+        ...FullType
+      }
+      directives {
+        name
+        description
+
+        locations
+        args {
+          ...InputValue
+        }
+      }
+    }
+  }
+
+  fragment FullType on __Type {
+    kind
+    name
+    description
+
+    fields(includeDeprecated: true) {
+      name
+      description
+      args {
+        ...InputValue
+      }
+      type {
+        ...TypeRef
+      }
+      isDeprecated
+      deprecationReason
+    }
+    inputFields {
+      ...InputValue
+    }
+    interfaces {
+      ...TypeRef
+    }
+    enumValues(includeDeprecated: true) {
+      name
+      description
+      isDeprecated
+      deprecationReason
+    }
+    possibleTypes {
+      ...TypeRef
+    }
+  }
+
+  fragment InputValue on __InputValue {
+    name
+    description
+    type { ...TypeRef }
+    defaultValue
+  }
+
+  fragment TypeRef on __Type {
+    kind
+    name
+    ofType {
+      kind
+      name
+      ofType {
+        kind
+        name
+        ofType {
+          kind
+          name
+          ofType {
+            kind
+            name
+            ofType {
+              kind
+              name
+              ofType {
+                kind
+                name
+                ofType {
+                  kind
+                  name
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+variables: { }
+serviceCalls: [ ]
+# language=JSON
+response: |-
+  {
+    "data": {
+      "__schema": {
+        "queryType": {
+          "name": "Query"
+        },
+        "mutationType": null,
+        "subscriptionType": null,
+        "types": [
+          {
+            "kind": "SCALAR",
+            "name": "Boolean",
+            "description": "Built-in Boolean",
+            "fields": null,
+            "inputFields": null,
+            "interfaces": null,
+            "enumValues": null,
+            "possibleTypes": null
+          },
+          {
+            "kind": "OBJECT",
+            "name": "CaringOwner",
+            "description": null,
+            "fields": [
+              {
+                "name": "name",
+                "description": null,
+                "args": [],
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "givesPats",
+                "description": null,
+                "args": [],
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                },
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "inputFields": null,
+            "interfaces": [
+              {
+                "kind": "INTERFACE",
+                "name": "Owner",
+                "ofType": null
+              }
+            ],
+            "enumValues": null,
+            "possibleTypes": null
+          },
+          {
+            "kind": "OBJECT",
+            "name": "Cat",
+            "description": null,
+            "fields": [
+              {
+                "name": "name",
+                "description": null,
+                "args": [],
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "wearsBell",
+                "description": null,
+                "args": [],
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                },
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "collar",
+                "description": null,
+                "args": [],
+                "type": {
+                  "kind": "INTERFACE",
+                  "name": "Collar",
+                  "ofType": null
+                },
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "collarToRenamed",
+                "description": null,
+                "args": [],
+                "type": {
+                  "kind": "INTERFACE",
+                  "name": "Collar",
+                  "ofType": null
+                },
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "inputFields": null,
+            "interfaces": [
+              {
+                "kind": "INTERFACE",
+                "name": "Pet",
+                "ofType": null
+              }
+            ],
+            "enumValues": null,
+            "possibleTypes": null
+          },
+          {
+            "kind": "OBJECT",
+            "name": "CatCollar",
+            "description": null,
+            "fields": [
+              {
+                "name": "color",
+                "description": null,
+                "args": [],
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "size",
+                "description": null,
+                "args": [],
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "inputFields": null,
+            "interfaces": [
+              {
+                "kind": "INTERFACE",
+                "name": "Collar",
+                "ofType": null
+              }
+            ],
+            "enumValues": null,
+            "possibleTypes": null
+          },
+          {
+            "kind": "UNION",
+            "name": "CatsAndDogs",
+            "description": null,
+            "fields": null,
+            "inputFields": null,
+            "interfaces": null,
+            "enumValues": null,
+            "possibleTypes": [
+              {
+                "kind": "OBJECT",
+                "name": "Cat",
+                "ofType": null
+              },
+              {
+                "kind": "OBJECT",
+                "name": "Dog",
+                "ofType": null
+              }
+            ]
+          },
+          {
+            "kind": "INTERFACE",
+            "name": "Collar",
+            "description": null,
+            "fields": [
+              {
+                "name": "color",
+                "description": null,
+                "args": [],
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "size",
+                "description": null,
+                "args": [],
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "inputFields": null,
+            "interfaces": [],
+            "enumValues": null,
+            "possibleTypes": [
+              {
+                "kind": "OBJECT",
+                "name": "CatCollar",
+                "ofType": null
+              },
+              {
+                "kind": "OBJECT",
+                "name": "DogCollar",
+                "ofType": null
+              }
+            ]
+          },
+          {
+            "kind": "OBJECT",
+            "name": "CruelOwner",
+            "description": null,
+            "fields": [
+              {
+                "name": "name",
+                "description": null,
+                "args": [],
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "givesSmacks",
+                "description": null,
+                "args": [],
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                },
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "inputFields": null,
+            "interfaces": [
+              {
+                "kind": "INTERFACE",
+                "name": "Owner",
+                "ofType": null
+              }
+            ],
+            "enumValues": null,
+            "possibleTypes": null
+          },
+          {
+            "kind": "OBJECT",
+            "name": "Dog",
+            "description": null,
+            "fields": [
+              {
+                "name": "name",
+                "description": null,
+                "args": [],
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "wearsCollar",
+                "description": null,
+                "args": [],
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                },
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "collar",
+                "description": null,
+                "args": [],
+                "type": {
+                  "kind": "INTERFACE",
+                  "name": "Collar",
+                  "ofType": null
+                },
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "collarToRenamed",
+                "description": null,
+                "args": [],
+                "type": {
+                  "kind": "INTERFACE",
+                  "name": "Collar",
+                  "ofType": null
+                },
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "inputFields": null,
+            "interfaces": [
+              {
+                "kind": "INTERFACE",
+                "name": "Pet",
+                "ofType": null
+              }
+            ],
+            "enumValues": null,
+            "possibleTypes": null
+          },
+          {
+            "kind": "OBJECT",
+            "name": "DogCollar",
+            "description": null,
+            "fields": [
+              {
+                "name": "color",
+                "description": null,
+                "args": [],
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "size",
+                "description": null,
+                "args": [],
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "inputFields": null,
+            "interfaces": [
+              {
+                "kind": "INTERFACE",
+                "name": "Collar",
+                "ofType": null
+              }
+            ],
+            "enumValues": null,
+            "possibleTypes": null
+          },
+          {
+            "kind": "SCALAR",
+            "name": "Float",
+            "description": "Built-in Float",
+            "fields": null,
+            "inputFields": null,
+            "interfaces": null,
+            "enumValues": null,
+            "possibleTypes": null
+          },
+          {
+            "kind": "SCALAR",
+            "name": "ID",
+            "description": "Built-in ID",
+            "fields": null,
+            "inputFields": null,
+            "interfaces": null,
+            "enumValues": null,
+            "possibleTypes": null
+          },
+          {
+            "kind": "SCALAR",
+            "name": "Int",
+            "description": "Built-in Int",
+            "fields": null,
+            "inputFields": null,
+            "interfaces": null,
+            "enumValues": null,
+            "possibleTypes": null
+          },
+          {
+            "kind": "INPUT_OBJECT",
+            "name": "NadelBatchObjectIdentifiedBy",
+            "description": "This is required by batch hydration to understand how to pull out objects from the batched result",
+            "fields": null,
+            "inputFields": [
+              {
+                "name": "sourceId",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "resultId",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              }
+            ],
+            "interfaces": null,
+            "enumValues": null,
+            "possibleTypes": null
+          },
+          {
+            "kind": "INPUT_OBJECT",
+            "name": "NadelHydrationArgument",
+            "description": "This allows you to hydrate new values into fields",
+            "fields": null,
+            "inputFields": [
+              {
+                "name": "name",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "value",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              }
+            ],
+            "interfaces": null,
+            "enumValues": null,
+            "possibleTypes": null
+          },
+          {
+            "kind": "INPUT_OBJECT",
+            "name": "NadelHydrationFromArgument",
+            "description": "This allows you to hydrate new values into fields with the @hydratedFrom directive",
+            "fields": null,
+            "inputFields": [
+              {
+                "name": "name",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "valueFromField",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "valueFromArg",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null
+              }
+            ],
+            "interfaces": null,
+            "enumValues": null,
+            "possibleTypes": null
+          },
+          {
+            "kind": "ENUM",
+            "name": "NadelHydrationTemplate",
+            "description": null,
+            "fields": null,
+            "inputFields": null,
+            "interfaces": null,
+            "enumValues": [
+              {
+                "name": "NADEL_PLACEHOLDER",
+                "description": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "possibleTypes": null
+          },
+          {
+            "kind": "INTERFACE",
+            "name": "Owner",
+            "description": null,
+            "fields": [
+              {
+                "name": "name",
+                "description": null,
+                "args": [],
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "inputFields": null,
+            "interfaces": [],
+            "enumValues": null,
+            "possibleTypes": [
+              {
+                "kind": "OBJECT",
+                "name": "CaringOwner",
+                "ofType": null
+              },
+              {
+                "kind": "OBJECT",
+                "name": "CruelOwner",
+                "ofType": null
+              }
+            ]
+          },
+          {
+            "kind": "INTERFACE",
+            "name": "Pet",
+            "description": null,
+            "fields": [
+              {
+                "name": "name",
+                "description": null,
+                "args": [],
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "collar",
+                "description": null,
+                "args": [],
+                "type": {
+                  "kind": "INTERFACE",
+                  "name": "Collar",
+                  "ofType": null
+                },
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "collarToRenamed",
+                "description": null,
+                "args": [],
+                "type": {
+                  "kind": "INTERFACE",
+                  "name": "Collar",
+                  "ofType": null
+                },
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "inputFields": null,
+            "interfaces": [],
+            "enumValues": null,
+            "possibleTypes": [
+              {
+                "kind": "OBJECT",
+                "name": "Cat",
+                "ofType": null
+              },
+              {
+                "kind": "OBJECT",
+                "name": "Dog",
+                "ofType": null
+              }
+            ]
+          },
+          {
+            "kind": "OBJECT",
+            "name": "Query",
+            "description": null,
+            "fields": [
+              {
+                "name": "pets",
+                "description": null,
+                "args": [
+                  {
+                    "name": "isLoyal",
+                    "description": null,
+                    "type": {
+                      "kind": "SCALAR",
+                      "name": "Boolean",
+                      "ofType": null
+                    },
+                    "defaultValue": null
+                  }
+                ],
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INTERFACE",
+                    "name": "Pet",
+                    "ofType": null
+                  }
+                },
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "raining",
+                "description": null,
+                "args": [
+                  {
+                    "name": "isLoyal",
+                    "description": null,
+                    "type": {
+                      "kind": "SCALAR",
+                      "name": "Boolean",
+                      "ofType": null
+                    },
+                    "defaultValue": null
+                  }
+                ],
+                "type": {
+                  "kind": "UNION",
+                  "name": "CatsAndDogs",
+                  "ofType": null
+                },
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "owner",
+                "description": null,
+                "args": [
+                  {
+                    "name": "id",
+                    "description": null,
+                    "type": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    },
+                    "defaultValue": null
+                  }
+                ],
+                "type": {
+                  "kind": "INTERFACE",
+                  "name": "Owner",
+                  "ofType": null
+                },
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "inputFields": null,
+            "interfaces": [],
+            "enumValues": null,
+            "possibleTypes": null
+          },
+          {
+            "kind": "SCALAR",
+            "name": "String",
+            "description": "Built-in String",
+            "fields": null,
+            "inputFields": null,
+            "interfaces": null,
+            "enumValues": null,
+            "possibleTypes": null
+          },
+          {
+            "kind": "OBJECT",
+            "name": "__Directive",
+            "description": null,
+            "fields": [
+              {
+                "name": "name",
+                "description": "The __Directive type represents a Directive that a server supports.",
+                "args": [],
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "description",
+                "description": null,
+                "args": [],
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "isRepeatable",
+                "description": null,
+                "args": [],
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  }
+                },
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "locations",
+                "description": null,
+                "args": [],
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "ENUM",
+                        "name": "__DirectiveLocation",
+                        "ofType": null
+                      }
+                    }
+                  }
+                },
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "args",
+                "description": null,
+                "args": [
+                  {
+                    "name": "includeDeprecated",
+                    "description": null,
+                    "type": {
+                      "kind": "SCALAR",
+                      "name": "Boolean",
+                      "ofType": null
+                    },
+                    "defaultValue": "false"
+                  }
+                ],
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "OBJECT",
+                        "name": "__InputValue",
+                        "ofType": null
+                      }
+                    }
+                  }
+                },
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "onOperation",
+                "description": null,
+                "args": [],
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                },
+                "isDeprecated": true,
+                "deprecationReason": "Use `locations`."
+              },
+              {
+                "name": "onFragment",
+                "description": null,
+                "args": [],
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                },
+                "isDeprecated": true,
+                "deprecationReason": "Use `locations`."
+              },
+              {
+                "name": "onField",
+                "description": null,
+                "args": [],
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                },
+                "isDeprecated": true,
+                "deprecationReason": "Use `locations`."
+              }
+            ],
+            "inputFields": null,
+            "interfaces": [],
+            "enumValues": null,
+            "possibleTypes": null
+          },
+          {
+            "kind": "ENUM",
+            "name": "__DirectiveLocation",
+            "description": "An enum describing valid locations where a directive can be placed",
+            "fields": null,
+            "inputFields": null,
+            "interfaces": null,
+            "enumValues": [
+              {
+                "name": "QUERY",
+                "description": "Indicates the directive is valid on queries.",
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "MUTATION",
+                "description": "Indicates the directive is valid on mutations.",
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "SUBSCRIPTION",
+                "description": "Indicates the directive is valid on subscriptions.",
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "FIELD",
+                "description": "Indicates the directive is valid on fields.",
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "FRAGMENT_DEFINITION",
+                "description": "Indicates the directive is valid on fragment definitions.",
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "FRAGMENT_SPREAD",
+                "description": "Indicates the directive is valid on fragment spreads.",
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "INLINE_FRAGMENT",
+                "description": "Indicates the directive is valid on inline fragments.",
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "VARIABLE_DEFINITION",
+                "description": "Indicates the directive is valid on variable definitions.",
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "SCHEMA",
+                "description": "Indicates the directive is valid on a schema SDL definition.",
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "SCALAR",
+                "description": "Indicates the directive is valid on a scalar SDL definition.",
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "OBJECT",
+                "description": "Indicates the directive is valid on an object SDL definition.",
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "FIELD_DEFINITION",
+                "description": "Indicates the directive is valid on a field SDL definition.",
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "ARGUMENT_DEFINITION",
+                "description": "Indicates the directive is valid on a field argument SDL definition.",
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "INTERFACE",
+                "description": "Indicates the directive is valid on an interface SDL definition.",
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "UNION",
+                "description": "Indicates the directive is valid on an union SDL definition.",
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "ENUM",
+                "description": "Indicates the directive is valid on an enum SDL definition.",
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "ENUM_VALUE",
+                "description": "Indicates the directive is valid on an enum value SDL definition.",
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "INPUT_OBJECT",
+                "description": "Indicates the directive is valid on an input object SDL definition.",
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "INPUT_FIELD_DEFINITION",
+                "description": "Indicates the directive is valid on an input object field SDL definition.",
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "possibleTypes": null
+          },
+          {
+            "kind": "OBJECT",
+            "name": "__EnumValue",
+            "description": null,
+            "fields": [
+              {
+                "name": "name",
+                "description": null,
+                "args": [],
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "description",
+                "description": null,
+                "args": [],
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "isDeprecated",
+                "description": null,
+                "args": [],
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  }
+                },
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "deprecationReason",
+                "description": null,
+                "args": [],
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "inputFields": null,
+            "interfaces": [],
+            "enumValues": null,
+            "possibleTypes": null
+          },
+          {
+            "kind": "OBJECT",
+            "name": "__Field",
+            "description": null,
+            "fields": [
+              {
+                "name": "name",
+                "description": null,
+                "args": [],
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "description",
+                "description": null,
+                "args": [],
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "args",
+                "description": null,
+                "args": [
+                  {
+                    "name": "includeDeprecated",
+                    "description": null,
+                    "type": {
+                      "kind": "SCALAR",
+                      "name": "Boolean",
+                      "ofType": null
+                    },
+                    "defaultValue": "false"
+                  }
+                ],
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "OBJECT",
+                        "name": "__InputValue",
+                        "ofType": null
+                      }
+                    }
+                  }
+                },
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "type",
+                "description": null,
+                "args": [],
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "__Type",
+                    "ofType": null
+                  }
+                },
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "isDeprecated",
+                "description": null,
+                "args": [],
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  }
+                },
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "deprecationReason",
+                "description": null,
+                "args": [],
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "inputFields": null,
+            "interfaces": [],
+            "enumValues": null,
+            "possibleTypes": null
+          },
+          {
+            "kind": "OBJECT",
+            "name": "__InputValue",
+            "description": null,
+            "fields": [
+              {
+                "name": "name",
+                "description": null,
+                "args": [],
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "description",
+                "description": null,
+                "args": [],
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "type",
+                "description": null,
+                "args": [],
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "__Type",
+                    "ofType": null
+                  }
+                },
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "defaultValue",
+                "description": null,
+                "args": [],
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "isDeprecated",
+                "description": null,
+                "args": [],
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                },
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "deprecationReason",
+                "description": null,
+                "args": [],
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "inputFields": null,
+            "interfaces": [],
+            "enumValues": null,
+            "possibleTypes": null
+          },
+          {
+            "kind": "OBJECT",
+            "name": "__Schema",
+            "description": "A GraphQL Introspection defines the capabilities of a GraphQL server. It exposes all available types and directives on the server, the entry points for query, mutation, and subscription operations.",
+            "fields": [
+              {
+                "name": "description",
+                "description": null,
+                "args": [],
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "types",
+                "description": "A list of all types supported by this server.",
+                "args": [],
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "OBJECT",
+                        "name": "__Type",
+                        "ofType": null
+                      }
+                    }
+                  }
+                },
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "queryType",
+                "description": "The type that query operations will be rooted at.",
+                "args": [],
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "__Type",
+                    "ofType": null
+                  }
+                },
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "mutationType",
+                "description": "If this server supports mutation, the type that mutation operations will be rooted at.",
+                "args": [],
+                "type": {
+                  "kind": "OBJECT",
+                  "name": "__Type",
+                  "ofType": null
+                },
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "directives",
+                "description": "'A list of all directives supported by this server.",
+                "args": [],
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "OBJECT",
+                        "name": "__Directive",
+                        "ofType": null
+                      }
+                    }
+                  }
+                },
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "subscriptionType",
+                "description": "'If this server support subscription, the type that subscription operations will be rooted at.",
+                "args": [],
+                "type": {
+                  "kind": "OBJECT",
+                  "name": "__Type",
+                  "ofType": null
+                },
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "inputFields": null,
+            "interfaces": [],
+            "enumValues": null,
+            "possibleTypes": null
+          },
+          {
+            "kind": "OBJECT",
+            "name": "__Type",
+            "description": null,
+            "fields": [
+              {
+                "name": "kind",
+                "description": null,
+                "args": [],
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "ENUM",
+                    "name": "__TypeKind",
+                    "ofType": null
+                  }
+                },
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "name",
+                "description": null,
+                "args": [],
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "description",
+                "description": null,
+                "args": [],
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "fields",
+                "description": null,
+                "args": [
+                  {
+                    "name": "includeDeprecated",
+                    "description": null,
+                    "type": {
+                      "kind": "SCALAR",
+                      "name": "Boolean",
+                      "ofType": null
+                    },
+                    "defaultValue": "false"
+                  }
+                ],
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "__Field",
+                      "ofType": null
+                    }
+                  }
+                },
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "interfaces",
+                "description": null,
+                "args": [],
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "__Type",
+                      "ofType": null
+                    }
+                  }
+                },
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "possibleTypes",
+                "description": null,
+                "args": [],
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "__Type",
+                      "ofType": null
+                    }
+                  }
+                },
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "enumValues",
+                "description": null,
+                "args": [
+                  {
+                    "name": "includeDeprecated",
+                    "description": null,
+                    "type": {
+                      "kind": "SCALAR",
+                      "name": "Boolean",
+                      "ofType": null
+                    },
+                    "defaultValue": "false"
+                  }
+                ],
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "__EnumValue",
+                      "ofType": null
+                    }
+                  }
+                },
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "inputFields",
+                "description": null,
+                "args": [
+                  {
+                    "name": "includeDeprecated",
+                    "description": null,
+                    "type": {
+                      "kind": "SCALAR",
+                      "name": "Boolean",
+                      "ofType": null
+                    },
+                    "defaultValue": "false"
+                  }
+                ],
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "__InputValue",
+                      "ofType": null
+                    }
+                  }
+                },
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "ofType",
+                "description": null,
+                "args": [],
+                "type": {
+                  "kind": "OBJECT",
+                  "name": "__Type",
+                  "ofType": null
+                },
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "specifiedByUrl",
+                "description": null,
+                "args": [],
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "inputFields": null,
+            "interfaces": [],
+            "enumValues": null,
+            "possibleTypes": null
+          },
+          {
+            "kind": "ENUM",
+            "name": "__TypeKind",
+            "description": "An enum describing what kind of type a given __Type is",
+            "fields": null,
+            "inputFields": null,
+            "interfaces": null,
+            "enumValues": [
+              {
+                "name": "SCALAR",
+                "description": "Indicates this type is a scalar. 'specifiedByUrl' is a valid field",
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "OBJECT",
+                "description": "Indicates this type is an object. `fields` and `interfaces` are valid fields.",
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "INTERFACE",
+                "description": "Indicates this type is an interface. `fields` and `possibleTypes` are valid fields.",
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "UNION",
+                "description": "Indicates this type is a union. `possibleTypes` is a valid field.",
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "ENUM",
+                "description": "Indicates this type is an enum. `enumValues` is a valid field.",
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "INPUT_OBJECT",
+                "description": "Indicates this type is an input object. `inputFields` is a valid field.",
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "LIST",
+                "description": "Indicates this type is a list. `ofType` is a valid field.",
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "NON_NULL",
+                "description": "Indicates this type is a non-null. `ofType` is a valid field.",
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "possibleTypes": null
+          }
+        ],
+        "directives": [
+          {
+            "name": "include",
+            "description": "Directs the executor to include this field or fragment only when the `if` argument is true",
+            "locations": [
+              "FIELD",
+              "FRAGMENT_SPREAD",
+              "INLINE_FRAGMENT"
+            ],
+            "args": [
+              {
+                "name": "if",
+                "description": "Included when true.",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              }
+            ]
+          },
+          {
+            "name": "skip",
+            "description": "Directs the executor to skip this field or fragment when the `if` argument is true.",
+            "locations": [
+              "FIELD",
+              "FRAGMENT_SPREAD",
+              "INLINE_FRAGMENT"
+            ],
+            "args": [
+              {
+                "name": "if",
+                "description": "Skipped when true.",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              }
+            ]
+          },
+          {
+            "name": "hydrated",
+            "description": "This allows you to hydrate new values into fields",
+            "locations": [
+              "FIELD_DEFINITION"
+            ],
+            "args": [
+              {
+                "name": "service",
+                "description": "The target service",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "field",
+                "description": "The target top level field",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "identifiedBy",
+                "description": "How to identify matching results",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": "\"id\""
+              },
+              {
+                "name": "inputIdentifiedBy",
+                "description": "How to identify matching results",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "INPUT_OBJECT",
+                        "name": "NadelBatchObjectIdentifiedBy",
+                        "ofType": null
+                      }
+                    }
+                  }
+                },
+                "defaultValue": "[]"
+              },
+              {
+                "name": "indexed",
+                "description": "Are results indexed",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": "false"
+              },
+              {
+                "name": "batched",
+                "description": "Is querying batched",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": "false"
+              },
+              {
+                "name": "batchSize",
+                "description": "The batch size",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": "200"
+              },
+              {
+                "name": "timeout",
+                "description": "The timeout to use when completing hydration",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": "-1"
+              },
+              {
+                "name": "arguments",
+                "description": "The arguments to the hydrated field",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "INPUT_OBJECT",
+                        "name": "NadelHydrationArgument",
+                        "ofType": null
+                      }
+                    }
+                  }
+                },
+                "defaultValue": null
+              }
+            ]
+          },
+          {
+            "name": "renamed",
+            "description": "This allows you to rename a type or field in the overall schema",
+            "locations": [
+              "SCALAR",
+              "OBJECT",
+              "FIELD_DEFINITION",
+              "INTERFACE",
+              "UNION",
+              "ENUM",
+              "INPUT_OBJECT"
+            ],
+            "args": [
+              {
+                "name": "from",
+                "description": "The type to be renamed",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              }
+            ]
+          },
+          {
+            "name": "hidden",
+            "description": "Indicates that the field is not available for queries or introspection",
+            "locations": [
+              "FIELD_DEFINITION"
+            ],
+            "args": []
+          },
+          {
+            "name": "hydratedFrom",
+            "description": "This allows you to hydrate new values into fields",
+            "locations": [
+              "FIELD_DEFINITION"
+            ],
+            "args": [
+              {
+                "name": "arguments",
+                "description": "The arguments to the hydrated field",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "INPUT_OBJECT",
+                        "name": "NadelHydrationFromArgument",
+                        "ofType": null
+                      }
+                    }
+                  }
+                },
+                "defaultValue": "[]"
+              },
+              {
+                "name": "template",
+                "description": "The hydration template to use",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "ENUM",
+                    "name": "NadelHydrationTemplate",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              }
+            ]
+          },
+          {
+            "name": "hydratedTemplate",
+            "description": "This template directive provides common values to hydrated fields",
+            "locations": [
+              "ENUM_VALUE"
+            ],
+            "args": [
+              {
+                "name": "service",
+                "description": "The target service",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "field",
+                "description": "The target top level field",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "identifiedBy",
+                "description": "How to identify matching results",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": "\"id\""
+              },
+              {
+                "name": "inputIdentifiedBy",
+                "description": "How to identify matching results",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "INPUT_OBJECT",
+                        "name": "NadelBatchObjectIdentifiedBy",
+                        "ofType": null
+                      }
+                    }
+                  }
+                },
+                "defaultValue": "[]"
+              },
+              {
+                "name": "indexed",
+                "description": "Are results indexed",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                },
+                "defaultValue": "false"
+              },
+              {
+                "name": "batched",
+                "description": "Is querying batched",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                },
+                "defaultValue": "false"
+              },
+              {
+                "name": "batchSize",
+                "description": "The batch size",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": "200"
+              },
+              {
+                "name": "timeout",
+                "description": "The timeout in milliseconds",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": "-1"
+              }
+            ]
+          },
+          {
+            "name": "deprecated",
+            "description": "Marks the field, argument, input field or enum value as deprecated",
+            "locations": [
+              "FIELD_DEFINITION",
+              "ARGUMENT_DEFINITION",
+              "ENUM_VALUE",
+              "INPUT_FIELD_DEFINITION"
+            ],
+            "args": [
+              {
+                "name": "reason",
+                "description": "The reason for the deprecation",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": "\"No longer supported\""
+              }
+            ]
+          },
+          {
+            "name": "specifiedBy",
+            "description": "Exposes a URL that specifies the behaviour of this scalar.",
+            "locations": [
+              "SCALAR"
+            ],
+            "args": [
+              {
+                "name": "url",
+                "description": "The URL that specifies the behaviour of this scalar.",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "errors": []
+  }


### PR DESCRIPTION
Experimental change for faster introspection by avoiding some of the GraphQL Java execution overhead.

Old

```
    // Benchmark                                    Mode  Cnt    Score   Error  Units
    // IntrospectionBenchmarkJava.benchMarkAvgTime  avgt   20  134.819 ± 5.109  ms/op
```

New

```
    // Benchmark                                    Mode  Cnt   Score   Error  Units
    // IntrospectionBenchmarkJava.benchMarkAvgTime  avgt   20  30.656 ± 0.949  ms/op
```

If we like this approach I'll clean up the code and add an execution hint/feature flag.