### PR TITLE
Update to latest graphql-java build version

### DIFF
--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
     id("com.bnorm.power.kotlin-power-assert")
 }
 
-val graphqlJavaVersion = "0.0.0-2023-10-30T22-58-00-448780b"
+val graphqlJavaVersion = "0.0.0-2023-12-05T22-54-46-39d2155"
 val slf4jVersion = "1.7.25"
 
 dependencies {


### PR DESCRIPTION
This pulls in a version of graphql-java that contains all the `@oneOf` fixes