### PR TITLE
Remove unused secrets

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -21,8 +21,8 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: '11.0.9'
-        # Populates ARTIFACTORY_USERNAME and ARTIFACTORY_API_KEY with
-        # temporary username/password for publishing to packages.atlassian.com
+      # Populates ARTIFACTORY_USERNAME and ARTIFACTORY_API_KEY with
+      # temporary username/password for publishing to packages.atlassian.com
       - name: Get publish token
         id: publish-token
         uses: atlassian-labs/artifact-publish-token@v1.0.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,8 +11,6 @@ jobs:
   buildAndPublish:
     runs-on: ubuntu-latest
     env:
-      MAVEN_CENTRAL_USER: ${{ secrets.MAVEN_CENTRAL_USER }}
-      MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
       RELEASE_VERSION: ${{ github.event.inputs.version }}
 
     steps:


### PR DESCRIPTION
So I don't think we even use `release.yml` and it doesn't even publish anything, so we shouldn't even need the Maven credentials.