### PR TITLE
Pulls latest graphql-java version, which contains oneOf, and add some tests

### DIFF
--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
     id("com.bnorm.power.kotlin-power-assert")
 }
 
-val graphqlJavaVersion = "0.0.0-2023-07-12T23-55-39-fa8cf1b"
+val graphqlJavaVersion = "0.0.0-2023-10-17T05-10-19-42870f3"
 val slf4jVersion = "1.7.25"
 
 dependencies {

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
     id("com.bnorm.power.kotlin-power-assert")
 }
 
-val graphqlJavaVersion = "0.0.0-2023-10-17T05-10-19-42870f3"
+val graphqlJavaVersion = "0.0.0-2023-10-22T23-20-11-ea4414f"
 val slf4jVersion = "1.7.25"
 
 dependencies {

--- a/test/src/test/resources/fixtures/oneOf/one-of-fails-when-2-values-are-passed.yml
+++ b/test/src/test/resources/fixtures/oneOf/one-of-fails-when-2-values-are-passed.yml
@@ -6,8 +6,8 @@ overallSchema:
       search(by: SearchInput): String
     }
     input SearchInput @oneOf {
-      name: String!
-      id: ID!
+      name: String
+      id: ID
     }
 underlyingSchema:
   MyService: |-
@@ -15,8 +15,8 @@ underlyingSchema:
       search(by: SearchInput): String
     }
     input SearchInput @oneOf {
-      name: String!
-      id: ID!
+      name: String
+      id: ID
     }
 query: |
   query myQuery {

--- a/test/src/test/resources/fixtures/oneOf/one-of-fails-when-2-values-are-passed.yml
+++ b/test/src/test/resources/fixtures/oneOf/one-of-fails-when-2-values-are-passed.yml
@@ -1,0 +1,38 @@
+name: "oneOf fails when 2 values are passed"
+enabled: true
+overallSchema:
+  MyService: |
+    type Query {
+      search(by: SearchInput): String
+    }
+    input SearchInput @oneOf {
+      name: String!
+      id: ID!
+    }
+underlyingSchema:
+  MyService: |-
+    type Query {
+      search(by: SearchInput): String
+    }
+    input SearchInput @oneOf {
+      name: String!
+      id: ID!
+    }
+query: |
+  query myQuery {
+    search(by: {name: "Figaro", id: "1001"})
+  }
+variables: { }
+serviceCalls: []
+# language=JSON
+response: |-
+  {
+    "data": null,
+    "errors": [{
+      "message":"Exactly one key must be specified for OneOf type 'SearchInput'.",
+      "extensions":{
+        "classification":"ValidationError"
+      }
+    }],
+    "extensions": {}
+  }

--- a/test/src/test/resources/fixtures/oneOf/one-of-fails-when-invalid-variables-are-passed.yml
+++ b/test/src/test/resources/fixtures/oneOf/one-of-fails-when-invalid-variables-are-passed.yml
@@ -1,0 +1,39 @@
+name: "oneOf fails when invalid variables are passed"
+enabled: true
+overallSchema:
+  MyService: |
+    type Query {
+      search(by: SearchInput!): String
+    }
+    input SearchInput @oneOf {
+      name: String
+      id: ID
+    }
+underlyingSchema:
+  MyService: |-
+    type Query {
+      search(by: SearchInput!): String
+    }
+    input SearchInput @oneOf {
+      name: String
+      id: ID
+    }
+query: |
+  query myQuery($name: String, $id: ID) {
+    search(by: {name: $name, id: $id})
+  }
+variables:
+  name: "Figaro"
+serviceCalls: []
+# language=JSON
+response: |-
+  {
+    "data": null,
+    "errors": [{
+      "message":"Exactly one key must be specified for OneOf type 'SearchInput'.",
+      "extensions":{
+        "classification":"ValidationError"
+      }
+    }],
+    "extensions": {}
+  }

--- a/test/src/test/resources/fixtures/oneOf/one-of-fails-when-no-values-are-passed.yml
+++ b/test/src/test/resources/fixtures/oneOf/one-of-fails-when-no-values-are-passed.yml
@@ -1,9 +1,9 @@
-name: "oneOf fails when 2 values are passed"
+name: "oneOf fails when no values are passed"
 enabled: true
 overallSchema:
   MyService: |
     type Query {
-      search(by: SearchInput!): String
+      search(by: SearchInput): String
     }
     input SearchInput @oneOf {
       name: String
@@ -12,7 +12,7 @@ overallSchema:
 underlyingSchema:
   MyService: |-
     type Query {
-      search(by: SearchInput!): String
+      search(by: SearchInput): String
     }
     input SearchInput @oneOf {
       name: String
@@ -20,7 +20,7 @@ underlyingSchema:
     }
 query: |
   query myQuery {
-    search(by: {name: "Figaro", id: "1001"})
+    search(by: {})
   }
 variables: { }
 serviceCalls: []

--- a/test/src/test/resources/fixtures/oneOf/one-of-fails-when-null-value-is-passed.yml
+++ b/test/src/test/resources/fixtures/oneOf/one-of-fails-when-null-value-is-passed.yml
@@ -1,0 +1,38 @@
+name: "oneOf fails when null value is passed"
+enabled: true
+overallSchema:
+  MyService: |
+    type Query {
+      search(by: SearchInput): String
+    }
+    input SearchInput @oneOf {
+      name: String
+      id: ID
+    }
+underlyingSchema:
+  MyService: |-
+    type Query {
+      search(by: SearchInput): String
+    }
+    input SearchInput @oneOf {
+      name: String
+      id: ID
+    }
+query: |
+  query myQuery {
+    search(by: {name: null})
+  }
+variables: { }
+serviceCalls: []
+# language=JSON
+response: |-
+  {
+    "data": null,
+    "errors": [{
+      "message":"OneOf type field 'SearchInput.name' must be non-null.",
+      "extensions":{
+        "classification":"ValidationError"
+      }
+    }],
+    "extensions": {}
+  }

--- a/test/src/test/resources/fixtures/oneOf/one-of-successful.yml
+++ b/test/src/test/resources/fixtures/oneOf/one-of-successful.yml
@@ -1,0 +1,50 @@
+name: "oneOf successful"
+enabled: true
+overallSchema:
+  MyService: |
+    type Query {
+      search(by: SearchInput): String
+    }
+    input SearchInput @oneOf {
+      name: String
+      id: ID
+    }
+underlyingSchema:
+  MyService: |-
+    type Query {
+      search(by: SearchInput): String
+    }
+    input SearchInput @oneOf {
+      name: String
+      id: ID
+    }
+query: |
+  query myQuery {
+    search(by: {name: "Figaro"})
+  }
+variables: { }
+serviceCalls:
+  - serviceName: "MyService"
+    request:
+      query: |
+        query myQuery {
+          search(by: {name: "Figaro"})
+        }
+      variables: { }
+      operationName: "myQuery"
+    # language=JSON
+    response: |-
+      {
+        "data": {
+          "search": "Figaro"
+        },
+        "extensions": {}
+      }
+# language=JSON
+response: |-
+  {
+    "data": {
+      "search": "Figaro"
+    },
+    "extensions": {}
+  }


### PR DESCRIPTION
Please make sure you consider the following:

- [n/a ] Add tests that use __typename in queries
- [n/a ] Does this change work with all nadel transformations (rename, type rename, hydration, etc)? Add tests for this.
- [n/a] Is it worth using hints for this change in order to be able to enable a percentage rollout?
- [n/a ] Do we need to add integration tests for this change in the graphql gateway?
- [n/a ] Do we need a pollinator check for this?
