### PR TITLE
Pull graphql-java with oneof fix and add more tests

### DIFF
--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
     id("com.bnorm.power.kotlin-power-assert")
 }
 
-val graphqlJavaVersion = "0.0.0-2023-10-22T23-20-11-ea4414f"
+val graphqlJavaVersion = "0.0.0-2023-10-30T22-58-00-448780b"
 val slf4jVersion = "1.7.25"
 
 dependencies {

--- a/test/src/test/resources/fixtures/oneOf/one-of-fails-when-nested-input.yml
+++ b/test/src/test/resources/fixtures/oneOf/one-of-fails-when-nested-input.yml
@@ -1,0 +1,51 @@
+name: "oneOf fails when nested input"
+enabled: true
+overallSchema:
+  MyService: |
+    type Query {
+      search(by: SearchInput): String
+    }
+     
+    input SearchInput {
+      name: String
+      id: IdInput
+    }
+    
+    input IdInput @oneOf {
+      email: String
+      id: ID
+    }
+
+underlyingSchema:
+  MyService: |-
+    type Query {
+      search(by: SearchInput): String
+    }
+    
+    input SearchInput {
+      name: String
+      id: IdInput
+    }
+    
+    input IdInput @oneOf {
+      email: String
+      id: ID
+    }
+query: |
+  query myQuery {
+    search(by: {id: {email: null}})
+  }
+variables: { }
+serviceCalls: []
+# language=JSON
+response: |-
+  {
+    "data": null,
+    "errors": [{
+      "message":"OneOf type field 'IdInput.email' must be non-null.",
+      "extensions":{
+        "classification":"ValidationError"
+      }
+    }],
+    "extensions": {}
+  }


### PR DESCRIPTION
Please make sure you consider the following:

- [n ] Add tests that use __typename in queries
- [n ] Does this change work with all nadel transformations (rename, type rename, hydration, etc)? Add tests for this.
- [n ] Is it worth using hints for this change in order to be able to enable a percentage rollout?
- [y ] Do we need to add integration tests for this change in the graphql gateway?
- [n ] Do we need a pollinator check for this?
