### PR TITLE
GQLGW-666 Added hydration path to hydration details

### DIFF
--- a/lib/src/main/java/graphql/nadel/ServiceExecutionHydrationDetails.kt
+++ b/lib/src/main/java/graphql/nadel/ServiceExecutionHydrationDetails.kt
@@ -11,4 +11,5 @@ data class ServiceExecutionHydrationDetails(
     val hydrationSourceService: Service,
     val hydrationSourceField: FieldCoordinates,
     val hydrationActorField: FieldCoordinates,
+    val hydrationPath: List<String>,
 )

--- a/lib/src/main/java/graphql/nadel/engine/transform/hydration/NadelHydrationTransform.kt
+++ b/lib/src/main/java/graphql/nadel/engine/transform/hydration/NadelHydrationTransform.kt
@@ -210,7 +210,8 @@ internal class NadelHydrationTransform(
                         batchSize = 1,
                         hydrationSourceService = hydrationSourceService,
                         hydrationSourceField = instruction.location,
-                        hydrationActorField = hydrationActorField
+                        hydrationActorField = hydrationActorField,
+                        hydrationPath = fieldToHydrate.listOfResultKeys
                     )
                     engine.executeTopLevelField(
                         service = instruction.actorService,

--- a/lib/src/main/java/graphql/nadel/engine/transform/hydration/batch/NadelBatchHydrator.kt
+++ b/lib/src/main/java/graphql/nadel/engine/transform/hydration/batch/NadelBatchHydrator.kt
@@ -143,7 +143,8 @@ internal class NadelBatchHydrator(
                             batchSize = instruction.batchSize,
                             hydrationSourceService = hydrationSourceService,
                             hydrationSourceField = instruction.location,
-                            hydrationActorField = hydrationActorField
+                            hydrationActorField = hydrationActorField,
+                            hydrationPath = state.hydratedField.listOfResultKeys
                         )
                         engine.executeTopLevelField(
                             service = instruction.actorService,

--- a/test/src/test/kotlin/graphql/nadel/tests/hooks/HydrationDetailsHook.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/hooks/HydrationDetailsHook.kt
@@ -26,13 +26,16 @@ class `basic-hydration` : HydrationDetailsHook() {
         assert(actualHydrationDetails.hydrationActorField.toString() == "Query.barById")
         assert(actualHydrationDetails.hydrationSourceField.toString() == "Foo.bar")
         assert(actualHydrationDetails.hydrationSourceService.name == "service1")
+        assert(actualHydrationDetails.hydrationPath == listOf("foo", "bar"))
     }
 }
+
 @UseHook
 class `batch-hydration-with-renamed-actor-field` : HydrationDetailsHook() {
     override fun assertHydrationDetails(actualHydrationDetails: ServiceExecutionHydrationDetails) {
         assert(actualHydrationDetails.hydrationActorField.toString() == "Query.barsByIdOverall")
         assert(actualHydrationDetails.hydrationSourceField.toString() == "Foo.bar")
         assert(actualHydrationDetails.hydrationSourceService.name == "service1")
+        assert(actualHydrationDetails.hydrationPath == listOf("foo", "bar"))
     }
 }


### PR DESCRIPTION
This adds the path to the source hydration field into the hydration details so we can put that into an error in the AGG should we get a HTTP failure say