### PR TITLE
GQLGW-666 POC on how we might replace $argument things

### DIFF
--- a/lib/src/main/java/graphql/nadel/dsl/AstValueReplacer.kt
+++ b/lib/src/main/java/graphql/nadel/dsl/AstValueReplacer.kt
@@ -1,10 +1,8 @@
 package graphql.nadel.dsl
 
-import graphql.language.Argument
 import graphql.language.AstTransformer
 import graphql.language.Node
 import graphql.language.NodeVisitorStub
-import graphql.language.ObjectField
 import graphql.language.StringValue
 import graphql.language.Value
 import graphql.util.TraversalControl
@@ -29,26 +27,13 @@ class AstValueReplacer {
                 return null;
             }
 
-            override fun visitArgument(
-                node: Argument,
+            override fun visitStringValue(
+                node: StringValue,
                 context: TraverserContext<Node<*>>,
             ): TraversalControl {
-                val newAstValue = possiblyReplaceValue(node.value)
+                val newAstValue = possiblyReplaceValue(node)
                 if (newAstValue != null) {
-                    val transformedNode = node.transform { it.value(newAstValue) }
-                    return changeNode(context, transformedNode)
-                }
-                return TraversalControl.CONTINUE
-            }
-
-            override fun visitObjectField(
-                node: ObjectField,
-                context: TraverserContext<Node<*>>,
-            ): TraversalControl {
-                val newAstValue = possiblyReplaceValue(node.value)
-                if (newAstValue != null) {
-                    val transformedNode = node.transform { it.value(newAstValue) }
-                    return changeNode(context, transformedNode)
+                    return changeNode(context, newAstValue)
                 }
                 return TraversalControl.CONTINUE
             }

--- a/lib/src/main/java/graphql/nadel/dsl/AstValueReplacer.kt
+++ b/lib/src/main/java/graphql/nadel/dsl/AstValueReplacer.kt
@@ -1,0 +1,59 @@
+package graphql.nadel.dsl
+
+import graphql.language.Argument
+import graphql.language.AstTransformer
+import graphql.language.Node
+import graphql.language.NodeVisitorStub
+import graphql.language.ObjectField
+import graphql.language.StringValue
+import graphql.language.Value
+import graphql.util.TraversalControl
+import graphql.util.TraverserContext
+import graphql.util.TreeTransformerUtil.changeNode
+
+class AstValueReplacer {
+
+    interface ValueReplacer {
+        fun replaceString(strValue: String): Value<*>?
+    }
+
+    fun replaceValues(value: Value<*>, valueReplacer: ValueReplacer): Value<*> {
+        val nodeVisitor = object : NodeVisitorStub() {
+
+            private fun possiblyReplaceValue(value: Value<*>): Value<*>? {
+                if (value is StringValue) {
+                    if (value.value != null) {
+                        return valueReplacer.replaceString(value.value)
+                    }
+                }
+                return null;
+            }
+
+            override fun visitArgument(
+                node: Argument,
+                context: TraverserContext<Node<*>>,
+            ): TraversalControl {
+                val newAstValue = possiblyReplaceValue(node.value)
+                if (newAstValue != null) {
+                    val transformedNode = node.transform { it.value(newAstValue) }
+                    return changeNode(context, transformedNode)
+                }
+                return TraversalControl.CONTINUE
+            }
+
+            override fun visitObjectField(
+                node: ObjectField,
+                context: TraverserContext<Node<*>>,
+            ): TraversalControl {
+                val newAstValue = possiblyReplaceValue(node.value)
+                if (newAstValue != null) {
+                    val transformedNode = node.transform { it.value(newAstValue) }
+                    return changeNode(context, transformedNode)
+                }
+                return TraversalControl.CONTINUE
+            }
+        }
+        val newValue = AstTransformer().transform(value, nodeVisitor)
+        return newValue as Value<*>
+    }
+}

--- a/lib/src/test/kotlin/graphql/nadel/dsl/AstValueReplacerTest.kt
+++ b/lib/src/test/kotlin/graphql/nadel/dsl/AstValueReplacerTest.kt
@@ -1,0 +1,43 @@
+package graphql.nadel.dsl
+
+import graphql.language.AstPrinter
+import graphql.language.ObjectField
+import graphql.language.ObjectValue
+import graphql.language.StringValue
+import graphql.language.Value
+import graphql.parser.Parser
+import io.kotest.core.spec.style.DescribeSpec
+
+class AstValueReplacerTest : DescribeSpec({
+    describe("can change values") {
+        it("can replace object values in AST") {
+
+            val startingValue = Parser.parseValue(
+                """
+                {
+                    abc : "${'$'}argument.x"
+                    note : "not to be changed"
+                }
+            """.trimIndent()
+            )
+
+            val valueReplacer = object : AstValueReplacer.ValueReplacer {
+                override fun replaceString(strValue: String): Value<*>? {
+                    if (strValue.contains("${'$'}argument.x")) {
+                        return ObjectValue(
+                            listOf(
+                                ObjectField("x", StringValue("X")),
+                                ObjectField("y", StringValue("Y"))
+                            )
+                        )
+                    }
+                    return null
+                }
+            }
+            val newValue = AstValueReplacer().replaceValues(startingValue, valueReplacer)
+
+            assert(AstPrinter.printAst(newValue) == """{abc : {x : "X", y : "Y"}, note : "not to be changed"}""")
+
+        }
+    }
+})

--- a/lib/src/test/kotlin/graphql/nadel/dsl/AstValueReplacerTest.kt
+++ b/lib/src/test/kotlin/graphql/nadel/dsl/AstValueReplacerTest.kt
@@ -1,15 +1,66 @@
 package graphql.nadel.dsl
 
+import graphql.GraphQLContext
+import graphql.execution.ValuesResolver
 import graphql.language.AstPrinter
-import graphql.language.ObjectField
-import graphql.language.ObjectValue
-import graphql.language.StringValue
 import graphql.language.Value
 import graphql.parser.Parser
+import graphql.schema.GraphQLSchema
+import graphql.schema.InputValueWithState
+import graphql.schema.idl.RuntimeWiring
+import graphql.schema.idl.SchemaGenerator
+import graphql.schema.idl.SchemaParser
 import io.kotest.core.spec.style.DescribeSpec
+import java.util.Locale
 
 class AstValueReplacerTest : DescribeSpec({
+
+    fun getSchema(schemaText: String): GraphQLSchema {
+        val typeDefs = SchemaParser().parse(schemaText)
+        return SchemaGenerator().makeExecutableSchema(typeDefs, RuntimeWiring.MOCKED_WIRING)
+    }
+
+
     describe("can change values") {
+
+        val schema = getSchema(
+            """
+            type Query {
+                q(arg : ComplexXyType) : String
+            }
+            
+            input ComplexXyType {
+                x : String
+                y : String
+            }
+        """.trimIndent()
+        )
+
+        val complexXyType = schema.getType("ComplexXyType")!!
+
+        val argument = "${'$'}argument"
+
+        val xyValueReplacer = object : AstValueReplacer.ValueReplacer {
+            override fun replaceString(strValue: String): Value<*>? {
+                if (strValue.contains("$argument.x")) {
+                    // we would find all $argument things
+                    // then look them up to resolve to a JVM value
+                    // then create an AST value of that external value based on some type
+                    // which we get from the target field
+                    val jvmValue = mapOf("x" to "X", "y" to "Y") // from argument object
+                    val inputValueWithState = InputValueWithState.newExternalValue(jvmValue)
+                    // maybe its already a literal ???
+                    return ValuesResolver.valueToLiteral(
+                        inputValueWithState,
+                        complexXyType,
+                        GraphQLContext.getDefault(),
+                        Locale.getDefault()
+                    )
+                }
+                return null
+            }
+        }
+
         it("can replace object values in AST") {
 
             val startingValue = Parser.parseValue(
@@ -20,24 +71,21 @@ class AstValueReplacerTest : DescribeSpec({
                 }
             """.trimIndent()
             )
-
-            val valueReplacer = object : AstValueReplacer.ValueReplacer {
-                override fun replaceString(strValue: String): Value<*>? {
-                    if (strValue.contains("${'$'}argument.x")) {
-                        return ObjectValue(
-                            listOf(
-                                ObjectField("x", StringValue("X")),
-                                ObjectField("y", StringValue("Y"))
-                            )
-                        )
-                    }
-                    return null
-                }
-            }
-            val newValue = AstValueReplacer().replaceValues(startingValue, valueReplacer)
+            val newValue = AstValueReplacer().replaceValues(startingValue, xyValueReplacer)
 
             assert(AstPrinter.printAst(newValue) == """{abc : {x : "X", y : "Y"}, note : "not to be changed"}""")
 
         }
+
+        it("can replace string values in AST") {
+
+            val startingValue = Parser.parseValue(""""${'$'}argument.x"""")
+
+            val newValue = AstValueReplacer().replaceValues(startingValue, xyValueReplacer)
+
+            assert(AstPrinter.printAst(newValue) == """{x : "X", y : "Y"}""")
+
+        }
+
     }
 })


### PR DESCRIPTION
Please make sure you consider the following:

- [ ] Add tests that use __typename in queries
- [ ] Does this change work with all nadel transformations (rename, type rename, hydration, etc)? Add tests for this.
- [ ] Is it worth using hints for this change in order to be able to enable a percentage rollout?
- [ ] Do we need to add integration tests for this change in the graphql gateway?
- [ ] Do we need a pollinator check for this?
