### PR TITLE
add fieldPath to ServiceExecutionHydrationDetails

### DIFF
--- a/lib/src/main/java/graphql/nadel/ServiceExecutionHydrationDetails.kt
+++ b/lib/src/main/java/graphql/nadel/ServiceExecutionHydrationDetails.kt
@@ -11,4 +11,5 @@ data class ServiceExecutionHydrationDetails(
     val hydrationSourceService: Service,
     val hydrationSourceField: FieldCoordinates,
     val hydrationActorField: FieldCoordinates,
+    val fieldPath: List<String>,
 )

--- a/lib/src/main/java/graphql/nadel/engine/transform/hydration/NadelHydrationTransform.kt
+++ b/lib/src/main/java/graphql/nadel/engine/transform/hydration/NadelHydrationTransform.kt
@@ -217,7 +217,8 @@ internal class NadelHydrationTransform(
                         batchSize = 1,
                         hydrationSourceService = hydrationSourceService,
                         hydrationSourceField = instruction.location,
-                        hydrationActorField = hydrationActorField
+                        hydrationActorField = hydrationActorField,
+                        fieldPath = fieldToHydrate.listOfResultKeys
                     )
                     engine.executeTopLevelField(
                         service = instruction.actorService,

--- a/lib/src/main/java/graphql/nadel/engine/transform/hydration/batch/NadelBatchHydrator.kt
+++ b/lib/src/main/java/graphql/nadel/engine/transform/hydration/batch/NadelBatchHydrator.kt
@@ -145,7 +145,8 @@ internal class NadelBatchHydrator(
                             batchSize = instruction.batchSize,
                             hydrationSourceService = hydrationSourceService,
                             hydrationSourceField = instruction.location,
-                            hydrationActorField = hydrationActorField
+                            hydrationActorField = hydrationActorField,
+                            fieldPath = state.hydratedField.listOfResultKeys,
                         )
                         engine.executeTopLevelField(
                             service = instruction.actorService,

--- a/test/src/test/kotlin/graphql/nadel/tests/hooks/HydrationDetailsHook.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/hooks/HydrationDetailsHook.kt
@@ -26,6 +26,7 @@ class `basic-hydration` : HydrationDetailsHook() {
         assert(actualHydrationDetails.hydrationActorField.toString() == "Query.barById")
         assert(actualHydrationDetails.hydrationSourceField.toString() == "Foo.bar")
         assert(actualHydrationDetails.hydrationSourceService.name == "service1")
+        assert(actualHydrationDetails.fieldPath.toString() == "[foo, bar]")
     }
 }
 @UseHook
@@ -34,5 +35,6 @@ class `batch-hydration-with-renamed-actor-field` : HydrationDetailsHook() {
         assert(actualHydrationDetails.hydrationActorField.toString() == "Query.barsByIdOverall")
         assert(actualHydrationDetails.hydrationSourceField.toString() == "Foo.bar")
         assert(actualHydrationDetails.hydrationSourceService.name == "service1")
+        assert(actualHydrationDetails.fieldPath.toString() == "[foo, bar]")
     }
 }


### PR DESCRIPTION
Adds a fieldPath to ServiceExecutionHydrationDetails, one usecase is if a gateway wants to include it for any Hydration errors