### PR TITLE
add missing validation for batch hydrations

### DIFF
--- a/lib/src/main/java/graphql/nadel/engine/blueprint/NadelExecutionBlueprintFactory.kt
+++ b/lib/src/main/java/graphql/nadel/engine/blueprint/NadelExecutionBlueprintFactory.kt
@@ -8,7 +8,6 @@ import graphql.Scalars.GraphQLString
 import graphql.language.EnumTypeDefinition
 import graphql.language.FieldDefinition
 import graphql.language.ImplementingTypeDefinition
-import graphql.language.Value
 import graphql.nadel.Service
 import graphql.nadel.dsl.FieldMappingDefinition
 import graphql.nadel.dsl.RemoteArgumentSource.SourceType.FieldArgument
@@ -37,7 +36,6 @@ import graphql.nadel.engine.util.unwrapAll
 import graphql.nadel.engine.util.unwrapNonNull
 import graphql.nadel.schema.NadelDirectives
 import graphql.nadel.util.AnyAstValue
-import graphql.normalized.NormalizedInputValue
 import graphql.schema.FieldCoordinates
 import graphql.schema.GraphQLDirectiveContainer
 import graphql.schema.GraphQLFieldDefinition

--- a/lib/src/main/java/graphql/nadel/validation/NadelSchemaValidationError.kt
+++ b/lib/src/main/java/graphql/nadel/validation/NadelSchemaValidationError.kt
@@ -403,6 +403,20 @@ sealed interface NadelSchemaValidationError {
         override val subject = overallField
     }
 
+    data class MultipleSourceArgsInBatchHydration(
+        val parentType: NadelServiceSchemaElement,
+        val overallField: GraphQLFieldDefinition,
+    ) : NadelSchemaValidationError {
+        val service: Service get() = parentType.service
+
+        override val message = run {
+            val fieldCoordinates = makeFieldCoordinates(parentType.overall.name, overallField.name)
+            "Multiple \$source.xxx arguments are not supported for batch hydration. Field: $fieldCoordinates"
+        }
+
+        override val subject = overallField
+    }
+
     data class MissingArgumentOnUnderlying(
         val parentType: NadelServiceSchemaElement,
         val overallField: GraphQLFieldDefinition,
@@ -464,6 +478,7 @@ sealed interface NadelSchemaValidationError {
                     null -> "field ${location.name}"
                     else -> "field ${makeFieldCoordinates(parent.overall.name, location.name)}"
                 }
+
                 is GraphQLType -> "type ${location.name}"
                 else -> "${location.javaClass.simpleName} ${location.name}"
             }

--- a/lib/src/test/kotlin/graphql/nadel/validation/NadelHydrationValidationTest.kt
+++ b/lib/src/test/kotlin/graphql/nadel/validation/NadelHydrationValidationTest.kt
@@ -74,6 +74,119 @@ class NadelHydrationValidationTest : DescribeSpec({
             assert(errors.map { it.message }.isEmpty())
         }
 
+        it("fails when batch hydration with multiple \$source args") {
+            val fixture = NadelValidationTestFixture(
+                overallSchema = mapOf(
+                    "issues" to """
+                        type Query {
+                            issue: JiraIssue
+                        }
+                        type JiraIssue @renamed(from: "Issue") {
+                            id: ID!
+                            creator: User @hydrated(
+                                service: "users"
+                                field: "users"
+                                arguments: [
+                                    {name: "id", value: "$source.creator"}
+                                    {name: "siteId", value: "$source.siteId"}
+                                ]
+                            )
+                        }
+                    """.trimIndent(),
+                    "users" to """
+                        type Query {
+                            users(id: ID!, siteId: ID!): [User]
+                        }
+                        type User {
+                            id: ID!
+                            name: String!
+                        }
+                    """.trimIndent(),
+                ),
+                underlyingSchema = mapOf(
+                    "issues" to """
+                        type Query {
+                            issue: Issue
+                        }
+                        type Issue {
+                            id: ID!
+                            siteId: ID!
+                            creator: ID!
+                        }
+                    """.trimIndent(),
+                    "users" to """
+                        type Query {
+                            users(id: ID!, siteId: ID!): [User]
+                        }
+                        type User {
+                            id: ID!
+                            name: String!
+                        }
+                    """.trimIndent(),
+                ),
+            )
+
+            val errors = validate(fixture)
+            assert(errors.size == 1)
+            assert(errors.single() is NadelSchemaValidationError.MultipleSourceArgsInBatchHydration)
+            assert(errors.single().message == "Multiple \$source.xxx arguments are not supported for batch hydration. Field: JiraIssue.creator")
+        }
+
+        it("passes when batch hydration with a single \$source arg and an \$argument arg") {
+            val fixture = NadelValidationTestFixture(
+                overallSchema = mapOf(
+                    "issues" to """
+                        type Query {
+                            issue: JiraIssue
+                        }
+                        type JiraIssue @renamed(from: "Issue") {
+                            id: ID!
+                            creator(siteId: ID!): User @hydrated(
+                                service: "users"
+                                field: "users"
+                                arguments: [
+                                    {name: "id", value: "$source.creator"}
+                                    {name: "siteId", value: "$argument.siteId"}
+                                ]
+                            )
+                        }
+                    """.trimIndent(),
+                    "users" to """
+                        type Query {
+                            users(id: ID!, siteId: ID!): [User]
+                        }
+                        type User {
+                            id: ID!
+                            name: String!
+                        }
+                    """.trimIndent(),
+                ),
+                underlyingSchema = mapOf(
+                    "issues" to """
+                        type Query {
+                            issue: Issue
+                        }
+                        type Issue {
+                            id: ID!
+                            creator: ID!
+                        }
+                    """.trimIndent(),
+                    "users" to """
+                        type Query {
+                            users(id: ID!, siteId: ID!): [User]
+                        }
+                        type User {
+                            id: ID!
+                            name: String!
+                        }
+                    """.trimIndent(),
+                ),
+            )
+
+            val errors = validate(fixture)
+            assert(errors.isEmpty())
+        }
+
         it("fails if non-existent hydration reference field") {
             val fixture = NadelValidationTestFixture(
                 overallSchema = mapOf(


### PR DESCRIPTION
Please make sure you consider the following:

- [x] Add tests that use __typename in queries
- [x] Does this change work with all nadel transformations (rename, type rename, hydration, etc)? Add tests for this.
- [x] Is it worth using hints for this change in order to be able to enable a percentage rollout?
- [x] Do we need to add integration tests for this change in the graphql gateway?
- [x] Do we need a pollinator check for this?
