### PR TITLE
Adding conditional hydration validation

### DIFF
--- a/lib/src/main/java/graphql/nadel/dsl/UnderlyingServiceHydration.kt
+++ b/lib/src/main/java/graphql/nadel/dsl/UnderlyingServiceHydration.kt
@@ -10,7 +10,7 @@ data class UnderlyingServiceHydration(
     val isBatched: Boolean,
     val batchSize: Int,
     val timeout: Int,
-    val conditionalHydration: LinkedHashMap<String, Any>?
+    val conditionalHydration: Map<String, Any>?
 ) {
     data class ObjectIdentifier(val sourceId: String, val resultId: String)
 }

--- a/lib/src/main/java/graphql/nadel/dsl/UnderlyingServiceHydration.kt
+++ b/lib/src/main/java/graphql/nadel/dsl/UnderlyingServiceHydration.kt
@@ -10,6 +10,7 @@ data class UnderlyingServiceHydration(
     val isBatched: Boolean,
     val batchSize: Int,
     val timeout: Int,
+    val conditionalHydration: LinkedHashMap<String, Any>?
 ) {
     data class ObjectIdentifier(val sourceId: String, val resultId: String)
 }

--- a/lib/src/main/java/graphql/nadel/schema/NadelDirectives.kt
+++ b/lib/src/main/java/graphql/nadel/schema/NadelDirectives.kt
@@ -303,7 +303,10 @@ object NadelDirectives {
                 val identifiedByValues = resolveArgumentValue<List<Any>>(inputIdentifiedBy)
                 val identifiedBy = createObjectIdentifiers(identifiedByValues)
 
-                buildHydrationParameters(directive, arguments, identifiedBy)
+                val conditionalHydration = directive.getArgument("when")
+                    .getValue<LinkedHashMap<String, LinkedHashMap<String, Any>>>()?.get("result")
+
+                buildHydrationParameters(directive, arguments, identifiedBy, conditionalHydration)
             }
 
         val templatedHydrations = fieldDefinition.getAppliedDirectives(hydratedFromDirectiveDefinition.name)
@@ -319,6 +322,7 @@ object NadelDirectives {
         directive: GraphQLAppliedDirective,
         arguments: List<RemoteArgumentDefinition>,
         identifiedBy: List<UnderlyingServiceHydration.ObjectIdentifier>,
+        conditionalHydration: LinkedHashMap<String,Any>? = null
     ): UnderlyingServiceHydration {
         val service = getDirectiveValue<String>(directive, "service")
         val fieldNames = getDirectiveValue<String>(directive, "field").split('.')
@@ -344,7 +348,8 @@ object NadelDirectives {
             objectIndexed,
             batched,
             batchSize,
-            timeout
+            timeout,
+            conditionalHydration
         )
     }
 

--- a/lib/src/main/java/graphql/nadel/validation/NadelHydrationValidation.kt
+++ b/lib/src/main/java/graphql/nadel/validation/NadelHydrationValidation.kt
@@ -235,14 +235,9 @@ internal class NadelHydrationValidation(
                             actorField.name
                         ),
                         nadelHydrationWhenConditionValidation.validateHydrationWhenConditionInput(
-                            field.type,
-                            actorFieldArg.type,
                             parent,
                             overallField,
-                            remoteArgDef,
-                            hydration,
-                            isBatchHydration,
-                            actorField.name
+                            hydration
                         ),
                     )
                 }
@@ -255,7 +250,8 @@ internal class NadelHydrationValidation(
                 } else {
                     //check the input types match with hydration and actor fields
                     val hydrationArgType = argument.type
-                    val validationError = nadelHydrationArgumentValidation.validateHydrationInputArg(
+                    return listOfNotNull(
+                    nadelHydrationArgumentValidation.validateHydrationInputArg(
                         hydrationArgType,
                         actorFieldArg.type,
                         parent,
@@ -264,11 +260,7 @@ internal class NadelHydrationValidation(
                         hydration,
                         isBatchHydration,
                         actorField.name
-                    )
-                    if (validationError != null) {
-                        return listOf(validationError)
-                    }
-                    return emptyList()
+                    ))
                 }
             }
 

--- a/lib/src/main/java/graphql/nadel/validation/NadelHydrationValidation.kt
+++ b/lib/src/main/java/graphql/nadel/validation/NadelHydrationValidation.kt
@@ -33,6 +33,7 @@ internal class NadelHydrationValidation(
 ) {
     private val validationUtil = ValidationUtil()
     private val nadelHydrationArgumentValidation = NadelHydrationArgumentValidation()
+    private val nadelHydrationWhenConditionValidation = NadelHydrationWhenConditionValidation()
     fun validate(
         parent: NadelServiceSchemaElement,
         overallField: GraphQLFieldDefinition,
@@ -153,15 +154,15 @@ internal class NadelHydrationValidation(
                 DuplicatedHydrationArgument(parent, overallField, it)
             }
 
-        val remoteArgErrors = hydration.arguments.mapNotNull { remoteArg ->
+        val remoteArgErrors = hydration.arguments.flatMap { remoteArg ->
             val actorFieldArgument = actorField.getArgument(remoteArg.name)
             if (actorFieldArgument == null) {
-                NonExistentHydrationActorFieldArgument(
+                listOf(NonExistentHydrationActorFieldArgument(
                     parent,
                     overallField,
                     hydration,
                     argument = remoteArg.name,
-                )
+                ))
             } else {
                 val remoteArgSource = remoteArg.remoteArgumentSource
                 getRemoteArgErrors(parent, overallField, remoteArg, actorField, hydration)
@@ -210,7 +211,7 @@ internal class NadelHydrationValidation(
         remoteArgDef: RemoteArgumentDefinition,
         actorField: GraphQLFieldDefinition,
         hydration: UnderlyingServiceHydration,
-    ): NadelSchemaValidationError? {
+    ): List<NadelSchemaValidationError> {
         val remoteArgSource = remoteArgDef.remoteArgumentSource
         val actorFieldArg = actorField.getArgument(remoteArgDef.name)
         val isBatchHydration = actorField.type.unwrapNonNull().isList
@@ -218,18 +219,31 @@ internal class NadelHydrationValidation(
             ObjectField -> {
                 val field = (parent.underlying as GraphQLFieldsContainer).getFieldAt(remoteArgSource.pathToField!!)
                 if (field == null) {
-                    MissingHydrationFieldValueSource(parent, overallField, remoteArgSource)
+                    return listOf(
+                        MissingHydrationFieldValueSource(parent, overallField, remoteArgSource)
+                    )
                 } else {
-                    // check the input types match with hydration and actor fields
-                    return nadelHydrationArgumentValidation.validateHydrationInputArg(
-                        field.type,
-                        actorFieldArg.type,
-                        parent,
-                        overallField,
-                        remoteArgDef,
-                        hydration,
-                        isBatchHydration,
-                        actorField.name
+                    return listOfNotNull(
+                        nadelHydrationArgumentValidation.validateHydrationInputArg(
+                            field.type,
+                            actorFieldArg.type,
+                            parent,
+                            overallField,
+                            remoteArgDef,
+                            hydration,
+                            isBatchHydration,
+                            actorField.name
+                        ),
+                        nadelHydrationWhenConditionValidation.validateHydrationWhenConditionInput(
+                            field.type,
+                            actorFieldArg.type,
+                            parent,
+                            overallField,
+                            remoteArgDef,
+                            hydration,
+                            isBatchHydration,
+                            actorField.name
+                        ),
                     )
                 }
             }
@@ -237,11 +251,11 @@ internal class NadelHydrationValidation(
             FieldArgument -> {
                 val argument = overallField.getArgument(remoteArgSource.argumentName!!)
                 if (argument == null) {
-                    MissingHydrationArgumentValueSource(parent, overallField, remoteArgSource)
+                    return listOf(MissingHydrationArgumentValueSource(parent, overallField, remoteArgSource))
                 } else {
                     //check the input types match with hydration and actor fields
                     val hydrationArgType = argument.type
-                    return nadelHydrationArgumentValidation.validateHydrationInputArg(
+                    val validationError = nadelHydrationArgumentValidation.validateHydrationInputArg(
                         hydrationArgType,
                         actorFieldArg.type,
                         parent,
@@ -251,6 +265,10 @@ internal class NadelHydrationValidation(
                         isBatchHydration,
                         actorField.name
                     )
+                    if (validationError != null) {
+                        return listOf(validationError)
+                    }
+                    return emptyList()
                 }
             }
 
@@ -264,15 +282,15 @@ internal class NadelHydrationValidation(
                         Locale.getDefault()
                     )
                 ) {
-                    return NadelSchemaValidationError.StaticArgIsNotAssignable(
+                    return listOf(NadelSchemaValidationError.StaticArgIsNotAssignable(
                         parent,
                         overallField,
                         remoteArgDef,
                         actorFieldArg.type,
                         actorField.name
-                    )
+                    ))
                 }
-                return null
+                return emptyList()
             }
         }
     }

--- a/lib/src/main/java/graphql/nadel/validation/NadelHydrationWhenConditionValidation.kt
+++ b/lib/src/main/java/graphql/nadel/validation/NadelHydrationWhenConditionValidation.kt
@@ -2,6 +2,7 @@ package graphql.nadel.validation
 
 import graphql.Scalars
 import graphql.nadel.dsl.UnderlyingServiceHydration
+import graphql.nadel.engine.util.unwrapAll
 import graphql.nadel.engine.util.unwrapNonNull
 import graphql.schema.GraphQLFieldDefinition
 import graphql.schema.GraphQLFieldsContainer
@@ -23,8 +24,13 @@ internal class NadelHydrationWhenConditionValidation() {
         val whenConditionSourceFieldName: String = hydration.conditionalHydration?.get("sourceField") as String
         val whenConditionSourceField: GraphQLFieldDefinition = (parent.overall as GraphQLFieldsContainer).getField(whenConditionSourceFieldName)
 
+        if (whenConditionSourceField == null){
+            return NadelSchemaValidationError.WhenConditionSourceFieldDoesNotExist(whenConditionSourceFieldName, overallField)
+        }
+
+
         if (whenConditionSourceField.type.unwrapNonNull() !is GraphQLScalarType){
-            return return NadelSchemaValidationError.WhenConditionUnsupportedFieldType(whenConditionSourceFieldName, GraphQLTypeUtil.simplePrint(whenConditionSourceField.type), overallField)
+            return NadelSchemaValidationError.WhenConditionUnsupportedFieldType(whenConditionSourceFieldName, GraphQLTypeUtil.simplePrint(whenConditionSourceField.type), overallField)
         }
         val whenConditionSourceFieldTypeName: String = (whenConditionSourceField.type as GraphQLScalarType).name
 

--- a/lib/src/main/java/graphql/nadel/validation/NadelHydrationWhenConditionValidation.kt
+++ b/lib/src/main/java/graphql/nadel/validation/NadelHydrationWhenConditionValidation.kt
@@ -1,53 +1,42 @@
 package graphql.nadel.validation
 
-import graphql.GraphQLContext
 import graphql.Scalars
-import graphql.nadel.dsl.RemoteArgumentDefinition
 import graphql.nadel.dsl.UnderlyingServiceHydration
 import graphql.schema.GraphQLFieldDefinition
-import graphql.schema.GraphQLInputType
-import graphql.schema.GraphQLType
-import graphql.nadel.validation.NadelSchemaValidationError
 import graphql.schema.GraphQLFieldsContainer
 import graphql.schema.GraphQLScalarType
-import graphql.validation.ValidationUtil
 import java.math.BigInteger
-import java.util.Locale
 
 internal class NadelHydrationWhenConditionValidation() {
-    private val validationUtil = ValidationUtil()
 
     fun validateHydrationWhenConditionInput(
-        hydrationSourceType: GraphQLType,
-        actorFieldArgType: GraphQLInputType,
         parent: NadelServiceSchemaElement,
         overallField: GraphQLFieldDefinition,
-        remoteArg: RemoteArgumentDefinition,
         hydration: UnderlyingServiceHydration,
-        isBatchHydration: Boolean,
-        actorFieldName: String,
     ): NadelSchemaValidationError? {
         if (hydration.conditionalHydration == null) {
             return null
         }
 
         val whenConditionSourceFieldName: String = hydration.conditionalHydration?.get("sourceField") as String
-        val whenConditionSourceField = (parent.overall as GraphQLFieldsContainer).getField(whenConditionSourceFieldName)
+        val whenConditionSourceField: GraphQLFieldDefinition = (parent.overall as GraphQLFieldsContainer).getField(whenConditionSourceFieldName)
 
-        val whenConditionSourceFieldTypeName: String = ((whenConditionSourceField as GraphQLFieldDefinition).type as GraphQLScalarType).name
+        if (whenConditionSourceField.type !is GraphQLScalarType){
+            return return NadelSchemaValidationError.WhenConditionUnsupportedFieldType(whenConditionSourceFieldName, "", overallField)
+        }
+        val whenConditionSourceFieldTypeName: String = (whenConditionSourceField.type as GraphQLScalarType).name
 
 
         // Limit sourceField to simple values like String, Boolean, Int etc.
         if( ! (whenConditionSourceFieldTypeName == Scalars.GraphQLString.name ||
                 whenConditionSourceFieldTypeName == Scalars.GraphQLInt.name ||
                 whenConditionSourceFieldTypeName == Scalars.GraphQLID.name)) {
-            return NadelSchemaValidationError.WhenConditionSourceFieldNotASimpleType(whenConditionSourceFieldName, whenConditionSourceFieldTypeName, overallField)
+            return NadelSchemaValidationError.WhenConditionUnsupportedFieldType(whenConditionSourceFieldName, whenConditionSourceFieldTypeName, overallField)
         }
 
         // Ensure predicate matches the field type used
-        val predicateObject = hydration.conditionalHydration?.get("predicate") as LinkedHashMap<String, Any>
-        val predicateType = predicateObject.keys.first()
-        val predicateValue = predicateObject.getValue(predicateType)
+        val predicateObject = hydration.conditionalHydration?.get("predicate") as Map<String, Any>
+        val (predicateType, predicateValue) = predicateObject.entries.single()
 
         if (predicateType == "equals" ) {
             if (!(

--- a/lib/src/main/java/graphql/nadel/validation/NadelHydrationWhenConditionValidation.kt
+++ b/lib/src/main/java/graphql/nadel/validation/NadelHydrationWhenConditionValidation.kt
@@ -2,9 +2,11 @@ package graphql.nadel.validation
 
 import graphql.Scalars
 import graphql.nadel.dsl.UnderlyingServiceHydration
+import graphql.nadel.engine.util.unwrapNonNull
 import graphql.schema.GraphQLFieldDefinition
 import graphql.schema.GraphQLFieldsContainer
 import graphql.schema.GraphQLScalarType
+import graphql.schema.GraphQLTypeUtil
 import java.math.BigInteger
 
 internal class NadelHydrationWhenConditionValidation() {
@@ -21,8 +23,8 @@ internal class NadelHydrationWhenConditionValidation() {
         val whenConditionSourceFieldName: String = hydration.conditionalHydration?.get("sourceField") as String
         val whenConditionSourceField: GraphQLFieldDefinition = (parent.overall as GraphQLFieldsContainer).getField(whenConditionSourceFieldName)
 
-        if (whenConditionSourceField.type !is GraphQLScalarType){
-            return return NadelSchemaValidationError.WhenConditionUnsupportedFieldType(whenConditionSourceFieldName, "", overallField)
+        if (whenConditionSourceField.type.unwrapNonNull() !is GraphQLScalarType){
+            return return NadelSchemaValidationError.WhenConditionUnsupportedFieldType(whenConditionSourceFieldName, GraphQLTypeUtil.simplePrint(whenConditionSourceField.type), overallField)
         }
         val whenConditionSourceFieldTypeName: String = (whenConditionSourceField.type as GraphQLScalarType).name
 

--- a/lib/src/main/java/graphql/nadel/validation/NadelHydrationWhenConditionValidation.kt
+++ b/lib/src/main/java/graphql/nadel/validation/NadelHydrationWhenConditionValidation.kt
@@ -23,11 +23,7 @@ internal class NadelHydrationWhenConditionValidation() {
 
         val whenConditionSourceFieldName: String = hydration.conditionalHydration?.get("sourceField") as String
         val whenConditionSourceField: GraphQLFieldDefinition = (parent.overall as GraphQLFieldsContainer).getField(whenConditionSourceFieldName)
-
-        if (whenConditionSourceField == null){
-            return NadelSchemaValidationError.WhenConditionSourceFieldDoesNotExist(whenConditionSourceFieldName, overallField)
-        }
-
+            ?: return NadelSchemaValidationError.WhenConditionSourceFieldDoesNotExist(whenConditionSourceFieldName, overallField)
 
         if (whenConditionSourceField.type.unwrapNonNull() !is GraphQLScalarType){
             return NadelSchemaValidationError.WhenConditionUnsupportedFieldType(whenConditionSourceFieldName, GraphQLTypeUtil.simplePrint(whenConditionSourceField.type), overallField)

--- a/lib/src/main/java/graphql/nadel/validation/NadelHydrationWhenConditionValidation.kt
+++ b/lib/src/main/java/graphql/nadel/validation/NadelHydrationWhenConditionValidation.kt
@@ -1,0 +1,82 @@
+package graphql.nadel.validation
+
+import graphql.GraphQLContext
+import graphql.Scalars
+import graphql.nadel.dsl.RemoteArgumentDefinition
+import graphql.nadel.dsl.UnderlyingServiceHydration
+import graphql.schema.GraphQLFieldDefinition
+import graphql.schema.GraphQLInputType
+import graphql.schema.GraphQLType
+import graphql.nadel.validation.NadelSchemaValidationError
+import graphql.schema.GraphQLFieldsContainer
+import graphql.schema.GraphQLScalarType
+import graphql.validation.ValidationUtil
+import java.math.BigInteger
+import java.util.Locale
+
+internal class NadelHydrationWhenConditionValidation() {
+    private val validationUtil = ValidationUtil()
+
+    fun validateHydrationWhenConditionInput(
+        hydrationSourceType: GraphQLType,
+        actorFieldArgType: GraphQLInputType,
+        parent: NadelServiceSchemaElement,
+        overallField: GraphQLFieldDefinition,
+        remoteArg: RemoteArgumentDefinition,
+        hydration: UnderlyingServiceHydration,
+        isBatchHydration: Boolean,
+        actorFieldName: String,
+    ): NadelSchemaValidationError? {
+        if (hydration.conditionalHydration == null) {
+            return null
+        }
+
+        val whenConditionSourceFieldName: String = hydration.conditionalHydration?.get("sourceField") as String
+        val whenConditionSourceField = (parent.overall as GraphQLFieldsContainer).getField(whenConditionSourceFieldName)
+
+        val whenConditionSourceFieldTypeName: String = ((whenConditionSourceField as GraphQLFieldDefinition).type as GraphQLScalarType).name
+
+
+        // Limit sourceField to simple values like String, Boolean, Int etc.
+        if( ! (whenConditionSourceFieldTypeName == Scalars.GraphQLString.name ||
+                whenConditionSourceFieldTypeName == Scalars.GraphQLInt.name ||
+                whenConditionSourceFieldTypeName == Scalars.GraphQLID.name)) {
+            return NadelSchemaValidationError.WhenConditionSourceFieldNotASimpleType(whenConditionSourceFieldName, whenConditionSourceFieldTypeName, overallField)
+        }
+
+        // Ensure predicate matches the field type used
+        val predicateObject = hydration.conditionalHydration?.get("predicate") as LinkedHashMap<String, Any>
+        val predicateType = predicateObject.keys.first()
+        val predicateValue = predicateObject.getValue(predicateType)
+
+        if (predicateType == "equals" ) {
+            if (!(
+                predicateValue is String && whenConditionSourceFieldTypeName == Scalars.GraphQLString.name ||
+                predicateValue is BigInteger && whenConditionSourceFieldTypeName == Scalars.GraphQLInt.name ||
+                predicateValue is String && whenConditionSourceFieldTypeName == Scalars.GraphQLID.name ||
+                predicateValue is BigInteger && whenConditionSourceFieldTypeName == Scalars.GraphQLID.name
+            )) {
+                return NadelSchemaValidationError.WhenConditionPredicateDoesNotMatchSourceFieldType(
+                    whenConditionSourceFieldName,
+                    whenConditionSourceFieldTypeName,
+                    predicateValue.javaClass.simpleName,
+                    overallField
+                )
+            }
+        }
+        if (predicateType == "startsWith" || predicateType == "matches") {
+            if (!(whenConditionSourceFieldTypeName == Scalars.GraphQLString.name ||
+                whenConditionSourceFieldTypeName == Scalars.GraphQLID.name
+                )){
+                return NadelSchemaValidationError.WhenConditionPredicateRequiresStringSourceField(
+                    whenConditionSourceFieldName,
+                    whenConditionSourceFieldTypeName,
+                    predicateType,
+                    overallField
+                )
+            }
+        }
+
+        return null
+    }
+}

--- a/lib/src/main/java/graphql/nadel/validation/NadelSchemaValidationError.kt
+++ b/lib/src/main/java/graphql/nadel/validation/NadelSchemaValidationError.kt
@@ -408,6 +408,38 @@ sealed interface NadelSchemaValidationError {
         override val subject = overallField
     }
 
+    data class WhenConditionSourceFieldNotASimpleType(
+        val sourceFieldName: String,
+        val sourceFieldTypeName: String,
+        val overallField: GraphQLFieldDefinition
+    ) : NadelSchemaValidationError {
+        override val message = "When condition source field \"${sourceFieldName}\" is of type \"${sourceFieldTypeName}}\" " +
+            "but it needs to be of type String, Int or ID"
+        override val subject = overallField
+    }
+
+    data class WhenConditionPredicateDoesNotMatchSourceFieldType(
+        val sourceFieldName: String,
+        val sourceFieldTypeName: String,
+        val predicateTypeName: String,
+        val overallField: GraphQLFieldDefinition
+    ) : NadelSchemaValidationError {
+        override val message = "When condition source field \"${sourceFieldName}\" of type \"${sourceFieldTypeName}\" " +
+            "does not match the predicate type ${predicateTypeName} in the when condition"
+        override val subject = overallField
+    }
+
+    data class WhenConditionPredicateRequiresStringSourceField(
+        val sourceFieldName: String,
+        val sourceFieldTypeName: String,
+        val predicateType: String,
+        val overallField: GraphQLFieldDefinition
+    ) : NadelSchemaValidationError {
+        override val message = "When condition source field \"${sourceFieldName}\" of type \"${sourceFieldTypeName}\" " +
+            "needs to be of type String or ID in order to use the ${predicateType} predicate."
+        override val subject = overallField
+    }
+
     data class IncompatibleFieldInHydratedInputObject(
         val parentType: NadelServiceSchemaElement,
         val overallField: GraphQLFieldDefinition,

--- a/lib/src/main/java/graphql/nadel/validation/NadelSchemaValidationError.kt
+++ b/lib/src/main/java/graphql/nadel/validation/NadelSchemaValidationError.kt
@@ -418,6 +418,14 @@ sealed interface NadelSchemaValidationError {
         override val subject = overallField
     }
 
+    data class WhenConditionSourceFieldDoesNotExist(
+        val sourceFieldName: String,
+        val overallField: GraphQLFieldDefinition
+    ) : NadelSchemaValidationError {
+        override val message = "When condition source field \"${sourceFieldName}\" does not exist "
+        override val subject = overallField
+    }
+
     data class WhenConditionPredicateDoesNotMatchSourceFieldType(
         val sourceFieldName: String,
         val sourceFieldTypeName: String,

--- a/lib/src/main/java/graphql/nadel/validation/NadelSchemaValidationError.kt
+++ b/lib/src/main/java/graphql/nadel/validation/NadelSchemaValidationError.kt
@@ -408,7 +408,7 @@ sealed interface NadelSchemaValidationError {
         override val subject = overallField
     }
 
-    data class WhenConditionSourceFieldNotASimpleType(
+    data class WhenConditionUnsupportedFieldType(
         val sourceFieldName: String,
         val sourceFieldTypeName: String,
         val overallField: GraphQLFieldDefinition

--- a/lib/src/test/kotlin/graphql/nadel/validation/NadelHydrationWhenConditionValidationTest.kt
+++ b/lib/src/test/kotlin/graphql/nadel/validation/NadelHydrationWhenConditionValidationTest.kt
@@ -1,8 +1,9 @@
 package graphql.nadel.validation
 
-import graphql.nadel.validation.NadelSchemaValidationError.WhenConditionUnsupportedFieldType
 import graphql.nadel.validation.NadelSchemaValidationError.WhenConditionPredicateDoesNotMatchSourceFieldType
 import graphql.nadel.validation.NadelSchemaValidationError.WhenConditionPredicateRequiresStringSourceField
+import graphql.nadel.validation.NadelSchemaValidationError.WhenConditionSourceFieldDoesNotExist
+import graphql.nadel.validation.NadelSchemaValidationError.WhenConditionUnsupportedFieldType
 import graphql.nadel.validation.util.assertSingleOfType
 import io.kotest.core.spec.style.DescribeSpec
 
@@ -454,10 +455,9 @@ class NadelHydrationWhenConditionValidationTest : DescribeSpec({
             val errors = validate(fixture)
             assert(errors.map { it.message }.isNotEmpty())
 
-            val error = errors.assertSingleOfType<WhenConditionUnsupportedFieldType>()
+            val error = errors.assertSingleOfType<WhenConditionSourceFieldDoesNotExist>()
             assert(error.overallField.name == "creator")
-            assert(error.sourceFieldName == "categories")
-            assert(error.sourceFieldTypeName == "[String]")
+            assert(error.sourceFieldName == "type")
         }
         it("equals predicate fails if expected type mismatches with field type") {
             val fixture = NadelValidationTestFixture(

--- a/lib/src/test/kotlin/graphql/nadel/validation/NadelHydrationWhenConditionValidationTest.kt
+++ b/lib/src/test/kotlin/graphql/nadel/validation/NadelHydrationWhenConditionValidationTest.kt
@@ -1,13 +1,10 @@
 package graphql.nadel.validation
 
-import graphql.Assert.assertTrue
-import graphql.nadel.validation.NadelSchemaValidationError.WhenConditionSourceFieldNotASimpleType
+import graphql.nadel.validation.NadelSchemaValidationError.WhenConditionUnsupportedFieldType
 import graphql.nadel.validation.NadelSchemaValidationError.WhenConditionPredicateDoesNotMatchSourceFieldType
 import graphql.nadel.validation.NadelSchemaValidationError.WhenConditionPredicateRequiresStringSourceField
 import graphql.nadel.validation.util.assertSingleOfType
-import graphql.schema.GraphQLTypeUtil
 import io.kotest.core.spec.style.DescribeSpec
-import io.mockk.InternalPlatformDsl.toStr
 
 private const val source = "$" + "source"
 private const val argument = "$" + "argument"
@@ -325,7 +322,7 @@ class NadelHydrationWhenConditionValidationTest : DescribeSpec({
             val errors = validate(fixture)
             assert(errors.map { it.message }.isNotEmpty())
 
-            val error = errors.assertSingleOfType<WhenConditionSourceFieldNotASimpleType>()
+            val error = errors.assertSingleOfType<WhenConditionUnsupportedFieldType>()
             assert(error.overallField.name == "creator")
             assert(error.sourceFieldName == "valid")
             assert(error.sourceFieldTypeName == "Boolean")

--- a/lib/src/test/kotlin/graphql/nadel/validation/NadelHydrationWhenConditionValidationTest.kt
+++ b/lib/src/test/kotlin/graphql/nadel/validation/NadelHydrationWhenConditionValidationTest.kt
@@ -1,0 +1,790 @@
+package graphql.nadel.validation
+
+import graphql.Assert.assertTrue
+import graphql.nadel.validation.NadelSchemaValidationError.WhenConditionSourceFieldNotASimpleType
+import graphql.nadel.validation.NadelSchemaValidationError.WhenConditionPredicateDoesNotMatchSourceFieldType
+import graphql.nadel.validation.NadelSchemaValidationError.WhenConditionPredicateRequiresStringSourceField
+import graphql.nadel.validation.util.assertSingleOfType
+import graphql.schema.GraphQLTypeUtil
+import io.kotest.core.spec.style.DescribeSpec
+import io.mockk.InternalPlatformDsl.toStr
+
+private const val source = "$" + "source"
+private const val argument = "$" + "argument"
+
+
+class NadelHydrationWhenConditionValidationTest : DescribeSpec({
+    describe("Hydration when condition validation") {
+        it("happy path (valid when condition)") {
+            val fixture = NadelValidationTestFixture(
+                overallSchema = mapOf(
+                    "issues" to """
+                        type Query {
+                            issue: JiraIssue
+                        }
+                        type JiraIssue @renamed(from: "Issue") {
+                            id: ID!
+                        }
+                    """.trimIndent(),
+                    "users" to """
+                        type Query {
+                            user(id: ID!): User
+                        }
+                        type User {
+                            id: ID!
+                            name: String!
+                        }
+                        extend type JiraIssue {
+                            type: String
+                            creator: User @hydrated(
+                                service: "users"
+                                field: "user"
+                                arguments: [
+                                    {name: "id", value: "$source.creator"}
+                                ]
+                                when: {
+                                    result: {
+                                        sourceField: "type"
+                                        predicate: { equals: "issue" }
+                                    }
+                                }
+                            )
+                        }
+                    """.trimIndent(),
+                ),
+                underlyingSchema = mapOf(
+                    "issues" to """
+                        type Query {
+                            issue: Issue
+                        }
+                        type Issue {
+                            id: ID!
+                            creator: ID!
+                            type: String!
+                        }
+                    """.trimIndent(),
+                    "users" to """
+                        type Query {
+                            user(id: ID!): User
+                        }
+                        type User {
+                            id: ID!
+                            name: String!
+                        }
+                    """.trimIndent(),
+                ),
+            )
+            val errors = validate(fixture)
+            assert(errors.map { it.message }.isEmpty())
+        }
+        it("passes if sourceField is simple values Int") {
+            val fixture = NadelValidationTestFixture(
+                overallSchema = mapOf(
+                    "issues" to """
+                        type Query {
+                            issue: JiraIssue
+                        }
+                        type JiraIssue @renamed(from: "Issue") {
+                            id: ID!
+                        }
+                    """.trimIndent(),
+                    "users" to """
+                        type Query {
+                            user(id: ID!): User
+                        }
+                        type User {
+                            id: ID!
+                            name: String!
+                        }
+                        extend type JiraIssue {
+                            rank: Int
+                            creator: User @hydrated(
+                                service: "users"
+                                field: "user"
+                                arguments: [
+                                    {name: "id", value: "$source.creator"}
+                                ]
+                                when: {
+                                    result: {
+                                        sourceField: "rank"
+                                        predicate: { equals: 1 }
+                                    }
+                                }
+                            )
+                        }
+                    """.trimIndent(),
+                ),
+                underlyingSchema = mapOf(
+                    "issues" to """
+                        type Query {
+                            issue: Issue
+                        }
+                        type Issue {
+                            id: ID!
+                            creator: ID!
+                            rank: Int!
+                        }
+                    """.trimIndent(),
+                    "users" to """
+                        type Query {
+                            user(id: ID!): User
+                        }
+                        type User {
+                            id: ID!
+                            name: String!
+                        }
+                    """.trimIndent(),
+                ),
+            )
+            val errors = validate(fixture)
+            assert(errors.map { it.message }.isEmpty())
+        }
+        it("passes if expecting an Int for an ID sourceField") {
+            val fixture = NadelValidationTestFixture(
+                overallSchema = mapOf(
+                    "issues" to """
+                        type Query {
+                            issue: JiraIssue
+                        }
+                        type JiraIssue @renamed(from: "Issue") {
+                            id: ID!
+                        }
+                    """.trimIndent(),
+                    "users" to """
+                        type Query {
+                            user(id: ID!): User
+                        }
+                        type User {
+                            id: ID!
+                            name: String!
+                        }
+                        extend type JiraIssue {
+                            issueId: ID
+                            creator: User @hydrated(
+                                service: "users"
+                                field: "user"
+                                arguments: [
+                                    {name: "id", value: "$source.creator"}
+                                ]
+                                when: {
+                                    result: {
+                                        sourceField: "issueId"
+                                        predicate: { equals: 1 }
+                                    }
+                                }
+                            )
+                        }
+                    """.trimIndent(),
+                ),
+                underlyingSchema = mapOf(
+                    "issues" to """
+                        type Query {
+                            issue: Issue
+                        }
+                        type Issue {
+                            id: ID!
+                            creator: ID!
+                            issueId: ID!
+                        }
+                    """.trimIndent(),
+                    "users" to """
+                        type Query {
+                            user(id: ID!): User
+                        }
+                        type User {
+                            id: ID!
+                            name: String!
+                        }
+                    """.trimIndent(),
+                ),
+            )
+            val errors = validate(fixture)
+            assert(errors.map { it.message }.isEmpty())
+        }
+        it("passes if expecting a String for an ID sourceField") {
+            val fixture = NadelValidationTestFixture(
+                overallSchema = mapOf(
+                    "issues" to """
+                        type Query {
+                            issue: JiraIssue
+                        }
+                        type JiraIssue @renamed(from: "Issue") {
+                            id: ID!
+                        }
+                    """.trimIndent(),
+                    "users" to """
+                        type Query {
+                            user(id: ID!): User
+                        }
+                        type User {
+                            id: ID!
+                            name: String!
+                        }
+                        extend type JiraIssue {
+                            issueId: ID
+                            creator: User @hydrated(
+                                service: "users"
+                                field: "user"
+                                arguments: [
+                                    {name: "id", value: "$source.creator"}
+                                ]
+                                when: {
+                                    result: {
+                                        sourceField: "issueId"
+                                        predicate: { equals: "ID123" }
+                                    }
+                                }
+                            )
+                        }
+                    """.trimIndent(),
+                ),
+                underlyingSchema = mapOf(
+                    "issues" to """
+                        type Query {
+                            issue: Issue
+                        }
+                        type Issue {
+                            id: ID!
+                            creator: ID!
+                            issueId: ID!
+                        }
+                    """.trimIndent(),
+                    "users" to """
+                        type Query {
+                            user(id: ID!): User
+                        }
+                        type User {
+                            id: ID!
+                            name: String!
+                        }
+                    """.trimIndent(),
+                ),
+            )
+            val errors = validate(fixture)
+            assert(errors.map { it.message }.isEmpty())
+        }
+        it("fails if sourceField is not a value of String, Int, or ID") {
+            val fixture = NadelValidationTestFixture(
+                overallSchema = mapOf(
+                    "issues" to """
+                        type Query {
+                            issue: JiraIssue
+                        }
+                        type JiraIssue @renamed(from: "Issue") {
+                            id: ID!
+                        }
+                    """.trimIndent(),
+                    "users" to """
+                        type Query {
+                            user(id: ID!): User
+                        }
+                        type User {
+                            id: ID!
+                            name: String!
+                        }
+                        extend type JiraIssue {
+                            valid: Boolean
+                            creator: User @hydrated(
+                                service: "users"
+                                field: "user"
+                                arguments: [
+                                    {name: "id", value: "$source.creator"}
+                                ]
+                                when: {
+                                    result: {
+                                        sourceField: "valid"
+                                        predicate: { equals: true }
+                                    }
+                                }
+                            )
+                        }
+                    """.trimIndent(),
+                ),
+                underlyingSchema = mapOf(
+                    "issues" to """
+                        type Query {
+                            issue: Issue
+                        }
+                        type Issue {
+                            id: ID!
+                            creator: ID!
+                            valid: Boolean!
+                        }
+                    """.trimIndent(),
+                    "users" to """
+                        type Query {
+                            user(id: ID!): User
+                        }
+                        type User {
+                            id: ID!
+                            name: String!
+                        }
+                    """.trimIndent(),
+                ),
+            )
+            val errors = validate(fixture)
+            assert(errors.map { it.message }.isNotEmpty())
+
+            val error = errors.assertSingleOfType<WhenConditionSourceFieldNotASimpleType>()
+            assert(error.overallField.name == "creator")
+            assert(error.sourceFieldName == "valid")
+            assert(error.sourceFieldTypeName == "Boolean")
+        }
+        it("equals predicate fails if expected type mismatches with field type") {
+            val fixture = NadelValidationTestFixture(
+                overallSchema = mapOf(
+                    "issues" to """
+                        type Query {
+                            issue: JiraIssue
+                        }
+                        type JiraIssue @renamed(from: "Issue") {
+                            id: ID!
+                        }
+                    """.trimIndent(),
+                    "users" to """
+                        type Query {
+                            user(id: ID!): User
+                        }
+                        type User {
+                            id: ID!
+                            name: String!
+                        }
+                        extend type JiraIssue {
+                            type: String
+                            creator: User @hydrated(
+                                service: "users"
+                                field: "user"
+                                arguments: [
+                                    {name: "id", value: "$source.creator"}
+                                ]
+                                when: {
+                                    result: {
+                                        sourceField: "type"
+                                        predicate: { equals: 123 }
+                                    }
+                                }
+                            )
+                        }
+                    """.trimIndent(),
+                ),
+                underlyingSchema = mapOf(
+                    "issues" to """
+                        type Query {
+                            issue: Issue
+                        }
+                        type Issue {
+                            id: ID!
+                            creator: ID!
+                            type: String!
+                        }
+                    """.trimIndent(),
+                    "users" to """
+                        type Query {
+                            user(id: ID!): User
+                        }
+                        type User {
+                            id: ID!
+                            name: String!
+                        }
+                    """.trimIndent(),
+                ),
+            )
+            val errors = validate(fixture)
+            assert(errors.map { it.message }.isNotEmpty())
+
+            val error = errors.assertSingleOfType<WhenConditionPredicateDoesNotMatchSourceFieldType>()
+            assert(error.overallField.name == "creator")
+            assert(error.sourceFieldName == "type")
+            assert(error.sourceFieldTypeName == "String")
+            assert(error.predicateTypeName == "BigInteger")
+        }
+
+        it("startsWith predicate works on String field") {
+            val fixture = NadelValidationTestFixture(
+                overallSchema = mapOf(
+                    "issues" to """
+                        type Query {
+                            issue: JiraIssue
+                        }
+                        type JiraIssue @renamed(from: "Issue") {
+                            id: ID!
+                        }
+                    """.trimIndent(),
+                    "users" to """
+                        type Query {
+                            user(id: ID!): User
+                        }
+                        type User {
+                            id: ID!
+                            name: String!
+                        }
+                        extend type JiraIssue {
+                            type: String
+                            creator: User @hydrated(
+                                service: "users"
+                                field: "user"
+                                arguments: [
+                                    {name: "id", value: "$source.creator"}
+                                ]
+                                when: {
+                                    result: {
+                                        sourceField: "type"
+                                        predicate: { startsWith: "somePrefix" }
+                                    }
+                                }
+                            )
+                        }
+                    """.trimIndent(),
+                ),
+                underlyingSchema = mapOf(
+                    "issues" to """
+                        type Query {
+                            issue: Issue
+                        }
+                        type Issue {
+                            id: ID!
+                            creator: ID!
+                            type: String!
+                        }
+                    """.trimIndent(),
+                    "users" to """
+                        type Query {
+                            user(id: ID!): User
+                        }
+                        type User {
+                            id: ID!
+                            name: String!
+                        }
+                    """.trimIndent(),
+                ),
+            )
+            val errors = validate(fixture)
+            assert(errors.map { it.message }.isEmpty())
+        }
+        it("startsWith predicate works on ID field") {
+            val fixture = NadelValidationTestFixture(
+                overallSchema = mapOf(
+                    "issues" to """
+                        type Query {
+                            issue: JiraIssue
+                        }
+                        type JiraIssue @renamed(from: "Issue") {
+                            id: ID!
+                        }
+                    """.trimIndent(),
+                    "users" to """
+                        type Query {
+                            user(id: ID!): User
+                        }
+                        type User {
+                            id: ID!
+                            name: String!
+                        }
+                        extend type JiraIssue {
+                            issueID: ID
+                            creator: User @hydrated(
+                                service: "users"
+                                field: "user"
+                                arguments: [
+                                    {name: "id", value: "$source.creator"}
+                                ]
+                                when: {
+                                    result: {
+                                        sourceField: "issueID"
+                                        predicate: { startsWith: "somePrefix" }
+                                    }
+                                }
+                            )
+                        }
+                    """.trimIndent(),
+                ),
+                underlyingSchema = mapOf(
+                    "issues" to """
+                        type Query {
+                            issue: Issue
+                        }
+                        type Issue {
+                            id: ID!
+                            creator: ID!
+                            issueID: ID!
+                        }
+                    """.trimIndent(),
+                    "users" to """
+                        type Query {
+                            user(id: ID!): User
+                        }
+                        type User {
+                            id: ID!
+                            name: String!
+                        }
+                    """.trimIndent(),
+                ),
+            )
+            val errors = validate(fixture)
+            assert(errors.map { it.message }.isEmpty())
+        }
+        it("startsWith predicate fails on non-string field") {
+            val fixture = NadelValidationTestFixture(
+                overallSchema = mapOf(
+                    "issues" to """
+                        type Query {
+                            issue: JiraIssue
+                        }
+                        type JiraIssue @renamed(from: "Issue") {
+                            id: ID!
+                        }
+                    """.trimIndent(),
+                    "users" to """
+                        type Query {
+                            user(id: ID!): User
+                        }
+                        type User {
+                            id: ID!
+                            name: String!
+                        }
+                        extend type JiraIssue {
+                            size: Int
+                            creator: User @hydrated(
+                                service: "users"
+                                field: "user"
+                                arguments: [
+                                    {name: "id", value: "$source.creator"}
+                                ]
+                                when: {
+                                    result: {
+                                        sourceField: "size"
+                                        predicate: { startsWith: "1" }
+                                    }
+                                }
+                            )
+                        }
+                    """.trimIndent(),
+                ),
+                underlyingSchema = mapOf(
+                    "issues" to """
+                        type Query {
+                            issue: Issue
+                        }
+                        type Issue {
+                            id: ID!
+                            creator: ID!
+                            size: Int!
+                        }
+                    """.trimIndent(),
+                    "users" to """
+                        type Query {
+                            user(id: ID!): User
+                        }
+                        type User {
+                            id: ID!
+                            name: String!
+                        }
+                    """.trimIndent(),
+                ),
+            )
+            val errors = validate(fixture)
+            assert(errors.map { it.message }.isNotEmpty())
+
+            val error = errors.assertSingleOfType<WhenConditionPredicateRequiresStringSourceField>()
+            assert(error.overallField.name == "creator")
+            assert(error.sourceFieldName == "size")
+            assert(error.sourceFieldTypeName == "Int")
+            assert(error.predicateType == "startsWith")
+        }
+
+        it("matches predicate works on String field") {
+            val fixture = NadelValidationTestFixture(
+                overallSchema = mapOf(
+                    "issues" to """
+                        type Query {
+                            issue: JiraIssue
+                        }
+                        type JiraIssue @renamed(from: "Issue") {
+                            id: ID!
+                        }
+                    """.trimIndent(),
+                    "users" to """
+                        type Query {
+                            user(id: ID!): User
+                        }
+                        type User {
+                            id: ID!
+                            name: String!
+                        }
+                        extend type JiraIssue {
+                            type: String
+                            creator: User @hydrated(
+                                service: "users"
+                                field: "user"
+                                arguments: [
+                                    {name: "id", value: "$source.creator"}
+                                ]
+                                when: {
+                                    result: {
+                                        sourceField: "type"
+                                        predicate: { matches: "someRegex" }
+                                    }
+                                }
+                            )
+                        }
+                    """.trimIndent(),
+                ),
+                underlyingSchema = mapOf(
+                    "issues" to """
+                        type Query {
+                            issue: Issue
+                        }
+                        type Issue {
+                            id: ID!
+                            creator: ID!
+                            type: String!
+                        }
+                    """.trimIndent(),
+                    "users" to """
+                        type Query {
+                            user(id: ID!): User
+                        }
+                        type User {
+                            id: ID!
+                            name: String!
+                        }
+                    """.trimIndent(),
+                ),
+            )
+            val errors = validate(fixture)
+            assert(errors.map { it.message }.isEmpty())
+        }
+        it("matches predicate works on ID field") {
+            val fixture = NadelValidationTestFixture(
+                overallSchema = mapOf(
+                    "issues" to """
+                        type Query {
+                            issue: JiraIssue
+                        }
+                        type JiraIssue @renamed(from: "Issue") {
+                            id: ID!
+                        }
+                    """.trimIndent(),
+                    "users" to """
+                        type Query {
+                            user(id: ID!): User
+                        }
+                        type User {
+                            id: ID!
+                            name: String!
+                        }
+                        extend type JiraIssue {
+                            issueID: ID
+                            creator: User @hydrated(
+                                service: "users"
+                                field: "user"
+                                arguments: [
+                                    {name: "id", value: "$source.creator"}
+                                ]
+                                when: {
+                                    result: {
+                                        sourceField: "issueID"
+                                        predicate: { matches: "someRegex" }
+                                    }
+                                }
+                            )
+                        }
+                    """.trimIndent(),
+                ),
+                underlyingSchema = mapOf(
+                    "issues" to """
+                        type Query {
+                            issue: Issue
+                        }
+                        type Issue {
+                            id: ID!
+                            creator: ID!
+                            issueID: ID!
+                        }
+                    """.trimIndent(),
+                    "users" to """
+                        type Query {
+                            user(id: ID!): User
+                        }
+                        type User {
+                            id: ID!
+                            name: String!
+                        }
+                    """.trimIndent(),
+                ),
+            )
+            val errors = validate(fixture)
+            assert(errors.map { it.message }.isEmpty())
+        }
+        it("matches predicate fails on non-string field") {
+            val fixture = NadelValidationTestFixture(
+                overallSchema = mapOf(
+                    "issues" to """
+                        type Query {
+                            issue: JiraIssue
+                        }
+                        type JiraIssue @renamed(from: "Issue") {
+                            id: ID!
+                        }
+                    """.trimIndent(),
+                    "users" to """
+                        type Query {
+                            user(id: ID!): User
+                        }
+                        type User {
+                            id: ID!
+                            name: String!
+                        }
+                        extend type JiraIssue {
+                            size: Int
+                            creator: User @hydrated(
+                                service: "users"
+                                field: "user"
+                                arguments: [
+                                    {name: "id", value: "$source.creator"}
+                                ]
+                                when: {
+                                    result: {
+                                        sourceField: "size"
+                                        predicate: { matches: "someRegex" }
+                                    }
+                                }
+                            )
+                        }
+                    """.trimIndent(),
+                ),
+                underlyingSchema = mapOf(
+                    "issues" to """
+                        type Query {
+                            issue: Issue
+                        }
+                        type Issue {
+                            id: ID!
+                            creator: ID!
+                            size: Int!
+                        }
+                    """.trimIndent(),
+                    "users" to """
+                        type Query {
+                            user(id: ID!): User
+                        }
+                        type User {
+                            id: ID!
+                            name: String!
+                        }
+                    """.trimIndent(),
+                ),
+            )
+            val errors = validate(fixture)
+            assert(errors.map { it.message }.isNotEmpty())
+
+            val error = errors.assertSingleOfType<WhenConditionPredicateRequiresStringSourceField>()
+            assert(error.overallField.name == "creator")
+            assert(error.sourceFieldName == "size")
+            assert(error.sourceFieldTypeName == "Int")
+            assert(error.predicateType == "matches")
+        }
+
+    }
+
+})


### PR DESCRIPTION
Please make sure you consider the following:

- [ ] Add tests that use __typename in queries
- [ ] Does this change work with all nadel transformations (rename, type rename, hydration, etc)? Add tests for this.
- [ ] Is it worth using hints for this change in order to be able to enable a percentage rollout?
- [ ] Do we need to add integration tests for this change in the graphql gateway?
- [ ] Do we need a pollinator check for this?
