### PR TITLE
Batch hydration that works per source ID than per source object

### DIFF
--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -48,6 +48,7 @@ tasks.withType<KotlinCompile>().configureEach {
             "-java-parameters",
             "-Xopt-in=kotlin.RequiresOptIn",
             "-Xjvm-default=all",
+            "-Xcontext-receivers",
         )
     }
 }

--- a/lib/src/main/java/graphql/nadel/engine/blueprint/hydration/NadelBatchHydrationMatchStrategy.kt
+++ b/lib/src/main/java/graphql/nadel/engine/blueprint/hydration/NadelBatchHydrationMatchStrategy.kt
@@ -3,8 +3,11 @@ package graphql.nadel.engine.blueprint.hydration
 import graphql.nadel.engine.transform.query.NadelQueryPath
 
 sealed class NadelBatchHydrationMatchStrategy {
-    object MatchIndex : NadelBatchHydrationMatchStrategy()
+    data object MatchIndex : NadelBatchHydrationMatchStrategy()
 
+    /**
+     * todo: this by itself should not be a strategy, use [MatchObjectIdentifiers] instead.
+     */
     data class MatchObjectIdentifier(
         val sourceId: NadelQueryPath,
         // todo should also be NadelQueryPath

--- a/lib/src/main/java/graphql/nadel/engine/transform/NadelDeepRenameTransform.kt
+++ b/lib/src/main/java/graphql/nadel/engine/transform/NadelDeepRenameTransform.kt
@@ -13,7 +13,6 @@ import graphql.nadel.engine.transform.query.NadelQueryPath
 import graphql.nadel.engine.transform.query.NadelQueryTransformer
 import graphql.nadel.engine.transform.result.NadelResultInstruction
 import graphql.nadel.engine.transform.result.NadelResultKey
-import graphql.nadel.engine.transform.result.json.JsonNode
 import graphql.nadel.engine.transform.result.json.JsonNodeExtractor
 import graphql.nadel.engine.transform.result.json.JsonNodes
 import graphql.nadel.engine.util.emptyOrSingle

--- a/lib/src/main/java/graphql/nadel/engine/transform/hydration/NadelHydrationUtil.kt
+++ b/lib/src/main/java/graphql/nadel/engine/transform/hydration/NadelHydrationUtil.kt
@@ -2,6 +2,7 @@ package graphql.nadel.engine.transform.hydration
 
 import graphql.nadel.ServiceExecutionResult
 import graphql.nadel.engine.blueprint.NadelGenericHydrationInstruction
+import graphql.nadel.engine.transform.hydration.batch.NadelResolvedObjectBatch
 import graphql.nadel.engine.transform.result.NadelResultInstruction
 import graphql.nadel.engine.transform.result.json.JsonNode
 import graphql.nadel.engine.transform.result.json.JsonNodeExtractor
@@ -9,6 +10,17 @@ import graphql.nadel.engine.util.emptyOrSingle
 import graphql.nadel.engine.util.toGraphQLError
 
 internal object NadelHydrationUtil {
+    @JvmName("getInstructionsToAddErrors_2")
+    fun getInstructionsToAddErrors(
+        results: List<NadelResolvedObjectBatch>,
+    ): List<NadelResultInstruction> {
+        return results
+            .asSequence()
+            .map(NadelResolvedObjectBatch::result)
+            .flatMap(::sequenceOfInstructionsToAddErrors)
+            .toList()
+    }
+
     fun getInstructionsToAddErrors(
         results: List<ServiceExecutionResult>,
     ): List<NadelResultInstruction> {

--- a/lib/src/main/java/graphql/nadel/engine/transform/hydration/batch/NadelBatchHydrationIndexer.kt
+++ b/lib/src/main/java/graphql/nadel/engine/transform/hydration/batch/NadelBatchHydrationIndexer.kt
@@ -1,0 +1,164 @@
+package graphql.nadel.engine.transform.hydration.batch
+
+import graphql.nadel.engine.blueprint.NadelBatchHydrationFieldInstruction
+import graphql.nadel.engine.blueprint.hydration.NadelBatchHydrationMatchStrategy
+import graphql.nadel.engine.blueprint.hydration.NadelHydrationActorInputDef
+import graphql.nadel.engine.transform.artificial.NadelAliasHelper
+import graphql.nadel.engine.transform.result.json.JsonNode
+import graphql.nadel.engine.transform.result.json.JsonNodeExtractor
+import graphql.nadel.engine.util.AnyIterable
+import graphql.nadel.engine.util.MutableJsonMap
+import graphql.nadel.engine.util.emptyOrSingle
+import graphql.nadel.engine.util.singleOfType
+
+@Suppress("DataClassPrivateConstructor") // Whatever, no matter
+internal data class NadelBatchHydrationIndexKey private constructor(private val key: Any?) {
+    constructor(node: JsonNode?) : this(key = node)
+    constructor(nodes: List<JsonNode?>) : this(key = nodes)
+}
+
+/**
+ * Interface to define a process to index the result objects.
+ */
+internal interface NadelBatchHydrationIndexer {
+    fun getSourceKey(sourceInput: JsonNode): NadelBatchHydrationIndexKey
+
+    fun getIndex(
+        batches: List<NadelResolvedObjectBatch>,
+    ): Map<NadelBatchHydrationIndexKey, JsonNode>
+}
+
+internal class NadelBatchHydrationObjectIdentifiedIndexer(
+    private val aliasHelper: NadelAliasHelper,
+    private val instruction: NadelBatchHydrationFieldInstruction,
+    private val strategy: NadelBatchHydrationMatchStrategy.MatchObjectIdentifiers,
+) : NadelBatchHydrationIndexer {
+    constructor(
+        aliasHelper: NadelAliasHelper,
+        instruction: NadelBatchHydrationFieldInstruction,
+        strategy: NadelBatchHydrationMatchStrategy.MatchObjectIdentifier,
+    ) : this(
+        aliasHelper = aliasHelper,
+        instruction = instruction,
+        strategy = NadelBatchHydrationMatchStrategy.MatchObjectIdentifiers(listOf(strategy)),
+    )
+
+    override fun getSourceKey(sourceInput: JsonNode): NadelBatchHydrationIndexKey {
+        // todo: bake this into the instruction
+        val sourceInputPath = instruction.actorInputValueDefs
+            .asSequence()
+            .map { it.valueSource }
+            .singleOfType<NadelHydrationActorInputDef.ValueSource.FieldResultValue>()
+            .queryPathToField
+
+        return NadelBatchHydrationIndexKey(
+            strategy.objectIds
+                .map { identifiedBy ->
+                    // e.g. sourceInputPath is context.comment
+                    // e.g. identifiedBy.sourceId is context.comment.id
+                    // or
+                    // e.g. sourceInputPath is commentId
+                    // e.g. identifiedBy.sourceId is commentId
+                    if (identifiedBy.sourceId == sourceInputPath) {
+                        sourceInput
+                    } else {
+                        val pathFromSourceInput = identifiedBy.sourceId.drop(
+                            // Counts the common prefix to remove
+                            n = (identifiedBy.sourceId.segments)
+                                .asSequence()
+                                .zip(sourceInputPath.segments.asSequence())
+                                .takeWhile { (a, b) -> a == b }
+                                .count(),
+                        )
+
+                        JsonNodeExtractor.getNodesAt(sourceInput, pathFromSourceInput, flatten = false)
+                            .emptyOrSingle()
+                    }
+                },
+        )
+    }
+
+    override fun getIndex(
+        batches: List<NadelResolvedObjectBatch>,
+    ): Map<NadelBatchHydrationIndexKey, JsonNode> {
+        return batches
+            .asSequence()
+            .flatMap { batch ->
+                JsonNodeExtractor
+                    .getNodesAt(batch.result.data, instruction.queryPathToActorField, flatten = true)
+                    // Ignore nulls in result
+                    .filter {
+                        it.value != null
+                    }
+            }
+            .groupBy { node ->
+                @Suppress("UNCHECKED_CAST")
+                NadelBatchHydrationIndexKey(
+                    strategy.objectIds
+                        .map { objectId ->
+                            val resultKey = aliasHelper.getResultKey(objectId.resultId)
+                            JsonNode((node.value as MutableJsonMap).remove(resultKey))
+                        }
+                )
+            }
+            .mapValues { (_, values) ->
+                // todo: stop doing stupid here
+                values.first()
+            }
+    }
+}
+
+internal class NadelBatchHydrationIndexBasedIndexer(
+    private val instruction: NadelBatchHydrationFieldInstruction,
+) : NadelBatchHydrationIndexer {
+    override fun getSourceKey(sourceInput: JsonNode): NadelBatchHydrationIndexKey {
+        return NadelBatchHydrationIndexKey(sourceInput)
+    }
+
+    override fun getIndex(
+        batches: List<NadelResolvedObjectBatch>,
+    ): Map<NadelBatchHydrationIndexKey, JsonNode> {
+        return batches
+            .flatMap { batch ->
+                val data = JsonNodeExtractor
+                    .getNodesAt(batch.result.data, instruction.queryPathToActorField, flatten = false)
+
+                if (data.emptyOrSingle()?.value == null) {
+                    emptyList()
+                } else {
+                    JsonNodeExtractor
+                        .getNodesAt(batch.result.data, instruction.queryPathToActorField)
+                        .asSequence()
+                        .flatMap {
+                            when (val value = it.value) {
+                                is AnyIterable -> value.asSequence()
+                                else -> sequenceOf(value)
+                            }
+                        }
+                        .map {
+                            JsonNode(it)
+                        }
+                        .toList()
+                        .let { resolvedObjects ->
+                            // Must be 1-1 with inputs
+                            require(resolvedObjects.size == batch.sourceInputs.size) {
+                                "If you use indexed hydration then you MUST follow a contract where the resolved nodes matches the size of the input arguments"
+                            }
+                            batch.sourceInputs.zip(resolvedObjects)
+                        }
+                }
+            }
+            .groupBy(
+                keySelector = { (sourceId, _) ->
+                    NadelBatchHydrationIndexKey(sourceId)
+                },
+                valueTransform = { (_, resolvedObject) ->
+                    resolvedObject
+                },
+            )
+            .mapValues { (_, values) ->
+                // It's possible there are multiple, but there really shouldn't be
+                values.first()
+            }
+    }
+}

--- a/lib/src/main/java/graphql/nadel/engine/transform/hydration/batch/NadelNewBatchHydrator.kt
+++ b/lib/src/main/java/graphql/nadel/engine/transform/hydration/batch/NadelNewBatchHydrator.kt
@@ -1,37 +1,162 @@
 package graphql.nadel.engine.transform.hydration.batch
 
 import graphql.nadel.NextgenEngine
+import graphql.nadel.Service
 import graphql.nadel.ServiceExecutionHydrationDetails
-import graphql.nadel.ServiceExecutionResult
+import graphql.nadel.engine.NadelExecutionContext
 import graphql.nadel.engine.blueprint.NadelBatchHydrationFieldInstruction
 import graphql.nadel.engine.blueprint.NadelOverallExecutionBlueprint
 import graphql.nadel.engine.blueprint.hydration.NadelBatchHydrationMatchStrategy
 import graphql.nadel.engine.blueprint.hydration.NadelHydrationActorInputDef.ValueSource
+import graphql.nadel.engine.transform.GraphQLObjectTypeName
 import graphql.nadel.engine.transform.artificial.NadelAliasHelper
 import graphql.nadel.engine.transform.getInstructionsForNode
 import graphql.nadel.engine.transform.hydration.NadelHydrationFieldsBuilder
+import graphql.nadel.engine.transform.hydration.NadelHydrationUtil.getInstructionsToAddErrors
 import graphql.nadel.engine.transform.hydration.batch.NadelBatchHydrationTransform.State
+import graphql.nadel.engine.transform.hydration.batch.NadelNewBatchHydrator.SourceObjectMetadata
 import graphql.nadel.engine.transform.result.NadelResultInstruction
-import graphql.nadel.engine.transform.result.NadelResultKey
 import graphql.nadel.engine.transform.result.json.JsonNode
 import graphql.nadel.engine.transform.result.json.JsonNodeExtractor
-import graphql.nadel.engine.util.MutableJsonMap
+import graphql.nadel.engine.util.PairList
 import graphql.nadel.engine.util.flatten
 import graphql.nadel.engine.util.getField
 import graphql.nadel.engine.util.isList
 import graphql.nadel.engine.util.makeFieldCoordinates
 import graphql.nadel.engine.util.singleOfType
 import graphql.nadel.engine.util.unwrapNonNull
+import graphql.normalized.ExecutableNormalizedField
 import graphql.schema.FieldCoordinates
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 
+/**
+ * So this class performs batch hydration.
+ *
+ * Some things to consider
+ *
+ * 1. There can be repeated @hydrated instruction, so we need to choose one.
+ * 2. There can be multiple source IDs to hydrate per result object e.g. one issue may have multiple contributors
+ * 3. Each source ID can resolve to a different @hydrated instruction
+ *
+ * So what do we need
+ *
+ * 1. Source object -> Source IDs
+ * 2. Source ID -> @hydrated instruction
+ * 3. Resolved objects need to be indexed
+ *
+ * So let's consider a hydration
+ *
+ * ```graphql
+ * union IssueLink = User | Comment
+ * type Issue {
+ *   key: String!
+ *   linkIds: [IssueLink]
+ *     @hydrated(
+ *       field: "userById"
+ *       arguments: [{name: "ids", value: "$source.linkIds"}]
+ *     )
+ *     @hydrated(
+ *       field: "commentById"
+ *       arguments: [{name: "ids", value: "$source.linkIds"}]
+ *     )
+ * }
+ * ```
+ *
+ * Basically for given issues
+ *
+ * ```json
+ * [
+ *   {
+ *      "key": "GQLGW-6"
+ *      "linkIds": ["user/2", "comment/4"]
+ *   },
+ *   {
+ *      "key": "ZELDA-12"
+ *      "linkIds": ["user/128"]
+ *   },
+ * ]
+ * ```
+ *
+ * We need to create
+ *
+ * 1. Source object -> Source IDs [getSourceObjectsMetadata]
+ * 2. Source IDs to -> Instruction [getInstructionParingForSourceIds]
+ * 3. Resolved objects need to be indexed [indexResults]
+ *
+ * e.g. of [SourceObjectMetadata]
+ *
+ * ```json
+ * [
+ *   {
+ *      "sourceObject": {
+ *         "key": "GQLGW-6"
+ *         "linkIds": ["user/2", "comment/4"]
+ *      }
+ *      "sourceIds": [
+ *          {"user/2": "@hydrated(field: userById)"}
+ *          {"comment/4": "@hydrated(field: commentById)"}
+ *      ]
+ *   }
+ *   {
+ *      "sourceObject": {
+ *         "key": "ZELDA-12"
+ *         "linkIds": ["user/128"]
+ *      }
+ *      "sourceIds": [
+ *          {"user/122": "@hydrated(field: userById)"}
+ *      ]
+ *   }
+ * ]
+ * ```
+ *
+ * e.g. of resolved index
+ *
+ * ```json
+ * {
+ *   "@hydrated(field: userById)": {
+ *      "user/2": {"name": "Franklin"}
+ *      "user/128": {"name": "Steven"}
+ *   }
+ *   "@hydrated(field: commentById)": {
+ *     "comment/4": {"content": "Hello World"}
+ *   }
+ * }
+ * ```
+ *
+ * Then we can loop through [SourceObjectMetadata] and look up the result index e.g.
+ *
+ * ```kotlin
+ * for (sourceObjectMetadata in sourceObjectsMetadata) {
+ *   val values = sourceObjectMetadata
+ *     .sourceIdsPairedWithInstructions
+ *     .map { (sourceId, instruction) ->
+ *       index[instruction][sourceId]
+ *     }
+ * }
+ * ```
+ */
 internal class NadelNewBatchHydrator(
     private val engine: NextgenEngine,
 ) {
-    private data class ObjectIdentifier(
-        val data: Any?,
+    /**
+     * Holds hydration data about a given source object.
+     */
+    private data class SourceObjectMetadata(
+        val sourceObject: JsonNode,
+        val sourceIdsPairedWithInstructions: PairList<JsonNode, NadelBatchHydrationFieldInstruction?>?,
+    )
+
+    private data class BatchHydratorContext(
+        val instructionsByObjectTypeNames: Map<GraphQLObjectTypeName, List<NadelBatchHydrationFieldInstruction>>,
+        val executionContext: NadelExecutionContext,
+        val sourceField: ExecutableNormalizedField,
+        val sourceFieldService: Service,
+        val isSourceInputFieldListOutput: Boolean,
+        val isIndexHydration: Boolean,
+        val aliasHelper: NadelAliasHelper,
+        val executionBlueprint: NadelOverallExecutionBlueprint,
     )
 
     /**
@@ -40,123 +165,180 @@ internal class NadelNewBatchHydrator(
     suspend fun hydrate(
         state: State,
         executionBlueprint: NadelOverallExecutionBlueprint,
-        parentNodes: List<JsonNode>,
+        sourceObjects: List<JsonNode>,
     ): List<NadelResultInstruction> {
-        val parentNodeHydrationSetups = getParentNodeHydrationSetup(
-            state,
-            executionBlueprint,
-            parentNodes,
+        val context = BatchHydratorContext(
+            instructionsByObjectTypeNames = state.instructionsByObjectTypeNames,
+            executionContext = state.executionContext,
+            sourceField = state.hydratedField,
+            sourceFieldService = state.hydratedFieldService,
+            isSourceInputFieldListOutput = isSourceInputFieldListOutput(state.instructionsByObjectTypeNames),
+            isIndexHydration = isIndexBasedHydration(state.instructionsByObjectTypeNames),
+            aliasHelper = state.aliasHelper,
+            executionBlueprint = executionBlueprint,
         )
 
-        val sourceIdsByInstruction = parentNodeHydrationSetups
-            .flatMap {
-                it.sourceIds
-            }
-            .groupBy(
-                keySelector = { (_, instruction) ->
-                    instruction
-                },
-                valueTransform = { (sourceId, _) ->
-                    sourceId
-                },
-            )
+        return with(context) {
+            hydrate(sourceObjects)
+        }
+    }
 
-        val indexedResults = sourceIdsByInstruction
+    context(BatchHydratorContext)
+    suspend fun hydrate(sourceObjects: List<JsonNode>): List<NadelResultInstruction> {
+        val sourceObjectsMetadata = getSourceObjectsMetadata(
+            executionBlueprint = executionBlueprint,
+            parentNodes = sourceObjects,
+        )
+
+        val sourceIdsByInstruction = getSourceIdsByInstruction(sourceObjectsMetadata)
+
+        val resultsByInstruction = sourceIdsByInstruction
             .mapValues { (instruction, sourceIds) ->
-                val results = executeQueries(
-                    state = state,
+                executeQueries(
                     executionBlueprint = executionBlueprint,
                     instruction = instruction,
                     sourceIds = sourceIds,
                 )
-
-                indexResults(state.aliasHelper, instruction, results)
             }
 
-        val isHydratedFieldListOutput = executionBlueprint.engineSchema
-            .getField(
-                makeFieldCoordinates(
-                    typeName = state.hydratedField.objectTypeNames.first(),
-                    fieldName = state.hydratedField.name,
-                )
-            )!!.type.unwrapNonNull().isList
+        val setData = makeSetDataInstructions(
+            sourceObjectsMetadata = sourceObjectsMetadata,
+            resultsByInstruction = resultsByInstruction,
+        )
 
-        return parentNodeHydrationSetups
+        val addErrors = resultsByInstruction
+            .flatMap { (_, results) ->
+                getInstructionsToAddErrors(results)
+            }
+
+        return setData + addErrors
+    }
+
+    context(BatchHydratorContext)
+    private fun makeSetDataInstructions(
+        sourceObjectsMetadata: List<SourceObjectMetadata>,
+        resultsByInstruction: Map<NadelBatchHydrationFieldInstruction, List<NadelResolvedObjectBatch>>,
+    ): List<NadelResultInstruction> {
+        val isHydratedFieldListOutput = isHydratedFieldListOutput()
+
+        val indexedResultsByInstruction = getIndexedResultsByInstruction(resultsByInstruction)
+
+        return sourceObjectsMetadata
             .map { (parentNode, sourceIdsPairedWithInstruction) ->
-                fun extractNode(sourceId: JsonNode, instruction: NadelBatchHydrationFieldInstruction): JsonNode? {
-                    return indexedResults[instruction]!![ObjectIdentifier(sourceId.value)]
-                }
+                NadelResultInstruction.Set(
+                    subject = parentNode,
+                    field = sourceField,
+                    newValue = getHydrationValueForSourceNode(
+                        isHydratedFieldListOutput,
+                        indexedResultsByInstruction,
+                        sourceIdsPairedWithInstruction,
+                    ),
+                )
+            }
+    }
 
-                val value: Any? = if (isHydratedFieldListOutput) {
-                    sourceIdsPairedWithInstruction
-                        .map { (sourceId, instruction) ->
-                            extractNode(sourceId, instruction)?.value
-                        }
+    context(BatchHydratorContext)
+    private fun getHydrationValueForSourceNode(
+        isHydratedFieldListOutput: Boolean,
+        indexedResultsByInstruction: Map<NadelBatchHydrationFieldInstruction, Map<NadelBatchHydrationIndexKey, JsonNode>>,
+        sourceIdsPairedWithInstruction: PairList<JsonNode, NadelBatchHydrationFieldInstruction?>?,
+    ): JsonNode {
+        fun extractNode(sourceId: JsonNode, instruction: NadelBatchHydrationFieldInstruction?): JsonNode? {
+            return if (instruction == null) {
+                null
+            } else {
+                indexedResultsByInstruction[instruction]!![
+                    getIndexer(instruction).getSourceKey(sourceId)
+                ]
+            }
+        }
+
+        return JsonNode(
+            if (isIndexHydration) {
+                if (sourceIdsPairedWithInstruction == null) {
+                    null
+                } else if (isHydratedFieldListOutput) {
+                    if (isSourceInputFieldListOutput) {
+                        sourceIdsPairedWithInstruction
+                            .map { (sourceId, instruction) ->
+                                extractNode(sourceId, instruction)?.value
+                            }
+                    } else {
+                        val (sourceId, instruction) = sourceIdsPairedWithInstruction.single()
+                        extractNode(sourceId, instruction)?.value
+                    }
                 } else {
                     val (sourceId, instruction) = sourceIdsPairedWithInstruction.single()
                     extractNode(sourceId, instruction)?.value
                 }
-
-                NadelResultInstruction.Set(
-                    subject = parentNode,
-                    key = NadelResultKey(state.hydratedField.resultKey),
-                    newValue = JsonNode(value),
-                )
-            }
+            } else {
+                if (sourceIdsPairedWithInstruction == null) {
+                    null
+                } else if (isHydratedFieldListOutput) {
+                    sourceIdsPairedWithInstruction
+                        .map { (sourceId, instruction) ->
+                            extractNode(sourceId, instruction)?.value
+                        }
+                } else if (sourceIdsPairedWithInstruction.isEmpty()) {
+                    emptyList<Any>()
+                } else {
+                    val (sourceId, instruction) = sourceIdsPairedWithInstruction.single()
+                    extractNode(sourceId, instruction)?.value
+                }
+            },
+        )
     }
 
-    private fun indexResults(
-        aliasHelper: NadelAliasHelper,
+    context(BatchHydratorContext)
+    private fun getIndexer(
         instruction: NadelBatchHydrationFieldInstruction,
-        results: List<ServiceExecutionResult>,
-    ): Map<ObjectIdentifier, JsonNode> {
-        return when (val strategy = instruction.batchHydrationMatchStrategy) {
-            is NadelBatchHydrationMatchStrategy.MatchIndex -> {
-                throw UnsupportedOperationException("todo")
-            }
-            is NadelBatchHydrationMatchStrategy.MatchObjectIdentifier -> {
-                results
-                    .flatMap { result ->
-                        JsonNodeExtractor.getNodesAt(result.data, instruction.queryPathToActorField, flatten = true)
-                    }
-                    .groupBy { node ->
-                        @Suppress("UNCHECKED_CAST")
-                        ObjectIdentifier(
-                            // Remove result ID after using it to create this index to stop it showing up in end result
-                            (node.value as MutableJsonMap).remove(aliasHelper.getResultKey(strategy.resultId)),
-                        )
-                    }
-                    .mapValues { (_, values) ->
-                        // todo: stop doing stupid here
-                        values.single()
-                    }
-            }
-            is NadelBatchHydrationMatchStrategy.MatchObjectIdentifiers -> {
-                throw UnsupportedOperationException("todo")
-            }
+    ): NadelBatchHydrationIndexer {
+        return when (val matchStrategy = instruction.batchHydrationMatchStrategy) {
+            is NadelBatchHydrationMatchStrategy.MatchIndex -> NadelBatchHydrationIndexBasedIndexer(
+                instruction = instruction,
+            )
+            is NadelBatchHydrationMatchStrategy.MatchObjectIdentifier -> NadelBatchHydrationObjectIdentifiedIndexer(
+                aliasHelper = aliasHelper,
+                instruction = instruction,
+                strategy = matchStrategy,
+            )
+            is NadelBatchHydrationMatchStrategy.MatchObjectIdentifiers -> NadelBatchHydrationObjectIdentifiedIndexer(
+                aliasHelper = aliasHelper,
+                instruction = instruction,
+                strategy = matchStrategy,
+            )
         }
     }
 
+    context(BatchHydratorContext)
     private suspend fun executeQueries(
-        state: State,
         executionBlueprint: NadelOverallExecutionBlueprint,
         instruction: NadelBatchHydrationFieldInstruction,
         sourceIds: List<JsonNode>,
-    ): List<ServiceExecutionResult> {
+    ): List<NadelResolvedObjectBatch> {
+        val uniqueSourceIds = sourceIds
+            .asSequence()
+            // We don't want to query for null values, we always map those to null
+            .filter {
+                it.value != null
+            }
+            .toSet()
+            .toList()
+
         val argBatches = NadelNewBatchHydrationInputBuilder.getInputValueBatches(
-            hooks = state.executionContext.hooks,
-            userContext = state.executionContext.userContext,
+            hooks = executionContext.hooks,
+            userContext = executionContext.userContext,
             instruction = instruction,
-            hydrationField = state.hydratedField,
-            sourceIds = sourceIds,
+            hydrationField = sourceField,
+            sourceIds = uniqueSourceIds,
         )
 
         val queries = NadelHydrationFieldsBuilder
             .makeBatchActorQueries(
                 executionBlueprint = executionBlueprint,
                 instruction = instruction,
-                aliasHelper = state.aliasHelper,
-                hydratedField = state.hydratedField,
+                aliasHelper = aliasHelper,
+                hydratedField = sourceField,
                 argBatches = argBatches,
             )
 
@@ -174,61 +356,60 @@ internal class NadelNewBatchHydrator(
                             hydrationSourceService = hydrationSourceService,
                             hydrationSourceField = instruction.location,
                             hydrationActorField = hydrationActorField,
-                            fieldPath = state.hydratedField.listOfResultKeys,
+                            fieldPath = sourceField.listOfResultKeys,
                         )
                         engine.executeTopLevelField(
                             service = instruction.actorService,
                             topLevelField = query,
-                            executionContext = state.executionContext,
+                            executionContext = executionContext,
                             serviceHydrationDetails = serviceHydrationDetails,
                         )
                     }
                 }
-        }.awaitAll()
+                .awaitAll()
+                .asSequence()
+                .zip(uniqueSourceIds.asSequence().chunked(instruction.batchSize))
+                .map { (result, sourceIds) ->
+                    NadelResolvedObjectBatch(sourceIds, result)
+                }
+                .toList()
+        }
     }
 
-    private data class ParentNodeHydrationSetup(
-        val parentNode: JsonNode,
-        val sourceIds: List<Pair<JsonNode, NadelBatchHydrationFieldInstruction>>,
-    )
-
-    private fun getParentNodeHydrationSetup(
-        state: State,
+    context(BatchHydratorContext)
+    private fun getSourceObjectsMetadata(
         executionBlueprint: NadelOverallExecutionBlueprint,
         parentNodes: List<JsonNode>,
-    ): List<ParentNodeHydrationSetup> {
+    ): List<SourceObjectMetadata> {
         return parentNodes
             .map { parentNode ->
-                val instructions = state.instructionsByObjectTypeNames.getInstructionsForNode(
+                val instructions = instructionsByObjectTypeNames.getInstructionsForNode(
                     executionBlueprint = executionBlueprint,
-                    service = state.hydratedFieldService,
-                    aliasHelper = state.aliasHelper,
+                    service = sourceFieldService,
+                    aliasHelper = aliasHelper,
                     parentNode = parentNode,
                 )
 
                 val sourceIdsPairedWithInstructions = getInstructionParingForSourceIds(
-                    state = state,
-                    executionBlueprint = executionBlueprint,
                     parentNode = parentNode,
                     instructions = instructions,
                 )
 
-                ParentNodeHydrationSetup(
+                SourceObjectMetadata(
                     parentNode,
                     sourceIdsPairedWithInstructions,
                 )
             }
     }
 
+    context(BatchHydratorContext)
     private fun getInstructionParingForSourceIds(
-        state: State,
-        executionBlueprint: NadelOverallExecutionBlueprint,
         parentNode: JsonNode,
         instructions: List<NadelBatchHydrationFieldInstruction>,
-    ): List<Pair<JsonNode, NadelBatchHydrationFieldInstruction>> {
+    ): PairList<JsonNode, NadelBatchHydrationFieldInstruction?>? {
         val coords = makeFieldCoordinates(
-            typeName = state.hydratedField.objectTypeNames.first(),
-            fieldName = state.hydratedField.name,
+            typeName = sourceField.objectTypeNames.first(),
+            fieldName = sourceField.name,
         )
 
         val fieldSource = instructions
@@ -241,56 +422,152 @@ internal class NadelNewBatchHydrator(
             .singleOfType<ValueSource.FieldResultValue>()
 
         return if (executionBlueprint.engineSchema.getField(coords)!!.type.unwrapNonNull().isList) {
-
-            // todo: move this to validation
-            instructions
-                .forEach { instruction ->
-                    instruction.actorInputValueDefs.single { arg ->
-                        arg.valueSource == fieldSource
-                    }
-                }
-
-            extractValues(parentNode, fieldSource, state.aliasHelper)
-                .map { sourceId ->
-                    // todo: handle null here
-                    val instruction = state.executionContext.hooks.getHydrationInstruction(
+            getSourceInputs(parentNode, fieldSource, aliasHelper, includeNulls = isIndexHydration)
+                ?.map { sourceId ->
+                    val instruction = executionContext.hooks.getHydrationInstruction(
                         instructions = instructions,
                         sourceId = sourceId,
-                        userContext = state.executionContext.userContext,
-                    )!!
+                        userContext = executionContext.userContext,
+                    )
 
                     sourceId to instruction
                 }
         } else {
             // todo: determine what to do here in the longer term, this hook should probably be replaced
-            val instruction = state.executionContext.hooks.getHydrationInstruction(
+            val instruction = executionContext.hooks.getHydrationInstruction(
                 instructions = instructions,
                 parentNode = parentNode,
-                aliasHelper = state.aliasHelper,
-                userContext = state.executionContext.userContext,
-            )!!
+                aliasHelper = aliasHelper,
+                userContext = executionContext.userContext,
+            )
 
-            extractValues(parentNode, fieldSource, state.aliasHelper)
-                .map { sourceId ->
-                    sourceId to instruction
-                }
+            if (instruction == null) {
+                null
+            } else {
+                getSourceInputs(parentNode, fieldSource, aliasHelper, includeNulls = isIndexHydration)
+                    ?.map { sourceId ->
+                        sourceId to instruction
+                    }
+            }
         }
     }
 
-    private fun extractValues(
+    /**
+     * Creates a giant inverted Map of [SourceObjectMetadata.sourceIdsPairedWithInstructions]
+     * where the instruction is the key and the value is the source ID.
+     */
+    private fun getSourceIdsByInstruction(
+        sourceObjects: List<SourceObjectMetadata>,
+    ): Map<NadelBatchHydrationFieldInstruction, List<JsonNode>> {
+        return sourceObjects
+            .asSequence()
+            .flatMap {
+                it.sourceIdsPairedWithInstructions ?: emptyList()
+            }
+            // Removes Pair values where instruction is null
+            .mapNotNull { (sourceId, instruction) ->
+                if (instruction == null) {
+                    null
+                } else {
+                    sourceId to instruction
+                }
+            }
+            .groupBy(
+                // Pair<SourceId, Instruction>
+                keySelector = { (_, instruction) ->
+                    instruction
+                },
+                valueTransform = { (sourceId, _) ->
+                    sourceId
+                },
+            )
+    }
+
+    /**
+     * Gets the source inputs for [parentNode]
+     */
+    private fun getSourceInputs(
         parentNode: JsonNode,
         valueSource: ValueSource.FieldResultValue,
         aliasHelper: NadelAliasHelper,
-    ): List<JsonNode> {
+        includeNulls: Boolean,
+    ): List<JsonNode>? {
         val resultPath = aliasHelper.getQueryPath(valueSource.queryPathToField)
         @Suppress("DEPRECATION") // todo: maybe un-deprecate this or move to new JsonNodes
         return JsonNodeExtractor.getNodesAt(parentNode, resultPath, flatten = true)
+            .also {
+                // Do nothing
+                if (it.isNotEmpty() && it.all { it.value == null }) {
+                    return null
+                }
+            }
             .asSequence()
             .map { it.value }
             .flatten(recursively = true)
+            .let {
+                if (includeNulls) {
+                    it
+                } else {
+                    it.filterNotNull()
+                }
+            }
             .map {
                 JsonNode(it)
             }
             .toList()
+    }
+
+    /**
+     * Store in context itself.
+     */
+    context(BatchHydratorContext)
+    private fun isHydratedFieldListOutput(): Boolean {
+        return executionBlueprint.engineSchema
+            .getField(
+                makeFieldCoordinates(
+                    // In regard to the field output type, the abstract types must all define the same list wrapping
+                    // So here, it does not matter which object type we inspect
+                    typeName = sourceField.objectTypeNames.first(),
+                    fieldName = sourceField.name,
+                )
+            )!!.type.unwrapNonNull().isList
+    }
+
+    context(BatchHydratorContext)
+    private fun getIndexedResultsByInstruction(
+        resultsByInstruction: Map<NadelBatchHydrationFieldInstruction, List<NadelResolvedObjectBatch>>,
+    ): Map<NadelBatchHydrationFieldInstruction, Map<NadelBatchHydrationIndexKey, JsonNode>> {
+        return resultsByInstruction
+            .mapValues { (instruction, results) ->
+                val indexer = getIndexer(instruction)
+
+                indexer.getIndex(results)
+            }
+    }
+
+    private fun isSourceInputFieldListOutput(
+        instructionsByObjectTypeNames: Map<GraphQLObjectTypeName, List<NadelBatchHydrationFieldInstruction>>,
+    ): Boolean {
+        // todo: this assumption feels wrong and instructions aren't likely to be the same
+        return instructionsByObjectTypeNames.values.first()
+            .any { instruction ->
+                instruction.actorInputValueDefs
+                    .asSequence()
+                    .map { it.valueSource }
+                    .filterIsInstance<ValueSource.FieldResultValue>()
+                    .any { fromSourceInputField ->
+                        fromSourceInputField.fieldDefinition.type.unwrapNonNull().isList
+                    }
+            }
+    }
+
+    private fun isIndexBasedHydration(
+        instructionsByObjectTypeNames: Map<GraphQLObjectTypeName, List<NadelBatchHydrationFieldInstruction>>,
+    ): Boolean {
+        // We don't care which instruction it is, if one is index based hydration all of them must be
+        return instructionsByObjectTypeNames.values.first()
+            .any {
+                it.batchHydrationMatchStrategy is NadelBatchHydrationMatchStrategy.MatchIndex
+            }
     }
 }

--- a/lib/src/main/java/graphql/nadel/engine/transform/hydration/batch/NadelResolvedObjectBatch.kt
+++ b/lib/src/main/java/graphql/nadel/engine/transform/hydration/batch/NadelResolvedObjectBatch.kt
@@ -1,0 +1,9 @@
+package graphql.nadel.engine.transform.hydration.batch
+
+import graphql.nadel.ServiceExecutionResult
+import graphql.nadel.engine.transform.result.json.JsonNode
+
+internal data class NadelResolvedObjectBatch(
+    val sourceInputs: List<JsonNode>,
+    val result: ServiceExecutionResult,
+)

--- a/lib/src/main/java/graphql/nadel/engine/transform/hydration/batch/indexing/NadelBatchHydrationIndexBasedIndexer.kt
+++ b/lib/src/main/java/graphql/nadel/engine/transform/hydration/batch/indexing/NadelBatchHydrationIndexBasedIndexer.kt
@@ -1,0 +1,62 @@
+package graphql.nadel.engine.transform.hydration.batch.indexing
+
+import graphql.nadel.engine.blueprint.NadelBatchHydrationFieldInstruction
+import graphql.nadel.engine.transform.hydration.batch.NadelResolvedObjectBatch
+import graphql.nadel.engine.transform.result.json.JsonNode
+import graphql.nadel.engine.transform.result.json.JsonNodeExtractor
+import graphql.nadel.engine.util.AnyIterable
+import graphql.nadel.engine.util.emptyOrSingle
+
+internal class NadelBatchHydrationIndexBasedIndexer(
+    private val instruction: NadelBatchHydrationFieldInstruction,
+) : NadelBatchHydrationIndexer {
+    override fun getSourceKey(sourceInput: JsonNode): NadelBatchHydrationIndexKey {
+        return NadelBatchHydrationIndexKey(sourceInput)
+    }
+
+    override fun getIndex(
+        batches: List<NadelResolvedObjectBatch>,
+    ): Map<NadelBatchHydrationIndexKey, JsonNode> {
+        return batches
+            .flatMap { batch ->
+                val data =
+                    JsonNodeExtractor.getNodesAt(batch.result.data, instruction.queryPathToActorField, flatten = false)
+
+                if (data.emptyOrSingle()?.value == null) {
+                    emptyList()
+                } else {
+                    JsonNodeExtractor.getNodesAt(batch.result.data, instruction.queryPathToActorField)
+                        .asSequence()
+                        .flatMap {
+                            when (val value = it.value) {
+                                is AnyIterable -> value.asSequence()
+                                else -> sequenceOf(value)
+                            }
+                        }
+                        .map {
+                            JsonNode(it)
+                        }
+                        .toList()
+                        .let { resolvedObjects ->
+                            // Must be 1-1 with inputs
+                            require(resolvedObjects.size == batch.sourceInputs.size) {
+                                "If you use indexed hydration then you MUST follow a contract where the resolved nodes matches the size of the input arguments"
+                            }
+                            batch.sourceInputs.zip(resolvedObjects)
+                        }
+                }
+            }
+            .groupBy(
+                keySelector = { (sourceId, _) ->
+                    NadelBatchHydrationIndexKey(sourceId)
+                },
+                valueTransform = { (_, resolvedObject) ->
+                    resolvedObject
+                },
+            )
+            .mapValues { (_, values) ->
+                // It's possible there are multiple, but there really shouldn't be
+                values.first()
+            }
+    }
+}

--- a/lib/src/main/java/graphql/nadel/engine/transform/hydration/batch/indexing/NadelBatchHydrationIndexKey.kt
+++ b/lib/src/main/java/graphql/nadel/engine/transform/hydration/batch/indexing/NadelBatchHydrationIndexKey.kt
@@ -1,0 +1,9 @@
+package graphql.nadel.engine.transform.hydration.batch.indexing
+
+import graphql.nadel.engine.transform.result.json.JsonNode
+
+@Suppress("DataClassPrivateConstructor") // Whatever, no matter
+internal data class NadelBatchHydrationIndexKey private constructor(private val key: Any?) {
+    constructor(node: JsonNode?) : this(key = node)
+    constructor(nodes: List<JsonNode?>) : this(key = nodes)
+}

--- a/lib/src/main/java/graphql/nadel/engine/transform/hydration/batch/indexing/NadelBatchHydrationIndexer.kt
+++ b/lib/src/main/java/graphql/nadel/engine/transform/hydration/batch/indexing/NadelBatchHydrationIndexer.kt
@@ -1,0 +1,15 @@
+package graphql.nadel.engine.transform.hydration.batch.indexing
+
+import graphql.nadel.engine.transform.hydration.batch.NadelResolvedObjectBatch
+import graphql.nadel.engine.transform.result.json.JsonNode
+
+/**
+ * Interface to define a process to index the result objects.
+ */
+internal interface NadelBatchHydrationIndexer {
+    fun getSourceKey(sourceInput: JsonNode): NadelBatchHydrationIndexKey
+
+    fun getIndex(
+        batches: List<NadelResolvedObjectBatch>,
+    ): Map<NadelBatchHydrationIndexKey, JsonNode>
+}

--- a/lib/src/main/java/graphql/nadel/engine/transform/query/NadelQueryPath.kt
+++ b/lib/src/main/java/graphql/nadel/engine/transform/query/NadelQueryPath.kt
@@ -9,6 +9,10 @@ data class NadelQueryPath(val segments: List<String>) {
         return NadelQueryPath(segments + segment)
     }
 
+    fun drop(n: Int): NadelQueryPath {
+        return NadelQueryPath(segments.drop(n))
+    }
+
     fun dropLast(n: Int): NadelQueryPath {
         return NadelQueryPath(segments.dropLast(n))
     }

--- a/lib/src/main/java/graphql/nadel/engine/transform/result/NadelResultInstruction.kt
+++ b/lib/src/main/java/graphql/nadel/engine/transform/result/NadelResultInstruction.kt
@@ -2,6 +2,7 @@ package graphql.nadel.engine.transform.result
 
 import graphql.GraphQLError
 import graphql.nadel.engine.transform.result.json.JsonNode
+import graphql.normalized.ExecutableNormalizedField
 
 // todo: should be a value class one day… can't because of Java interop
 data class NadelResultKey(val value: String)
@@ -11,7 +12,17 @@ sealed class NadelResultInstruction {
         val subject: JsonNode,
         val key: NadelResultKey,
         val newValue: JsonNode?,
-    ) : NadelResultInstruction()
+    ) : NadelResultInstruction() {
+        constructor(
+            subject: JsonNode,
+            field: ExecutableNormalizedField,
+            newValue: JsonNode?,
+        ) : this(
+            subject = subject,
+            key = NadelResultKey(field.resultKey),
+            newValue = newValue,
+        )
+    }
 
     data class Remove(
         val subject: JsonNode,

--- a/lib/src/main/java/graphql/nadel/engine/transform/result/json/JsonNode.kt
+++ b/lib/src/main/java/graphql/nadel/engine/transform/result/json/JsonNode.kt
@@ -12,4 +12,8 @@ data class JsonNode(val value: Any?) {
     init {
         require(value == null || value is AnyMap || value is AnyList || value is Number || value is Boolean || value is String)
     }
+
+    companion object {
+        internal val Null = JsonNode(null)
+    }
 }

--- a/lib/src/main/java/graphql/nadel/engine/util/CollectionUtil.kt
+++ b/lib/src/main/java/graphql/nadel/engine/util/CollectionUtil.kt
@@ -266,3 +266,14 @@ fun <T> Sequence<T>.all(min: Int, predicate: (T) -> Boolean): Boolean {
 
     return count >= min
 }
+
+fun <A, B : Any> Sequence<Pair<A, B?>>.filterPairSecondNotNull(): Sequence<Pair<A, B>> {
+    return mapNotNull { pair ->
+        if (pair.second == null) {
+            null
+        } else {
+            @Suppress("UNCHECKED_CAST")
+            pair as Pair<A, B>
+        }
+    }
+}

--- a/lib/src/main/java/graphql/nadel/engine/util/CollectionUtil.kt
+++ b/lib/src/main/java/graphql/nadel/engine/util/CollectionUtil.kt
@@ -5,6 +5,8 @@ import kotlin.collections.component1
 import kotlin.collections.component2
 import kotlin.collections.set
 
+internal typealias PairList<A, B> = List<Pair<A, B>>
+
 /**
  * Like [singleOrNull] but the single item must be of type [T].
  */

--- a/lib/src/main/java/graphql/nadel/hooks/NadelExecutionHooks.kt
+++ b/lib/src/main/java/graphql/nadel/hooks/NadelExecutionHooks.kt
@@ -56,7 +56,7 @@ interface NadelExecutionHooks {
         sourceId: JsonNode,
         userContext: Any?,
     ): T? {
-        throw UnsupportedOperationException()
+        return instructions.single()
     }
 
     /**

--- a/lib/src/main/java/graphql/nadel/schema/NadelDirectives.kt
+++ b/lib/src/main/java/graphql/nadel/schema/NadelDirectives.kt
@@ -1,6 +1,5 @@
 package graphql.nadel.schema
 
-import graphql.scalars.ExtendedScalars
 import graphql.GraphQLContext
 import graphql.Scalars
 import graphql.Scalars.GraphQLString
@@ -39,6 +38,7 @@ import graphql.nadel.util.onObject
 import graphql.nadel.util.onScalar
 import graphql.nadel.util.onUnion
 import graphql.parser.Parser
+import graphql.scalars.ExtendedScalars
 import graphql.schema.GraphQLAppliedDirective
 import graphql.schema.GraphQLAppliedDirectiveArgument
 import graphql.schema.GraphQLDirectiveContainer

--- a/lib/src/main/java/graphql/nadel/validation/NadelHydrationValidation.kt
+++ b/lib/src/main/java/graphql/nadel/validation/NadelHydrationValidation.kt
@@ -7,7 +7,11 @@ import graphql.nadel.dsl.RemoteArgumentSource.SourceType.FieldArgument
 import graphql.nadel.dsl.RemoteArgumentSource.SourceType.ObjectField
 import graphql.nadel.dsl.RemoteArgumentSource.SourceType.StaticArgument
 import graphql.nadel.dsl.UnderlyingServiceHydration
-import graphql.nadel.engine.util.*
+import graphql.nadel.engine.util.getFieldAt
+import graphql.nadel.engine.util.isList
+import graphql.nadel.engine.util.isNonNull
+import graphql.nadel.engine.util.unwrapAll
+import graphql.nadel.engine.util.unwrapNonNull
 import graphql.nadel.validation.NadelSchemaValidationError.CannotRenameHydratedField
 import graphql.nadel.validation.NadelSchemaValidationError.DuplicatedHydrationArgument
 import graphql.nadel.validation.NadelSchemaValidationError.FieldWithPolymorphicHydrationMustReturnAUnion
@@ -22,9 +26,14 @@ import graphql.nadel.validation.NadelSchemaValidationError.NoSourceArgsInBatchHy
 import graphql.nadel.validation.NadelSchemaValidationError.NonExistentHydrationActorFieldArgument
 import graphql.nadel.validation.util.NadelSchemaUtil.getHydrations
 import graphql.nadel.validation.util.NadelSchemaUtil.hasRename
-import graphql.schema.*
+import graphql.schema.GraphQLFieldDefinition
+import graphql.schema.GraphQLFieldsContainer
+import graphql.schema.GraphQLInterfaceType
+import graphql.schema.GraphQLNamedOutputType
+import graphql.schema.GraphQLSchema
+import graphql.schema.GraphQLUnionType
 import graphql.validation.ValidationUtil
-import java.util.*
+import java.util.Locale
 
 internal class NadelHydrationValidation(
     private val services: Map<String, Service>,

--- a/test/src/test/kotlin/graphql/nadel/tests/EngineTests.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/EngineTests.kt
@@ -260,6 +260,13 @@ private suspend fun execute(
                         builder = builder.executionHints(
                             nadelExecutionHints = testHook
                                 .makeExecutionHints(defaultHints.toBuilder())
+                                .let {
+                                    if (fixture.name.startsWith("new ")) {
+                                        it.newBatchHydrationGrouping { true }
+                                    } else {
+                                        it
+                                    }
+                                }
                                 .build(),
                         ),
                     )

--- a/test/src/test/kotlin/graphql/nadel/tests/ServiceValidationException.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/ServiceValidationException.kt
@@ -2,7 +2,7 @@ package graphql.nadel.tests
 
 import graphql.nadel.validation.NadelSchemaValidationError
 
-data class ValidationException constructor(
+data class ValidationException(
     override val message: String,
     val errors: Set<NadelSchemaValidationError>,
 ) : RuntimeException(message)

--- a/test/src/test/kotlin/graphql/nadel/tests/hooks/batch-hydration-instruction-hook-returns-null.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/hooks/batch-hydration-instruction-hook-returns-null.kt
@@ -1,0 +1,40 @@
+package graphql.nadel.tests.hooks
+
+import graphql.nadel.Nadel
+import graphql.nadel.engine.blueprint.NadelGenericHydrationInstruction
+import graphql.nadel.engine.transform.artificial.NadelAliasHelper
+import graphql.nadel.engine.transform.result.json.JsonNode
+import graphql.nadel.hooks.NadelExecutionHooks
+import graphql.nadel.tests.EngineTestHook
+import graphql.nadel.tests.UseHook
+
+@UseHook
+class `new-batch-hydration-instruction-hook-returns-null` : EngineTestHook {
+    override fun makeNadel(builder: Nadel.Builder): Nadel.Builder {
+        return super.makeNadel(builder)
+            .executionHooks(
+                object : NadelExecutionHooks {
+                    override fun <T : NadelGenericHydrationInstruction> getHydrationInstruction(
+                        instructions: List<T>,
+                        parentNode: JsonNode,
+                        aliasHelper: NadelAliasHelper,
+                        userContext: Any?,
+                    ): Nothing {
+                        throw UnsupportedOperationException("should not run")
+                    }
+
+                    override fun <T : NadelGenericHydrationInstruction> getHydrationInstruction(
+                        instructions: List<T>,
+                        sourceId: JsonNode,
+                        userContext: Any?,
+                    ): T? {
+                        return if (sourceId.value.toString().contains("NULL", ignoreCase = true)) {
+                            null
+                        } else {
+                            instructions.single()
+                        }
+                    }
+                },
+            )
+    }
+}

--- a/test/src/test/kotlin/graphql/nadel/tests/hooks/document-variables-handling.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/hooks/document-variables-handling.kt
@@ -1,5 +1,6 @@
 package graphql.nadel.tests.hooks
 
+import graphql.nadel.NadelExecutionHints
 import graphql.nadel.NadelExecutionInput
 import graphql.nadel.schema.NeverWiringFactory
 import graphql.nadel.tests.EngineTestHook
@@ -45,33 +46,25 @@ class `primitive-json-arguments-variables` : EngineTestHook {
 open class AllDocumentVariablesHintHook : EngineTestHook {
     override val wiringFactory = NeverWiringFactoryWithExtendedJsonScalar()
 
-    override fun makeExecutionInput(
-        builder: NadelExecutionInput.Builder
-    ): NadelExecutionInput.Builder {
-        return builder.transformExecutionHints {
-            it.allDocumentVariablesHint {
+    override fun makeExecutionHints(builder: NadelExecutionHints.Builder): NadelExecutionHints.Builder {
+        return builder
+            .allDocumentVariablesHint {
                 true
             }
-        }
     }
 }
 
 @UseHook
-class `inlined-all-arguments` : AllDocumentVariablesHintHook() {
-}
+class `inlined-all-arguments` : AllDocumentVariablesHintHook()
 
 @UseHook
-class `inlined-all-arguments-with-mixed-literals-and-variables` : AllDocumentVariablesHintHook() {
-}
+class `inlined-all-arguments-with-mixed-literals-and-variables` : AllDocumentVariablesHintHook()
 
 @UseHook
-class `inlined-all-arguments-with-renamed-field` : AllDocumentVariablesHintHook() {
-
-}
-@UseHook
-class `inlined-all-arguments-with-renamed-field-input-is-wrapped-in-a-list` : AllDocumentVariablesHintHook() {
-}
+class `inlined-all-arguments-with-renamed-field` : AllDocumentVariablesHintHook()
 
 @UseHook
-class `complex-identified-by-with-rename` : AllDocumentVariablesHintHook() {
-}
+class `inlined-all-arguments-with-renamed-field-input-is-wrapped-in-a-list` : AllDocumentVariablesHintHook()
+
+@UseHook
+class `complex-identified-by-with-rename` : AllDocumentVariablesHintHook()

--- a/test/src/test/kotlin/graphql/nadel/tests/hooks/new-batching-conditional-hydration-in-abstract-type.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/hooks/new-batching-conditional-hydration-in-abstract-type.kt
@@ -1,0 +1,37 @@
+package graphql.nadel.tests.hooks
+
+import graphql.nadel.Nadel
+import graphql.nadel.NadelExecutionHints
+import graphql.nadel.engine.blueprint.NadelGenericHydrationInstruction
+import graphql.nadel.engine.transform.result.json.JsonNode
+import graphql.nadel.hooks.NadelExecutionHooks
+import graphql.nadel.tests.EngineTestHook
+import graphql.nadel.tests.UseHook
+
+@UseHook
+class `new-batching-conditional-hydration-in-abstract-type` : EngineTestHook {
+    override fun makeExecutionHints(builder: NadelExecutionHints.Builder): NadelExecutionHints.Builder {
+        return super.makeExecutionHints(builder)
+            .newBatchHydrationGrouping { true }
+    }
+
+    override fun makeNadel(builder: Nadel.Builder): Nadel.Builder {
+        return super.makeNadel(builder)
+            .executionHooks(
+                object : NadelExecutionHooks {
+                    override fun <T : NadelGenericHydrationInstruction> getHydrationInstruction(
+                        instructions: List<T>,
+                        sourceId: JsonNode,
+                        userContext: Any?,
+                    ): T {
+                        val type = (sourceId.value as String).substringBefore("/")
+
+                        return instructions
+                            .first {
+                                it.actorFieldDef.name.startsWith(type, ignoreCase = true)
+                            }
+                    }
+                },
+            )
+    }
+}

--- a/test/src/test/kotlin/graphql/nadel/tests/hooks/polymorphic-hydration-hooks.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/hooks/polymorphic-hydration-hooks.kt
@@ -17,9 +17,11 @@ private class PolymorphicHydrationHooks : NadelExecutionHooks {
         aliasHelper: NadelAliasHelper,
         userContext: Any?,
     ): T? {
-        val dataIdFieldName = if (instructions.any { it is NadelHydrationFieldInstruction })
+        val dataIdFieldName = if (instructions.any { it is NadelHydrationFieldInstruction }) {
             "hydration__data__dataId"
-        else "batch_hydration__data__dataId"
+        } else {
+            "batch_hydration__data__dataId"
+        }
 
         val dataIdValue = (parentNode.value as JsonMap)[dataIdFieldName] as String
         val actorFieldName = when {

--- a/test/src/test/resources/fixtures/hydration/complex identified by/complex-input-object-with-indexed-hydration.yml
+++ b/test/src/test/resources/fixtures/hydration/complex identified by/complex-input-object-with-indexed-hydration.yml
@@ -1,6 +1,7 @@
-name: "new complex identified by with indexed hydration"
+name: "complex input object with indexed hydration"
 enabled: true
 overallSchema:
+  # language=GraphQL
   Activity: |
     type Query {
       activities: [Activity]
@@ -15,6 +16,7 @@ overallSchema:
         indexed: true
       )
     }
+  # language=GraphQL
   Issue: |
     type Query {
       issues(issuesInput: IssueInput!): [Issue]
@@ -30,6 +32,7 @@ overallSchema:
       site: ID!
     }
 underlyingSchema:
+  # language=GraphQL
   Activity: |
     type Query {
       activities: [Activity]
@@ -48,6 +51,7 @@ underlyingSchema:
       id: ID!
       site: ID!
     }
+  # language=GraphQL
   Issue: |
     type Query {
       issues(issuesInput: IssueInput!): [Issue]
@@ -62,6 +66,7 @@ underlyingSchema:
       id: ID!
       site: ID!
     }
+# language=GraphQL
 query: |
   query {
     activities {
@@ -76,6 +81,7 @@ variables: { }
 serviceCalls:
   - serviceName: "Activity"
     request:
+      # language=GraphQL
       query: |
         {
           activities {
@@ -145,6 +151,7 @@ serviceCalls:
       }
   - serviceName: "Issue"
     request:
+      # language=GraphQL
       query: |
         {
           issues(issuesInput: [{id : "ISSUE-0", site : "CLOUD-0"}, {id : "ISSUE-1", site : "CLOUD-0"}, {id : "ISSUE-2", site : "CLOUD-0"}, {id : "ISSUE-3", site : "CLOUD-0"}]) {

--- a/test/src/test/resources/fixtures/new hydration/complex identified by/new-complex-identified-by-with-rename.yml
+++ b/test/src/test/resources/fixtures/new hydration/complex identified by/new-complex-identified-by-with-rename.yml
@@ -168,8 +168,6 @@ serviceCalls:
         v0:
           - site: "hello"
             userId: "USER-5"
-          - site: "jdog"
-            userId: "USER-2"
           - site: "hello"
             userId: "USER-2"
     # language=JSON
@@ -182,12 +180,6 @@ serviceCalls:
               "name": "H-Five",
               "batch_hydration__author__id": "USER-5",
               "batch_hydration__author__siteId": "hello"
-            },
-            {
-              "id": "USER-2",
-              "name": "J-Two",
-              "batch_hydration__author__id": "USER-2",
-              "batch_hydration__author__siteId": "jdog"
             },
             {
               "id": "USER-2",

--- a/test/src/test/resources/fixtures/new hydration/complex identified by/new-complex-identified-by.yml
+++ b/test/src/test/resources/fixtures/new hydration/complex identified by/new-complex-identified-by.yml
@@ -155,9 +155,10 @@ serviceCalls:
       }
   - serviceName: "UserService"
     request:
+      # language=GraphQL
       query: |
         query {
-          users(id: [{site : "hello", userId : "USER-5"}, {site : "jdog", userId : "USER-2"}, {site : "hello", userId : "USER-2"}]) {
+          users(id: [{site: "hello", userId: "USER-5"}, {site: "hello", userId: "USER-2"}]) {
             id
             name
             batch_hydration__author__id: id
@@ -178,12 +179,6 @@ serviceCalls:
             },
             {
               "id": "USER-2",
-              "name": "J-Two",
-              "batch_hydration__author__id": "USER-2",
-              "batch_hydration__author__siteId": "jdog"
-            },
-            {
-              "id": "USER-2",
               "name": "H-Two",
               "batch_hydration__author__id": "USER-2",
               "batch_hydration__author__siteId": "hello"
@@ -194,9 +189,10 @@ serviceCalls:
       }
   - serviceName: "UserService"
     request:
+      # language=GraphQL
       query: |
         query {
-          users(id: [{site : "hello", userId : "USER-1"}, {site : "hello", userId : "USER-3"}, {site : "jdog", userId : "USER-2"}, {site : "hello", userId : "USER-4"}]) {
+          users(id: [{site: "hello", userId: "USER-1"}, {site: "hello", userId: "USER-3"}, {site: "jdog", userId: "USER-2"}, {site: "hello", userId: "USER-4"}]) {
             id
             name
             batch_hydration__author__id: id

--- a/test/src/test/resources/fixtures/new hydration/complex identified by/new-complex-input-object-with-indexed-hydration.yml
+++ b/test/src/test/resources/fixtures/new hydration/complex identified by/new-complex-input-object-with-indexed-hydration.yml
@@ -1,0 +1,224 @@
+name: "new complex input object with indexed hydration"
+enabled: true
+overallSchema:
+  # language=GraphQL
+  Activity: |
+    type Query {
+      activities: [Activity]
+    }
+    
+    type Activity {
+      id: ID
+      issue: Issue @hydrated(
+        service: "Issue"
+        field: "issues"
+        arguments: [{name: "issuesInput" value: "$source.context.issueHydrationInput"}]
+        indexed: true
+      )
+    }
+  # language=GraphQL
+  Issue: |
+    type Query {
+      issues(issuesInput: IssueInput!): [Issue]
+    }
+    
+    type Issue {
+      issueId: ID
+      description: String
+    }
+    
+    input IssueInput {
+      id: ID!
+      site: ID!
+    }
+underlyingSchema:
+  # language=GraphQL
+  Activity: |
+    type Query {
+      activities: [Activity]
+    }
+    
+    type Activity {
+      id: ID
+      context: HydrationContext
+    }
+    
+    type HydrationContext {
+      issueHydrationInput: IssueHydrationInput
+    }
+    
+    type IssueHydrationInput {
+      id: ID!
+      site: ID!
+    }
+  # language=GraphQL
+  Issue: |
+    type Query {
+      issues(issuesInput: IssueInput!): [Issue]
+    }
+    
+    type Issue {
+      issueId: ID
+      description: String
+    }
+    
+    input IssueInput {
+      id: ID!
+      site: ID!
+    }
+# language=GraphQL
+query: |
+  query {
+    activities {
+      id
+      issue {
+        issueId
+        description
+      }
+    }
+  }
+variables: { }
+serviceCalls:
+  - serviceName: "Activity"
+    request:
+      # language=GraphQL
+      query: |
+        {
+          activities {
+            __typename__batch_hydration__issue: __typename
+            batch_hydration__issue__context: context {
+              issueHydrationInput {
+                id
+              }
+            }
+            batch_hydration__issue__context: context {
+              issueHydrationInput {
+                site
+              }
+            }
+            id
+          }
+        }
+      variables: { }
+    # language=JSON
+    response: |-
+      {
+        "data": {
+          "activities": [
+            {
+              "__typename__batch_hydration__issue": "Activity",
+              "batch_hydration__issue__context": {
+                "issueHydrationInput": {
+                  "id": "ISSUE-0",
+                  "site": "CLOUD-0"
+                }
+              },
+              "id": "ACTIVITY-0"
+            },
+            {
+              "__typename__batch_hydration__issue": "Activity",
+              "batch_hydration__issue__context": {
+                "issueHydrationInput": {
+                  "id": "ISSUE-1",
+                  "site": "CLOUD-0"
+                }
+              },
+              "id": "ACTIVITY-1"
+            },
+            {
+              "__typename__batch_hydration__issue": "Activity",
+              "batch_hydration__issue__context": {
+                "issueHydrationInput": {
+                  "id": "ISSUE-2",
+                  "site": "CLOUD-0"
+                }
+              },
+              "id": "ACTIVITY-2"
+            },
+            {
+              "__typename__batch_hydration__issue": "Activity",
+              "batch_hydration__issue__context": {
+                "issueHydrationInput": {
+                  "id": "ISSUE-3",
+                  "site": "CLOUD-0"
+                }
+              },
+              "id": "ACTIVITY-3"
+            }
+          ]
+        },
+        "extensions": {}
+      }
+  - serviceName: "Issue"
+    request:
+      # language=GraphQL
+      query: |
+        {
+          issues(issuesInput: [{id: "ISSUE-0", site: "CLOUD-0"}, {id: "ISSUE-1", site: "CLOUD-0"}, {id: "ISSUE-2", site: "CLOUD-0"}, {id: "ISSUE-3", site: "CLOUD-0"}]) {
+            description
+            issueId
+          }
+        }
+      variables: { }
+    # language=JSON
+    response: |-
+      {
+        "data": {
+          "issues": [
+            {
+              "issueId": "ISSUE-0",
+              "description": "fix A"
+            },
+            {
+              "issueId": "ISSUE-1",
+              "description": "fix B"
+            },
+            {
+              "issueId": "ISSUE-2",
+              "description": "fix C"
+            },
+            {
+              "issueId": "ISSUE-3",
+              "description": "fix D"
+            }
+          ]
+        },
+        "extensions": {}
+      }
+# language=JSON
+response: |-
+  {
+    "data": {
+      "activities": [
+        {
+          "id": "ACTIVITY-0",
+          "issue": {
+            "issueId": "ISSUE-0",
+            "description": "fix A"
+          }
+        },
+        {
+          "id": "ACTIVITY-1",
+          "issue": {
+            "issueId": "ISSUE-1",
+            "description": "fix B"
+          }
+        },
+        {
+          "id": "ACTIVITY-2",
+          "issue": {
+            "issueId": "ISSUE-2",
+            "description": "fix C"
+          }
+        },
+        {
+          "id": "ACTIVITY-3",
+          "issue": {
+            "issueId": "ISSUE-3",
+            "description": "fix D"
+          }
+        }
+      ]
+    },
+    "errors": []
+  }

--- a/test/src/test/resources/fixtures/new hydration/index/new-hydration-matching-using-index-one-batch-returns-errors.yml
+++ b/test/src/test/resources/fixtures/new hydration/index/new-hydration-matching-using-index-one-batch-returns-errors.yml
@@ -1,6 +1,7 @@
 name: "new hydration matching using index one batch returns errors"
 enabled: true
 overallSchema:
+  # language=GraphQL
   UserService: |
     type Query {
       usersByIds(ids: [ID]): [User]
@@ -9,6 +10,7 @@ overallSchema:
       id: ID
       name: String
     }
+  # language=GraphQL
   Issues: |
     type Query {
       issues: [Issue]
@@ -18,6 +20,7 @@ overallSchema:
       authors: [User] @hydrated(service: "UserService" field: "usersByIds" arguments: [{name: "ids" value: "$source.authorIds"}] indexed: true batchSize: 2)
     }
 underlyingSchema:
+  # language=GraphQL
   UserService: |
     type Query {
       usersByIds(ids: [ID]): [User]
@@ -26,6 +29,7 @@ underlyingSchema:
       id: ID
       name: String
     }
+  # language=GraphQL
   Issues: |
     type Issue {
       authorIds: [ID]
@@ -34,6 +38,7 @@ underlyingSchema:
     type Query {
       issues: [Issue]
     }
+# language=GraphQL
 query: |
   query {
     issues {
@@ -47,6 +52,7 @@ variables: { }
 serviceCalls:
   - serviceName: "Issues"
     request:
+      # language=GraphQL
       query: |
         query {
           issues {
@@ -90,9 +96,10 @@ serviceCalls:
       }
   - serviceName: "UserService"
     request:
+      # language=GraphQL
       query: |
         query {
-          usersByIds(ids: ["1", "1"]) {
+          usersByIds(ids: ["1", "2"]) {
             name
           }
         }
@@ -103,18 +110,19 @@ serviceCalls:
         "data": {
           "usersByIds": [
             {
-              "name":  "User-1"},
-            {
-              "name":  "User-1"}
+              "name": "User-1"
+            },
+            null
           ]
         },
         "extensions": {}
       }
   - serviceName: "UserService"
     request:
+      # language=GraphQL
       query: |
         query {
-          usersByIds(ids: ["2", "2"]) {
+          usersByIds(ids: ["4"]) {
             name
           }
         }
@@ -130,27 +138,6 @@ serviceCalls:
             "message": "Fail"
           }
         ],
-        "extensions": {}
-      }
-  - serviceName: "UserService"
-    request:
-      query: |
-        query {
-          usersByIds(ids: ["4"]) {
-            name
-          }
-        }
-      variables: { }
-    # language=JSON
-    response: |-
-      {
-        "data": {
-          "usersByIds": [
-            {
-              "name": "User-4"
-            }
-          ]
-        },
         "extensions": {}
       }
 # language=JSON
@@ -179,9 +166,7 @@ response: |-
           "id": "ISSUE-3",
           "authors": [
             null,
-            {
-              "name": "User-4"
-            }
+            null
           ]
         }
       ]

--- a/test/src/test/resources/fixtures/new hydration/index/new-hydration-matching-using-index-result-size-invariant-mismatch.yml
+++ b/test/src/test/resources/fixtures/new hydration/index/new-hydration-matching-using-index-result-size-invariant-mismatch.yml
@@ -1,6 +1,7 @@
 name: "new hydration matching using index result size invariant mismatch"
 enabled: true
 overallSchema:
+  # language=GraphQL
   UserService: |
     type Query {
       usersByIds(ids: [ID]): [User]
@@ -9,6 +10,7 @@ overallSchema:
       id: ID
       name: String
     }
+  # language=GraphQL
   Issues: |
     type Query {
       issues: [Issue]
@@ -18,6 +20,7 @@ overallSchema:
       authors: [User] @hydrated(service: "UserService" field: "usersByIds" arguments: [{name: "ids" value: "$source.authorIds"}] indexed: true batchSize: 5)
     }
 underlyingSchema:
+  # language=GraphQL
   UserService: |
     type Query {
       usersByIds(ids: [ID]): [User]
@@ -27,6 +30,7 @@ underlyingSchema:
       id: ID
       name: String
     }
+  # language=GraphQL
   Issues: |
     type Issue {
       authorIds: [ID]
@@ -36,6 +40,7 @@ underlyingSchema:
     type Query {
       issues: [Issue]
     }
+# language=GraphQL
 query: |
   query {
     issues {
@@ -49,6 +54,7 @@ variables: { }
 serviceCalls:
   - serviceName: "Issues"
     request:
+      # language=GraphQL
       query: |
         query {
           issues {
@@ -84,9 +90,10 @@ serviceCalls:
       }
   - serviceName: "UserService"
     request:
+      # language=GraphQL
       query: |
         query {
-          usersByIds(ids: ["1", "1", "2"]) {
+          usersByIds(ids: ["1", "2"]) {
             name
           }
         }
@@ -98,8 +105,7 @@ serviceCalls:
           "usersByIds": [
             {
               "name": "Name"
-            },
-            null
+            }
           ]
         },
         "extensions": {}

--- a/test/src/test/resources/fixtures/new hydration/index/new-hydration-matching-using-index-returning-errors.yml
+++ b/test/src/test/resources/fixtures/new hydration/index/new-hydration-matching-using-index-returning-errors.yml
@@ -1,6 +1,7 @@
 name: "new hydration matching using index returning errors"
 enabled: true
 overallSchema:
+  # language=GraphQL
   UserService: |
     type Query {
       usersByIds(ids: [ID]): [User]
@@ -9,6 +10,7 @@ overallSchema:
       id: ID
       name: String
     }
+  # language=GraphQL
   Issues: |
     type Query {
       issues: [Issue]
@@ -18,6 +20,7 @@ overallSchema:
       authors: [User] @hydrated(service: "UserService" field: "usersByIds" arguments: [{name: "ids" value: "$source.authorIds"}] indexed: true batchSize: 5)
     }
 underlyingSchema:
+  # language=GraphQL
   UserService: |
     type Query {
       usersByIds(ids: [ID]): [User]
@@ -26,6 +29,7 @@ underlyingSchema:
       id: ID
       name: String
     }
+  # language=GraphQL
   Issues: |
     type Issue {
       authorIds: [ID]
@@ -34,6 +38,7 @@ underlyingSchema:
     type Query {
       issues: [Issue]
     }
+# language=GraphQL
 query: |
   query {
     issues {
@@ -47,6 +52,7 @@ variables: { }
 serviceCalls:
   - serviceName: "Issues"
     request:
+      # language=GraphQL
       query: |
         query {
           issues {
@@ -82,9 +88,10 @@ serviceCalls:
       }
   - serviceName: "UserService"
     request:
+      # language=GraphQL
       query: |
         query {
-          usersByIds(ids: ["1", "1", "2"]) {
+          usersByIds(ids: ["1", "2"]) {
             name
           }
         }

--- a/test/src/test/resources/fixtures/new hydration/index/new-hydration-matching-using-index-returning-null-elements.yml
+++ b/test/src/test/resources/fixtures/new hydration/index/new-hydration-matching-using-index-returning-null-elements.yml
@@ -1,6 +1,7 @@
 name: "new hydration matching using index returning null elements"
 enabled: true
 overallSchema:
+  # language=GraphQL
   UserService: |
     type Query {
       usersByIds(ids: [ID]): [User]
@@ -9,6 +10,7 @@ overallSchema:
       id: ID
       name: String
     }
+  # language=GraphQL
   Issues: |
     type Query {
       issues: [Issue]
@@ -18,6 +20,7 @@ overallSchema:
       authors: [User] @hydrated(service: "UserService" field: "usersByIds" arguments: [{name: "ids" value: "$source.authorIds"}] indexed: true batchSize: 5)
     }
 underlyingSchema:
+  # language=GraphQL
   UserService: |
     type Query {
       usersByIds(ids: [ID]): [User]
@@ -27,6 +30,7 @@ underlyingSchema:
       id: ID
       name: String
     }
+  # language=GraphQL
   Issues: |
     type Issue {
       authorIds: [ID]
@@ -36,6 +40,7 @@ underlyingSchema:
     type Query {
       issues: [Issue]
     }
+# language=GraphQL
 query: |
   query {
     issues {
@@ -86,7 +91,7 @@ serviceCalls:
     request:
       query: |
         query {
-          usersByIds(ids: ["1", "1", "2"]) {
+          usersByIds(ids: ["1", "2"]) {
             name
           }
         }
@@ -96,9 +101,6 @@ serviceCalls:
       {
         "data": {
           "usersByIds": [
-            {
-              "name": "Name"
-            },
             null,
             {
               "name": "Name 2"
@@ -115,9 +117,7 @@ response: |-
         {
           "id": "ISSUE-1",
           "authors": [
-            {
-              "name": "Name"
-            }
+            null
           ]
         },
         {

--- a/test/src/test/resources/fixtures/new hydration/index/new-hydration-matching-using-index-returning-null.yml
+++ b/test/src/test/resources/fixtures/new hydration/index/new-hydration-matching-using-index-returning-null.yml
@@ -1,6 +1,7 @@
 name: "new hydration matching using index returning null"
 enabled: true
 overallSchema:
+  # language=GraphQL
   UserService: |
     type Query {
       usersByIds(ids: [ID]): [User]
@@ -9,6 +10,7 @@ overallSchema:
       id: ID
       name: String
     }
+  # language=GraphQL
   Issues: |
     type Query {
       issues: [Issue]
@@ -18,6 +20,7 @@ overallSchema:
       authors: [User] @hydrated(service: "UserService" field: "usersByIds" arguments: [{name: "ids" value: "$source.authorIds"}] indexed: true batchSize: 5)
     }
 underlyingSchema:
+  # language=GraphQL
   UserService: |
     type Query {
       usersByIds(ids: [ID]): [User]
@@ -26,6 +29,7 @@ underlyingSchema:
       id: ID
       name: String
     }
+  # language=GraphQL
   Issues: |
     type Issue {
       authorIds: [ID]
@@ -34,6 +38,7 @@ underlyingSchema:
     type Query {
       issues: [Issue]
     }
+# language=GraphQL
 query: |
   query {
     issues {
@@ -47,6 +52,7 @@ variables: { }
 serviceCalls:
   - serviceName: "Issues"
     request:
+      # language=GraphQL
       query: |
         query {
           issues {
@@ -82,9 +88,10 @@ serviceCalls:
       }
   - serviceName: "UserService"
     request:
+      # language=GraphQL
       query: |
         query {
-          usersByIds(ids: ["1", "1", "2"]) {
+          usersByIds(ids: ["1", "2"]) {
             name
           }
         }

--- a/test/src/test/resources/fixtures/new hydration/index/new-hydration-matching-using-index-with-lists-with-hydration-field-not-exposed.yml
+++ b/test/src/test/resources/fixtures/new hydration/index/new-hydration-matching-using-index-with-lists-with-hydration-field-not-exposed.yml
@@ -1,6 +1,7 @@
 name: "new hydration matching using index with lists with hydration field not exposed"
 enabled: true
 overallSchema:
+  # language=GraphQL
   UserService: |
     type Query {
       echo: String
@@ -10,6 +11,7 @@ overallSchema:
       id: ID
       name: String
     }
+  # language=GraphQL
   Issues: |
     type Query {
       issues: [Issue]
@@ -19,6 +21,7 @@ overallSchema:
       authors: [User] @hydrated(service: "UserService" field: "usersByIssueIds" arguments: [{name: "issueIds" value: "$source.id"}] indexed: true batchSize: 5)
     }
 underlyingSchema:
+  # language=GraphQL
   UserService: |
     type Query {
       echo: String
@@ -29,6 +32,7 @@ underlyingSchema:
       id: ID
       name: String
     }
+  # language=GraphQL
   Issues: |
     type Issue {
       id: ID
@@ -37,6 +41,7 @@ underlyingSchema:
     type Query {
       issues: [Issue]
     }
+# language=GraphQL
 query: |
   query {
     issues {
@@ -50,6 +55,7 @@ variables: { }
 serviceCalls:
   - serviceName: "Issues"
     request:
+      # language=GraphQL
       query: |
         query {
           issues {

--- a/test/src/test/resources/fixtures/new hydration/index/new-hydration-matching-using-index-with-null-input-nodes.yml
+++ b/test/src/test/resources/fixtures/new hydration/index/new-hydration-matching-using-index-with-null-input-nodes.yml
@@ -1,6 +1,7 @@
 name: "new hydration matching using index with null input nodes"
 enabled: true
 overallSchema:
+  # language=GraphQL
   UserService: |
     type Query {
       usersByIds(ids: [ID]): [User]
@@ -9,6 +10,7 @@ overallSchema:
       id: ID
       name: String
     }
+  # language=GraphQL
   Issues: |
     type Query {
       issues: [Issue]
@@ -18,6 +20,7 @@ overallSchema:
       authors: [User] @hydrated(service: "UserService" field: "usersByIds" arguments: [{name: "ids" value: "$source.authorIds"}] indexed: true batchSize: 5)
     }
 underlyingSchema:
+  # language=GraphQL
   UserService: |
     type Query {
       usersByIds(ids: [ID]): [User]
@@ -27,6 +30,7 @@ underlyingSchema:
       id: ID
       name: String
     }
+  # language=GraphQL
   Issues: |
     type Issue {
       authorIds: [ID]
@@ -36,6 +40,7 @@ underlyingSchema:
     type Query {
       issues: [Issue]
     }
+# language=GraphQL
 query: |
   query {
     issues {
@@ -49,6 +54,7 @@ variables: { }
 serviceCalls:
   - serviceName: "Issues"
     request:
+      # language=GraphQL
       query: |
         query {
           issues {
@@ -84,6 +90,7 @@ serviceCalls:
       }
   - serviceName: "UserService"
     request:
+      # language=GraphQL
       query: |
         query {
           usersByIds(ids: ["1", "2"]) {

--- a/test/src/test/resources/fixtures/new hydration/index/new-hydration-matching-using-index.yml
+++ b/test/src/test/resources/fixtures/new hydration/index/new-hydration-matching-using-index.yml
@@ -86,7 +86,7 @@ serviceCalls:
     request:
       query: |
         query {
-          usersByIds(ids: ["1", "1", "2"]) {
+          usersByIds(ids: ["1", "2"]) {
             name
           }
         }
@@ -96,9 +96,6 @@ serviceCalls:
       {
         "data": {
           "usersByIds": [
-            {
-              "name": "Name"
-            },
             {
               "name": "Name"
             },

--- a/test/src/test/resources/fixtures/new hydration/new batching/new-batching-conditional-hydration-in-abstract-type.yml
+++ b/test/src/test/resources/fixtures/new hydration/new batching/new-batching-conditional-hydration-in-abstract-type.yml
@@ -1,0 +1,307 @@
+name: "new batching conditional hydration in abstract type"
+enabled: true
+overallSchema:
+  # language=GraphQL
+  monolith: |
+    type Query {
+      activity: [IActivity]
+      issuesByIds(ids: [ID!]!): [Issue!]
+      commentsByIds(ids: [ID!]!): [Comment!]
+    }
+    interface IActivity {
+      content: [ActivityContent]
+    }
+    union ActivityContent = Issue | Comment
+    type Activity implements IActivity {
+      id: ID!
+      content: [ActivityContent]
+      @hydrated(
+        service: "monolith"
+        field: "commentsByIds"
+        arguments: [
+          {name: "ids" value: "$source.contentIds"}
+        ]
+      )
+      @hydrated(
+        service: "monolith"
+        field: "issuesByIds"
+        arguments: [
+          {name: "ids" value: "$source.contentIds"}
+        ]
+      )
+    }
+    type SingleActivity implements IActivity {
+      id: ID!
+      content: [ActivityContent]
+      @hydrated(
+        service: "monolith"
+        field: "issuesByIds"
+        arguments: [
+          {name: "ids" value: "$source.contentId"}
+        ]
+      )
+    }
+    type Issue {
+      id: ID!
+      title: String
+    }
+    type Comment {
+      id: ID!
+      content: String
+    }
+underlyingSchema:
+  # language=GraphQL
+  monolith: |
+    type Query {
+      activity: [IActivity]
+      commentsByIds(ids: [ID!]!): [Comment!]
+      issuesByIds(ids: [ID!]!): [Issue!]
+    }
+    interface IActivity {
+      content: [ActivityContent]
+    }
+    union ActivityContent = Issue | Comment
+    type Activity implements IActivity {
+      id: ID!
+      content: [ActivityContent]
+      contentIds: [ID!]
+    }
+    type SingleActivity implements IActivity {
+      id: ID!
+      content: [ActivityContent]
+      contentId: ID!
+    }
+    type Issue {
+      id: ID!
+      title: String
+    }
+    type Comment {
+      id: ID!
+      content: String
+    }
+# language=GraphQL
+query: |
+  {
+    activity {
+      content {
+        __typename
+        ... on Issue {
+          id
+          title
+        }
+        ... on Comment {
+          id
+          content
+        }
+      }
+    }
+  }
+variables: { }
+serviceCalls:
+  - serviceName: "monolith"
+    request:
+      # language=GraphQL
+      query: |
+        {
+          activity {
+            __typename__batch_hydration__content: __typename
+            ... on Activity {
+              batch_hydration__content__contentIds: contentIds
+              batch_hydration__content__contentIds: contentIds
+            }
+            ... on SingleActivity {
+              batch_hydration__content__contentId: contentId
+            }
+          }
+        }
+      variables: { }
+    # language=JSON
+    response: |-
+      {
+        "data": {
+          "activity": [
+            {
+              "__typename__batch_hydration__content": "Activity",
+              "batch_hydration__content__contentIds": [
+                "issue/4000",
+                "comment/5000",
+                "comment/6000"
+              ]
+            },
+            {
+              "__typename__batch_hydration__content": "SingleActivity",
+              "batch_hydration__content__contentId": "issue/8080"
+            },
+            {
+              "__typename__batch_hydration__content": "Activity",
+              "batch_hydration__content__contentIds": [
+                "comment/1234",
+                "comment/9001"
+              ]
+            },
+            {
+              "__typename__batch_hydration__content": "SingleActivity",
+              "batch_hydration__content__contentId": "issue/7496"
+            }
+          ]
+        },
+        "extensions": {}
+      }
+  - serviceName: "monolith"
+    request:
+      # language=GraphQL
+      query: |
+        {
+          issuesByIds(ids: ["issue/4000"]) {
+            __typename
+            id
+            batch_hydration__content__id: id
+            title
+          }
+        }
+      variables: { }
+    # language=JSON
+    response: |-
+      {
+        "data": {
+          "issuesByIds": [
+            {
+              "__typename": "Issue",
+              "id": "issue/4000",
+              "batch_hydration__content__id": "issue/4000",
+              "title": "Four Thousand"
+            }
+          ]
+        },
+        "extensions": {}
+      }
+  - serviceName: "monolith"
+    request:
+      # language=GraphQL
+      query: |
+        {
+          issuesByIds(ids: ["issue/8080", "issue/7496"]) {
+            __typename
+            id
+            batch_hydration__content__id: id
+            title
+          }
+        }
+      variables: { }
+    # language=JSON
+    response: |-
+      {
+        "data": {
+          "issuesByIds": [
+            {
+              "__typename": "Issue",
+              "id": "issue/7496",
+              "batch_hydration__content__id": "issue/7496",
+              "title": "Seven Four Nine Six"
+            }
+          ]
+        },
+        "extensions": {}
+      }
+  - serviceName: "monolith"
+    request:
+      # language=GraphQL
+      query: |
+        {
+          commentsByIds(ids: ["comment/5000", "comment/6000", "comment/1234", "comment/9001"]) {
+            __typename
+            content
+            id
+            batch_hydration__content__id: id
+          }
+        }
+      variables: { }
+    # language=JSON
+    response: |-
+      {
+        "data": {
+          "commentsByIds": [
+            {
+              "__typename": "Comment",
+              "id": "comment/5000",
+              "batch_hydration__content__id": "comment/5000",
+              "content": "Five Thousand"
+            },
+            {
+              "__typename": "Comment",
+              "id": "comment/6000",
+              "batch_hydration__content__id": "comment/6000",
+              "content": "Six Thousand"
+            },
+            {
+              "__typename": "Comment",
+              "id": "comment/9001",
+              "batch_hydration__content__id": "comment/9001",
+              "content": "It's over 9000"
+            },
+            {
+              "__typename": "Comment",
+              "id": "comment/1234",
+              "batch_hydration__content__id": "comment/1234",
+              "content": "One Two Three Four"
+            }
+          ]
+        },
+        "extensions": {}
+      }
+# language=JSON
+response: |
+  {
+    "data": {
+      "activity": [
+        {
+          "content": [
+            {
+              "__typename": "Issue",
+              "id": "issue/4000",
+              "title": "Four Thousand"
+            },
+            {
+              "__typename": "Comment",
+              "id": "comment/5000",
+              "content": "Five Thousand"
+            },
+            {
+              "__typename": "Comment",
+              "id": "comment/6000",
+              "content": "Six Thousand"
+            }
+          ]
+        },
+        {
+          "content": [
+            null
+          ]
+        },
+        {
+          "content": [
+            {
+              "__typename": "Comment",
+              "id": "comment/1234",
+              "content": "One Two Three Four"
+            },
+            {
+              "__typename": "Comment",
+              "id": "comment/9001",
+              "content": "It's over 9000"
+            }
+          ]
+        },
+        {
+          "content": [
+            {
+              "__typename": "Issue",
+              "id": "issue/7496",
+              "title": "Seven Four Nine Six"
+            }
+          ]
+        }
+      ]
+    },
+    "errors": []
+  }

--- a/test/src/test/resources/fixtures/new hydration/new-batch-hydration-instruction-hook-returns-null.yml
+++ b/test/src/test/resources/fixtures/new hydration/new-batch-hydration-instruction-hook-returns-null.yml
@@ -1,0 +1,139 @@
+name: "new batch hydration instruction hook returns null"
+enabled: true
+overallSchema:
+  # language=GraphQL
+  Issues: |
+    type Query {
+      issueById(id: ID!): Issue!
+    }
+    type Issue {
+      id: ID!
+      key: String
+      collaborators: [User]
+        @hydrated(
+          service: "Users"
+          field: "usersByIds"
+          arguments: [
+            {name: "ids", value: "$source.collaboratorIds"}
+          ]
+          identifiedBy: "id"
+        )
+    }
+  # language=GraphQL
+  Users: |
+    type Query {
+      usersByIds(ids: [ID!]!): [User]
+    }
+    type User {
+      id: ID!
+      name: String
+    }
+underlyingSchema:
+  # language=GraphQL
+  Issues: |
+    type Query {
+      issueById(id: ID!): Issue!
+    }
+    type Issue {
+      id: ID!
+      key: String
+      collaboratorIds: [ID]
+    }
+  # language=GraphQL
+  Users: |
+    type Query {
+      usersByIds(ids: [ID!]!): [User]
+    }
+    type User {
+      id: ID!
+      name: String
+    }
+# language=GraphQL
+query: |
+  query {
+    issueById(id: "10000") {
+      key
+      collaborators {
+        __typename
+        name
+      }
+    }
+  }
+variables: { }
+serviceCalls:
+  - serviceName: "Issues"
+    request:
+      # language=GraphQL
+      query: |
+        {
+          issueById(id: "10000") {
+            __typename__batch_hydration__collaborators: __typename
+            batch_hydration__collaborators__collaboratorIds: collaboratorIds
+            key
+          }
+        }
+    # language=JSON
+    response: |
+      {
+        "data": {
+          "issueById": {
+            "__typename__batch_hydration__collaborators": "Issue",
+            "batch_hydration__collaborators__collaboratorIds": [
+              "100",
+              "NULL/1",
+              "200"
+            ],
+            "key": "GQLGW-1000"
+          }
+        }
+      }
+  - serviceName: "Users"
+    request:
+      # language=GraphQL
+      query: |
+        {
+          usersByIds(ids: ["100", "200"]) {
+            __typename
+            batch_hydration__collaborators__id: id
+            name
+          }
+        }
+    # language=JSON
+    response: |
+      {
+        "data": {
+          "usersByIds": [
+            {
+              "__typename": "User",
+              "batch_hydration__collaborators__id": "100",
+              "name": "John Doe"
+            },
+            {
+              "__typename": "User",
+              "batch_hydration__collaborators__id": "200",
+              "name": "Joe"
+            }
+          ]
+        }
+      }
+# language=JSON
+response: |
+  {
+    "data": {
+      "issueById": {
+        "key": "GQLGW-1000",
+        "collaborators": [
+          {
+            "__typename": "User",
+            "name": "John Doe"
+          },
+          null,
+          {
+            "__typename": "User",
+            "name": "Joe"
+          }
+        ]
+      }
+    },
+    "errors": []
+  }

--- a/test/src/test/resources/fixtures/new hydration/new-batched-hydration-from-direct-query-with-a-synthetic-field.yml
+++ b/test/src/test/resources/fixtures/new hydration/new-batched-hydration-from-direct-query-with-a-synthetic-field.yml
@@ -1,6 +1,7 @@
 name: "new batched hydration from direct query with a synthetic field"
 enabled: true
 overallSchema:
+  # language=GraphQL
   service2: |
     type Query {
       users: UsersQuery
@@ -11,6 +12,7 @@ overallSchema:
     type User {
       id: ID
     }
+  # language=GraphQL
   service1: |
     type Query {
       issues: [Issue]
@@ -34,6 +36,7 @@ overallSchema:
       )
     }
 underlyingSchema:
+  # language=GraphQL
   service2: |
     type Query {
       users: UsersQuery
@@ -47,6 +50,7 @@ underlyingSchema:
     type UsersQuery {
       usersByIds(id: [ID]): [User]
     }
+  # language=GraphQL
   service1: |
     type Issue {
       authorIds: [ID]
@@ -56,6 +60,7 @@ underlyingSchema:
     type Query {
       issues: [Issue]
     }
+  # language=GraphQL
 query: |
   query {
     issues {
@@ -69,6 +74,7 @@ variables: { }
 serviceCalls:
   - serviceName: "service1"
     request:
+      # language=GraphQL
       query: |
         query {
           issues {
@@ -113,10 +119,11 @@ serviceCalls:
       }
   - serviceName: "service2"
     request:
+      # language=GraphQL
       query: |
         query {
           users {
-            usersByIds(id: ["USER-2", "USER-4", "USER-5"]) {
+            usersByIds(id: ["USER-4", "USER-5"]) {
               id
               batch_hydration__authors__id: id
             }
@@ -129,10 +136,6 @@ serviceCalls:
         "data": {
           "users": {
             "usersByIds": [
-              {
-                "id": "USER-2",
-                "batch_hydration__authors__id": "USER-2"
-              },
               {
                 "id": "USER-4",
                 "batch_hydration__authors__id": "USER-4"
@@ -148,6 +151,7 @@ serviceCalls:
       }
   - serviceName: "service2"
     request:
+      # language=GraphQL
       query: |
         query {
           users {

--- a/test/src/test/resources/fixtures/new hydration/new-batched-hydration-query-with-a-synthetic-field.yml
+++ b/test/src/test/resources/fixtures/new hydration/new-batched-hydration-query-with-a-synthetic-field.yml
@@ -105,7 +105,7 @@ serviceCalls:
       query: |
         query {
           users {
-            usersByIds(id: ["USER-2", "USER-4", "USER-5"]) {
+            usersByIds(id: ["USER-4", "USER-5"]) {
               id
               batch_hydration__authors__id: id
             }
@@ -118,10 +118,6 @@ serviceCalls:
         "data": {
           "users": {
             "usersByIds": [
-              {
-                "id": "USER-2",
-                "batch_hydration__authors__id": "USER-2"
-              },
               {
                 "id": "USER-4",
                 "batch_hydration__authors__id": "USER-4"

--- a/test/src/test/resources/fixtures/new hydration/new-batched-hydration-with-default-array-argument-values.yml
+++ b/test/src/test/resources/fixtures/new hydration/new-batched-hydration-with-default-array-argument-values.yml
@@ -141,7 +141,7 @@ serviceCalls:
       # language=GraphQL
       query: |
         query {
-          usersByIds(id: ["USER-2", "USER-4", "USER-5"], test: ["Hello", "World"]) {
+          usersByIds(id: ["USER-4", "USER-5"], test: ["Hello", "World"]) {
             id
             batch_hydration__authors__id: id
           }
@@ -152,10 +152,6 @@ serviceCalls:
       {
         "data": {
           "usersByIds": [
-            {
-              "id": "USER-2",
-              "batch_hydration__authors__id": "USER-2"
-            },
             {
               "id": "USER-4",
               "batch_hydration__authors__id": "USER-4"

--- a/test/src/test/resources/fixtures/new hydration/new-batched-hydration-with-default-boolean-argument-values.yml
+++ b/test/src/test/resources/fixtures/new hydration/new-batched-hydration-with-default-boolean-argument-values.yml
@@ -141,7 +141,7 @@ serviceCalls:
       # language=GraphQL
       query: |
         query {
-          usersByIds(id: ["USER-2", "USER-4", "USER-5"], test: true) {
+          usersByIds(id: ["USER-4", "USER-5"], test: true) {
             id
             batch_hydration__authors__id: id
           }
@@ -152,10 +152,6 @@ serviceCalls:
       {
         "data": {
           "usersByIds": [
-            {
-              "id": "USER-2",
-              "batch_hydration__authors__id": "USER-2"
-            },
             {
               "id": "USER-4",
               "batch_hydration__authors__id": "USER-4"

--- a/test/src/test/resources/fixtures/new hydration/new-batched-hydration-with-default-int-argument-values.yml
+++ b/test/src/test/resources/fixtures/new hydration/new-batched-hydration-with-default-int-argument-values.yml
@@ -141,7 +141,7 @@ serviceCalls:
       # language=GraphQL
       query: |
         query {
-          usersByIds(id: ["USER-2", "USER-4", "USER-5"], test: 42) {
+          usersByIds(id: ["USER-4", "USER-5"], test: 42) {
             id
             batch_hydration__authors__id: id
           }
@@ -152,10 +152,6 @@ serviceCalls:
       {
         "data": {
           "usersByIds": [
-            {
-              "id": "USER-2",
-              "batch_hydration__authors__id": "USER-2"
-            },
             {
               "id": "USER-4",
               "batch_hydration__authors__id": "USER-4"

--- a/test/src/test/resources/fixtures/new hydration/new-batched-hydration-with-default-null-argument-values.yml
+++ b/test/src/test/resources/fixtures/new hydration/new-batched-hydration-with-default-null-argument-values.yml
@@ -141,7 +141,7 @@ serviceCalls:
       # language=GraphQL
       query: |
         query {
-          usersByIds(id: ["USER-2", "USER-4", "USER-5"], test: null) {
+          usersByIds(id: ["USER-4", "USER-5"], test: null) {
             id
             batch_hydration__authors__id: id
           }
@@ -152,10 +152,6 @@ serviceCalls:
       {
         "data": {
           "usersByIds": [
-            {
-              "id": "USER-2",
-              "batch_hydration__authors__id": "USER-2"
-            },
             {
               "id": "USER-4",
               "batch_hydration__authors__id": "USER-4"

--- a/test/src/test/resources/fixtures/new hydration/new-batched-hydration-with-default-object-argument-values.yml
+++ b/test/src/test/resources/fixtures/new hydration/new-batched-hydration-with-default-object-argument-values.yml
@@ -155,7 +155,7 @@ serviceCalls:
       # language=GraphQL
       query: |
         query {
-          usersByIds(id: ["USER-2", "USER-4", "USER-5"], test: {echo: "Hello World"}) {
+          usersByIds(id: ["USER-4", "USER-5"], test: {echo: "Hello World"}) {
             id
             batch_hydration__authors__id: id
           }
@@ -166,10 +166,6 @@ serviceCalls:
       {
         "data": {
           "usersByIds": [
-            {
-              "id": "USER-2",
-              "batch_hydration__authors__id": "USER-2"
-            },
             {
               "id": "USER-4",
               "batch_hydration__authors__id": "USER-4"

--- a/test/src/test/resources/fixtures/new hydration/new-batched-hydration-with-default-string-argument-values.yml
+++ b/test/src/test/resources/fixtures/new hydration/new-batched-hydration-with-default-string-argument-values.yml
@@ -141,7 +141,7 @@ serviceCalls:
       # language=GraphQL
       query: |
         query {
-          usersByIds(id: ["USER-2", "USER-4", "USER-5"], test: "Hello World") {
+          usersByIds(id: ["USER-4", "USER-5"], test: "Hello World") {
             id
             batch_hydration__authors__id: id
           }
@@ -152,10 +152,6 @@ serviceCalls:
       {
         "data": {
           "usersByIds": [
-            {
-              "id": "USER-2",
-              "batch_hydration__authors__id": "USER-2"
-            },
             {
               "id": "USER-4",
               "batch_hydration__authors__id": "USER-4"

--- a/test/src/test/resources/fixtures/new hydration/new-batched-with-null-value-in-source-array.yml
+++ b/test/src/test/resources/fixtures/new hydration/new-batched-with-null-value-in-source-array.yml
@@ -1,0 +1,138 @@
+name: new batched with null value in source array
+enabled: true
+overallSchema:
+  # language=GraphQL
+  Issues: |
+    type Query {
+      issueById(id: ID!): Issue!
+    }
+    type Issue {
+      id: ID!
+      key: String
+      collaborators: [User]
+        @hydrated(
+          service: "Users"
+          field: "usersByIds"
+          arguments: [
+            {name: "ids", value: "$source.collaboratorIds"}
+          ]
+          identifiedBy: "id"
+        )
+    }
+  # language=GraphQL
+  Users: |
+    type Query {
+      usersByIds(ids: [ID!]!): [User]
+    }
+    type User {
+      id: ID!
+      name: String
+    }
+underlyingSchema:
+  # language=GraphQL
+  Issues: |
+    type Query {
+      issueById(id: ID!): Issue!
+    }
+    type Issue {
+      id: ID!
+      key: String
+      collaboratorIds: [ID]
+    }
+  # language=GraphQL
+  Users: |
+    type Query {
+      usersByIds(ids: [ID!]!): [User]
+    }
+    type User {
+      id: ID!
+      name: String
+    }
+# language=GraphQL
+query: |
+  query {
+    issueById(id: "10000") {
+      key
+      collaborators {
+        __typename
+        name
+      }
+    }
+  }
+variables: { }
+serviceCalls:
+  - serviceName: "Issues"
+    request:
+      # language=GraphQL
+      query: |
+        {
+          issueById(id: "10000") {
+            __typename__batch_hydration__collaborators: __typename
+            batch_hydration__collaborators__collaboratorIds: collaboratorIds
+            key
+          }
+        }
+    # language=JSON
+    response: |
+      {
+        "data": {
+          "issueById": {
+            "__typename__batch_hydration__collaborators": "Issue",
+            "batch_hydration__collaborators__collaboratorIds": [
+              "100",
+              null,
+              "200"
+            ],
+            "key": "GQLGW-1000"
+          }
+        }
+      }
+  - serviceName: "Users"
+    request:
+      # language=GraphQL
+      query: |
+        {
+          usersByIds(ids: ["100", "200"]) {
+            __typename
+            batch_hydration__collaborators__id: id
+            name
+          }
+        }
+    # language=JSON
+    response: |
+      {
+        "data": {
+          "usersByIds": [
+            {
+              "__typename": "User",
+              "batch_hydration__collaborators__id": "100",
+              "name": "John Doe"
+            },
+            {
+              "__typename": "User",
+              "batch_hydration__collaborators__id": "200",
+              "name": "Joe"
+            }
+          ]
+        }
+      }
+# language=JSON
+response: |
+  {
+    "data": {
+      "issueById": {
+        "key": "GQLGW-1000",
+        "collaborators": [
+          {
+            "__typename": "User",
+            "name": "John Doe"
+          },
+          {
+            "__typename": "User",
+            "name": "Joe"
+          }
+        ]
+      }
+    },
+    "errors": []
+  }

--- a/test/src/test/resources/fixtures/new hydration/new-batching-of-hydration-list-with-flattened-arguments.yml
+++ b/test/src/test/resources/fixtures/new hydration/new-batching-of-hydration-list-with-flattened-arguments.yml
@@ -143,7 +143,7 @@ serviceCalls:
     request:
       query: |
         query {
-          usersByIds(id: ["USER-2", "USER-4", "USER-5"]) {
+          usersByIds(id: ["USER-4", "USER-5"]) {
             id
             batch_hydration__authors__id: id
           }
@@ -154,10 +154,6 @@ serviceCalls:
       {
         "data": {
           "usersByIds": [
-            {
-              "id": "USER-2",
-              "batch_hydration__authors__id": "USER-2"
-            },
             {
               "id": "USER-4",
               "batch_hydration__authors__id": "USER-4"

--- a/test/src/test/resources/fixtures/new hydration/new-batching-of-hydration-list.yml
+++ b/test/src/test/resources/fixtures/new hydration/new-batching-of-hydration-list.yml
@@ -124,7 +124,7 @@ serviceCalls:
     request:
       query: |
         query {
-          usersByIds(id: ["USER-2", "USER-4", "USER-5"]) {
+          usersByIds(id: ["USER-4", "USER-5"]) {
             id
             batch_hydration__authors__id: id
           }
@@ -135,10 +135,6 @@ serviceCalls:
       {
         "data": {
           "usersByIds": [
-            {
-              "id": "USER-2",
-              "batch_hydration__authors__id": "USER-2"
-            },
             {
               "id": "USER-4",
               "batch_hydration__authors__id": "USER-4"

--- a/test/src/test/resources/fixtures/new hydration/new-hydration-call-over-itself-with-renamed-types.yml
+++ b/test/src/test/resources/fixtures/new hydration/new-hydration-call-over-itself-with-renamed-types.yml
@@ -107,7 +107,7 @@ serviceCalls:
     request:
       query: |
         query {
-          characters(ids: ["C2", "C3"]) {
+          characters(ids: ["C1", "C2", "C3"]) {
             id
             batch_hydration__characters__id: id
             name
@@ -119,6 +119,11 @@ serviceCalls:
       {
         "data": {
           "characters": [
+            {
+              "name": "Luke",
+              "batch_hydration__characters__id": "C1",
+              "id": "C1"
+            },
             {
               "name": "Leia",
               "batch_hydration__characters__id": "C2",
@@ -128,41 +133,6 @@ serviceCalls:
               "name": "Anakin",
               "batch_hydration__characters__id": "C3",
               "id": "C3"
-            }
-          ]
-        },
-        "extensions": {}
-      }
-  - serviceName: "testing"
-    request:
-      query: |
-        query {
-          characters(ids: ["C1", "C2", "C1"]) {
-            id
-            batch_hydration__characters__id: id
-            name
-          }
-        }
-      variables: { }
-    # language=JSON
-    response: |-
-      {
-        "data": {
-          "characters": [
-            {
-              "name": "Luke",
-              "batch_hydration__characters__id": "C1",
-              "id": "C1"
-            },
-            {
-              "name": "Leia",
-              "batch_hydration__characters__id": "C2",
-              "id": "C2"
-            },
-            {
-              "name": "Luke",
-              "batch_hydration__characters__id": "C1",
-              "id": "C1"
             }
           ]
         },

--- a/test/src/test/resources/fixtures/new hydration/new-index-hydration-all-null-ids.yml
+++ b/test/src/test/resources/fixtures/new hydration/new-index-hydration-all-null-ids.yml
@@ -1,0 +1,100 @@
+name: "new index hydration all null ids"
+enabled: true
+overallSchema:
+  # language=GraphQL
+  Issues: |
+    type Query {
+      issueById(id: ID!): Issue!
+    }
+    type Issue {
+      id: ID!
+      key: String
+      collaborators: [User]
+        @hydrated(
+          service: "Users"
+          field: "usersByIds"
+          arguments: [
+            {name: "ids", value: "$source.collaboratorIds"}
+          ]
+          identifiedBy: "id"
+          indexed: true
+        )
+    }
+  # language=GraphQL
+  Users: |
+    type Query {
+      usersByIds(ids: [ID!]!): [User]
+    }
+    type User {
+      id: ID!
+      name: String
+    }
+underlyingSchema:
+  # language=GraphQL
+  Issues: |
+    type Query {
+      issueById(id: ID!): Issue!
+    }
+    type Issue {
+      id: ID!
+      key: String
+      collaboratorIds: [ID]
+    }
+  # language=GraphQL
+  Users: |
+    type Query {
+      usersByIds(ids: [ID!]!): [User]
+    }
+    type User {
+      id: ID!
+      name: String
+    }
+# language=GraphQL
+query: |
+  query {
+    issueById(id: "10000") {
+      key
+      collaborators {
+        __typename
+        name
+      }
+    }
+  }
+variables: { }
+serviceCalls:
+  - serviceName: "Issues"
+    request:
+      # language=GraphQL
+      query: |
+        {
+          issueById(id: "10000") {
+            __typename__batch_hydration__collaborators: __typename
+            batch_hydration__collaborators__collaboratorIds: collaboratorIds
+            key
+          }
+        }
+    # language=JSON
+    response: |
+      {
+        "data": {
+          "issueById": {
+            "__typename__batch_hydration__collaborators": "Issue",
+            "batch_hydration__collaborators__collaboratorIds": [
+              null,
+              null
+            ],
+            "key": "GQLGW-1000"
+          }
+        }
+      }
+# language=JSON
+response: |
+  {
+    "data": {
+      "issueById": {
+        "key": "GQLGW-1000",
+        "collaborators": null
+      }
+    },
+    "errors": []
+  }

--- a/test/src/test/resources/fixtures/new hydration/new-synthetic-hydration-call-over-itself-within-renamed-types.yml
+++ b/test/src/test/resources/fixtures/new hydration/new-synthetic-hydration-call-over-itself-within-renamed-types.yml
@@ -1,6 +1,7 @@
 name: "new synthetic hydration call over itself within renamed types"
 enabled: true
 overallSchema:
+  # language=GraphQL
   testing: |
     type Query {
       tests: TestQuery
@@ -22,6 +23,7 @@ overallSchema:
       characters: [TestingCharacter] @hydrated(service: "testing" field: "tests.characters" arguments: [{name: "ids" value: "$source.characterIds"}] identifiedBy: "id" batchSize: 3)
     }
 underlyingSchema:
+  # language=GraphQL
   testing: |
     type Character {
       id: ID!
@@ -46,6 +48,7 @@ underlyingSchema:
     type Testing {
       movies: [Movie]
     }
+# language=GraphQL
 query: |
   query {
     tests {
@@ -65,6 +68,7 @@ variables: { }
 serviceCalls:
   - serviceName: "testing"
     request:
+      # language=GraphQL
       query: |
         query {
           tests {
@@ -113,10 +117,11 @@ serviceCalls:
       }
   - serviceName: "testing"
     request:
+      # language=GraphQL
       query: |
         query {
           tests {
-            characters(ids: ["C2", "C3"]) {
+            characters(ids: ["C1", "C2", "C3"]) {
               id
               batch_hydration__characters__id: id
               name
@@ -130,6 +135,11 @@ serviceCalls:
         "data": {
           "tests": {
             "characters": [
+              {
+                "name": "Luke",
+                "batch_hydration__characters__id": "C1",
+                "id": "C1"
+              },
               {
                 "name": "Leia",
                 "batch_hydration__characters__id": "C2",
@@ -139,45 +149,6 @@ serviceCalls:
                 "name": "Anakin",
                 "batch_hydration__characters__id": "C3",
                 "id": "C3"
-              }
-            ]
-          }
-        },
-        "extensions": {}
-      }
-  - serviceName: "testing"
-    request:
-      query: |
-        query {
-          tests {
-            characters(ids: ["C1", "C2", "C1"]) {
-              id
-              batch_hydration__characters__id: id
-              name
-            }
-          }
-        }
-      variables: { }
-    # language=JSON
-    response: |-
-      {
-        "data": {
-          "tests": {
-            "characters": [
-              {
-                "name": "Luke",
-                "batch_hydration__characters__id": "C1",
-                "id": "C1"
-              },
-              {
-                "name": "Leia",
-                "batch_hydration__characters__id": "C2",
-                "id": "C2"
-              },
-              {
-                "name": "Luke",
-                "batch_hydration__characters__id": "C1",
-                "id": "C1"
               }
             ]
           }

--- a/test/src/test/resources/fixtures/new hydration/new-top-level-field-data-returns-null-in-batched-synthetic-hydration.yml
+++ b/test/src/test/resources/fixtures/new hydration/new-top-level-field-data-returns-null-in-batched-synthetic-hydration.yml
@@ -1,6 +1,7 @@
 name: "new top level field data returns null in batched synthetic hydration"
 enabled: true
 overallSchema:
+  # language=GraphQL
   service2: |
     type Query {
       users: UsersQuery
@@ -12,6 +13,7 @@ overallSchema:
       id: ID
       name: String
     }
+  # language=GraphQL
   service1: |
     type Query {
       issues: [Issue]
@@ -21,6 +23,7 @@ overallSchema:
       authors: [User] @hydrated(service: "service2" field: "users.usersByIds" arguments: [{name: "id" value: "$source.authorIds"}] identifiedBy: "id" batchSize: 3)
     }
 underlyingSchema:
+  # language=GraphQL
   service2: |
     type Query {
       users: UsersQuery
@@ -34,6 +37,7 @@ underlyingSchema:
     type UsersQuery {
       usersByIds(id: [ID]): [User]
     }
+  # language=GraphQL
   service1: |
     type Issue {
       authorIds: [ID]
@@ -43,6 +47,7 @@ underlyingSchema:
     type Query {
       issues: [Issue]
     }
+# language=GraphQL
 query: |
   query {
     issues {
@@ -56,6 +61,7 @@ variables: { }
 serviceCalls:
   - serviceName: "service1"
     request:
+      # language=GraphQL
       query: |
         query {
           issues {
@@ -100,10 +106,11 @@ serviceCalls:
       }
   - serviceName: "service2"
     request:
+      # language=GraphQL
       query: |
         query {
           users {
-            usersByIds(id: ["USER-2", "USER-4", "USER-5"]) {
+            usersByIds(id: ["USER-4", "USER-5"]) {
               id
               batch_hydration__authors__id: id
             }
@@ -122,6 +129,7 @@ serviceCalls:
       }
   - serviceName: "service2"
     request:
+      # language=GraphQL
       query: |
         query {
           users {

--- a/test/src/test/resources/fixtures/new hydration/new-top-level-field-is-null-in-batched-synthetic-hydration.yml
+++ b/test/src/test/resources/fixtures/new hydration/new-top-level-field-is-null-in-batched-synthetic-hydration.yml
@@ -122,7 +122,7 @@ serviceCalls:
       query: |
         query {
           users {
-            usersByIds(id: ["USER-2", "USER-4", "USER-5"]) {
+            usersByIds(id: ["USER-4", "USER-5"]) {
               id
               batch_hydration__authors__id: id
             }

--- a/test/src/test/resources/fixtures/new hydration/polymorphic hydrations/new-batch-polymorphic-hydration-when-hook-returns-null.yml
+++ b/test/src/test/resources/fixtures/new hydration/polymorphic hydrations/new-batch-polymorphic-hydration-when-hook-returns-null.yml
@@ -1,6 +1,7 @@
 name: "new batch polymorphic hydration when hook returns null"
 enabled: true
 overallSchema:
+  # language=GraphQL
   pets: |
     type Query {
       petById(ids: [ID]): [Pet]
@@ -10,6 +11,7 @@ overallSchema:
       id: ID
       breed: String
     }
+  # language=GraphQL
   people: |
     type Query {
       humanById(ids: [ID]): [Human]
@@ -19,6 +21,7 @@ overallSchema:
       id: ID
       name: String
     }
+  # language=GraphQL
   foo: |
     type Query {
       foo: [Foo]
@@ -46,6 +49,7 @@ overallSchema:
 
     union Data = Pet | Human
 underlyingSchema:
+  # language=GraphQL
   pets: |
     type Query {
       petById(ids: [ID]): [Pet]
@@ -55,6 +59,7 @@ underlyingSchema:
       id: ID
       breed: String
     }
+  # language=GraphQL
   people: |
     type Query {
       humanById(ids: [ID]): [Human]
@@ -64,6 +69,7 @@ underlyingSchema:
       id: ID
       name: String
     }
+  # language=GraphQL
   foo: |
     type Query {
       foo: [Foo]
@@ -73,6 +79,7 @@ underlyingSchema:
       id: ID
       dataId: ID
     }
+# language=GraphQL
 query: |
   query {
     foo {
@@ -96,6 +103,7 @@ variables: { }
 serviceCalls:
   - serviceName: "foo"
     request:
+      # language=GraphQL
       query: |
         query {
           foo {
@@ -116,13 +124,11 @@ serviceCalls:
               "__typename": "Foo",
               "__typename__batch_hydration__data": "Foo",
               "batch_hydration__data__dataId": "NULL-0",
-              "batch_hydration__data__dataId": "NULL-0",
               "id": "FOO-0"
             },
             {
               "__typename": "Foo",
               "__typename__batch_hydration__data": "Foo",
-              "batch_hydration__data__dataId": "HUMAN-0",
               "batch_hydration__data__dataId": "HUMAN-0",
               "id": "FOO-1"
             },
@@ -130,13 +136,11 @@ serviceCalls:
               "__typename": "Foo",
               "__typename__batch_hydration__data": "Foo",
               "batch_hydration__data__dataId": "NULL-1",
-              "batch_hydration__data__dataId": "NULL-1",
               "id": "FOO-2"
             },
             {
               "__typename": "Foo",
               "__typename__batch_hydration__data": "Foo",
-              "batch_hydration__data__dataId": "HUMAN-1",
               "batch_hydration__data__dataId": "HUMAN-1",
               "id": "FOO-3"
             } ]
@@ -145,6 +149,7 @@ serviceCalls:
       }
   - serviceName: "people"
     request:
+      # language=GraphQL
       query: |
         query {
           humanById(ids: ["HUMAN-0", "HUMAN-1"]) {
@@ -183,7 +188,7 @@ response: |-
         {
           "__typename": "Foo",
           "id": "FOO-0",
-          "data" : null
+          "data": null
         },
         {
           "__typename": "Foo",
@@ -197,7 +202,7 @@ response: |-
         {
           "__typename": "Foo",
           "id": "FOO-2",
-          "data" : null
+          "data": null
         },
         {
           "__typename": "Foo",
@@ -207,7 +212,8 @@ response: |-
             "id": "HUMAN-1",
             "name": "John Doe"
           }
-        }]
+        }
+      ]
     },
     "extensions": {}
   }


### PR DESCRIPTION
Please make sure you consider the following:

- [ ] Add tests that use __typename in queries
- [ ] Does this change work with all nadel transformations (rename, type rename, hydration, etc)? Add tests for this.
- [ ] Is it worth using hints for this change in order to be able to enable a percentage rollout?
- [ ] Do we need to add integration tests for this change in the graphql gateway?
- [ ] Do we need a pollinator check for this?
