### PR TITLE
[WIP] Pull in graphql-java version with @defer support and add some tests

### DIFF
--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
     id("com.bnorm.power.kotlin-power-assert")
 }
 
-val graphqlJavaVersion = "0.0.0-2023-10-30T22-58-00-448780b"
+val graphqlJavaVersion = "0.0.0-defer-support-in-enf-SNAPSHOT"
 val slf4jVersion = "1.7.25"
 
 dependencies {

--- a/lib/src/main/java/graphql/nadel/NadelExecutionHints.kt
+++ b/lib/src/main/java/graphql/nadel/NadelExecutionHints.kt
@@ -1,6 +1,7 @@
 package graphql.nadel
 
 import graphql.nadel.hints.AllDocumentVariablesHint
+import graphql.nadel.hints.DeferSupportHint
 import graphql.nadel.hints.LegacyOperationNamesHint
 import graphql.nadel.hints.NewBatchHydrationGroupingHint
 import graphql.nadel.hints.NewResultMergerAndNamespacedTypename
@@ -10,6 +11,7 @@ data class NadelExecutionHints(
     val allDocumentVariablesHint: AllDocumentVariablesHint,
     val newResultMergerAndNamespacedTypename: NewResultMergerAndNamespacedTypename,
     val newBatchHydrationGrouping: NewBatchHydrationGroupingHint,
+    val deferSupport: DeferSupportHint,
 ) {
     /**
      * Returns a builder with the same field values as this object.
@@ -26,6 +28,7 @@ data class NadelExecutionHints(
         private var allDocumentVariablesHint = AllDocumentVariablesHint { false }
         private var newResultMergerAndNamespacedTypename = NewResultMergerAndNamespacedTypename { false }
         private var newBatchHydrationGrouping = NewBatchHydrationGroupingHint { false }
+        private var deferSupport = DeferSupportHint { false }
 
         constructor()
 
@@ -55,12 +58,18 @@ data class NadelExecutionHints(
             return this
         }
 
+        fun deferSupport(flag: DeferSupportHint): Builder {
+            deferSupport = flag
+            return this
+        }
+
         fun build(): NadelExecutionHints {
             return NadelExecutionHints(
                 legacyOperationNames,
                 allDocumentVariablesHint,
                 newResultMergerAndNamespacedTypename,
                 newBatchHydrationGrouping,
+                deferSupport
             )
         }
     }

--- a/lib/src/main/java/graphql/nadel/ServiceExecutionResult.kt
+++ b/lib/src/main/java/graphql/nadel/ServiceExecutionResult.kt
@@ -1,6 +1,6 @@
 package graphql.nadel
 
-class ServiceExecutionResult @JvmOverloads constructor(
+open class ServiceExecutionResult @JvmOverloads constructor(
     val data: MutableMap<String, Any?> = LinkedHashMap(),
     val errors: MutableList<MutableMap<String, Any?>> = ArrayList(),
     val extensions: MutableMap<String, Any?> = LinkedHashMap(),

--- a/lib/src/main/java/graphql/nadel/engine/util/GraphQLUtil.kt
+++ b/lib/src/main/java/graphql/nadel/engine/util/GraphQLUtil.kt
@@ -586,12 +586,23 @@ fun compileToDocument(
     operationName: String?,
     topLevelFields: List<ExecutableNormalizedField>,
     variablePredicate: VariablePredicate?,
+    deferSupport: Boolean = false,
 ): CompilerResult {
-    return ExecutableNormalizedOperationToAstCompiler.compileToDocument(
-        schema,
-        operationKind,
-        operationName,
-        topLevelFields,
-        variablePredicate,
-    )
+    if (deferSupport) {
+        return ExecutableNormalizedOperationToAstCompiler.compileToDocumentWithDeferSupport(
+            schema,
+            operationKind,
+            operationName,
+            topLevelFields,
+            variablePredicate,
+        )
+    } else {
+        return ExecutableNormalizedOperationToAstCompiler.compileToDocument(
+            schema,
+            operationKind,
+            operationName,
+            topLevelFields,
+            variablePredicate,
+        )
+    }
 }

--- a/lib/src/main/java/graphql/nadel/hints/DeferSupportHint.kt
+++ b/lib/src/main/java/graphql/nadel/hints/DeferSupportHint.kt
@@ -1,0 +1,8 @@
+package graphql.nadel.hints
+
+fun interface DeferSupportHint {
+    /**
+     * Adds support for the @defer directive on Nadel execution
+     */
+    operator fun invoke(): Boolean
+}

--- a/lib/src/main/java/graphql/nadel/incremental/IncrementalServiceExecutionResult.kt
+++ b/lib/src/main/java/graphql/nadel/incremental/IncrementalServiceExecutionResult.kt
@@ -1,0 +1,14 @@
+package graphql.nadel.incremental
+
+import graphql.nadel.ServiceExecutionResult
+import org.reactivestreams.Publisher
+
+class IncrementalServiceExecutionResult(
+    serviceExecutionResult: ServiceExecutionResult,
+    val incrementalItemPublisher: Publisher<Any>,
+) : ServiceExecutionResult(serviceExecutionResult.data, serviceExecutionResult.errors, serviceExecutionResult.extensions)
+
+fun List<ServiceExecutionResult>.containsIncremental(): Boolean {
+    return this.find { it is IncrementalServiceExecutionResult } != null
+}
+

--- a/test/src/test/kotlin/graphql/nadel/tests/hooks/enable-defer-support.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/hooks/enable-defer-support.kt
@@ -1,0 +1,25 @@
+package graphql.nadel.tests.hooks
+
+import graphql.nadel.NadelExecutionInput
+import graphql.nadel.tests.EngineTestHook
+import graphql.nadel.tests.UseHook
+
+private interface DeferHook : EngineTestHook {
+    override fun makeExecutionInput(builder: NadelExecutionInput.Builder): NadelExecutionInput.Builder {
+        return super.makeExecutionInput(builder)
+            .transformExecutionHints {
+                it
+                    .deferSupport { true }
+            }
+    }
+}
+
+@UseHook
+class `defer-with-label` : DeferHook
+
+@UseHook
+class `defer-no-label` : DeferHook
+
+@UseHook
+class `defer-on-hydrated-field` : DeferHook
+

--- a/test/src/test/resources/fixtures/defer/defer-is-disabled.yml
+++ b/test/src/test/resources/fixtures/defer/defer-is-disabled.yml
@@ -1,4 +1,4 @@
-name: "defer with label"
+name: "defer is disabled"
 enabled: true
 overallSchema:
   service: |
@@ -41,9 +41,7 @@ serviceCalls:
         query {
           defer {
             hello
-            ... @defer(label: "slow-defer") {
-              slow
-            }
+            slow
           }
         }
       variables: { }
@@ -52,7 +50,8 @@ serviceCalls:
       {
         "data": {
           "defer": {
-            "hello": "world"
+            "hello": "world",
+            "slow": "🐌"
           }
         },
         "extensions": {}
@@ -62,7 +61,8 @@ response: |-
   {
     "data": {
       "defer": {
-        "hello": "world"
+        "hello": "world",
+        "slow": "🐌"
       }
     },
     "extensions": {}

--- a/test/src/test/resources/fixtures/defer/defer-no-label.yml
+++ b/test/src/test/resources/fixtures/defer/defer-no-label.yml
@@ -1,0 +1,71 @@
+name: "defer no label"
+enabled: true
+overallSchema:
+  service: |
+    directive @defer(if: Boolean, label: String) on FRAGMENT_SPREAD | INLINE_FRAGMENT
+    
+    type Query {
+      defer: DeferApi
+    }
+    
+    type DeferApi {
+      hello: String
+      slow: String
+    }
+underlyingSchema:
+  service: |
+    directive @defer(if: Boolean, label: String) on FRAGMENT_SPREAD | INLINE_FRAGMENT
+    
+    type Query {
+      defer: DeferApi
+    }
+    
+    type DeferApi {
+      hello: String
+      slow: String
+    }
+query: |
+  query {
+    defer {
+      hello
+      ... @defer {
+        slow
+      }
+    }
+  }
+variables: { }
+serviceCalls:
+  - serviceName: "service"
+    request:
+      query: |
+        query {
+          defer {
+            hello
+            ... @defer {
+              slow
+            }
+          }
+        }
+      variables: { }
+    # language=JSON
+    response: |-
+      {
+        "data": {
+          "defer": {
+            "hello": "world",
+            "slow": "🐌"
+          }
+        },
+        "extensions": {}
+      }
+# language=JSON
+response: |-
+  {
+    "data": {
+      "defer": {
+        "hello": "world",
+        "slow": "🐌"
+      }
+    },
+    "extensions": {}
+  }

--- a/test/src/test/resources/fixtures/defer/defer-no-label.yml
+++ b/test/src/test/resources/fixtures/defer/defer-no-label.yml
@@ -52,8 +52,7 @@ serviceCalls:
       {
         "data": {
           "defer": {
-            "hello": "world",
-            "slow": "🐌"
+            "hello": "world"
           }
         },
         "extensions": {}
@@ -63,8 +62,7 @@ response: |-
   {
     "data": {
       "defer": {
-        "hello": "world",
-        "slow": "🐌"
+        "hello": "world"
       }
     },
     "extensions": {}

--- a/test/src/test/resources/fixtures/defer/defer-on-hydrated-field.yml
+++ b/test/src/test/resources/fixtures/defer/defer-on-hydrated-field.yml
@@ -1,0 +1,112 @@
+name: "defer on hydrated field"
+enabled: true
+overallSchema:
+  petService: |
+    directive @defer(if: Boolean, label: String) on FRAGMENT_SPREAD | INLINE_FRAGMENT
+    
+    type Query {
+      pet(id: ID!): Pet
+    }
+    type Pet {
+      name: String
+      owner: Person @hydrated(service: "personService" field: "person" arguments: [{name: "id" value: "$source.ownerId"}])
+    }
+  personService: |
+    type Query {
+      person(id: ID!): Person 
+    }
+    type Person {
+      firstname: String
+      lastname: String
+    }
+underlyingSchema:
+  petService: |
+    type Query {
+      pet(id: ID!): Pet
+    }
+    type Pet {
+      name: String
+      ownerId: ID
+    }
+  personService: |
+    type Query {
+      person(id: ID!): Person 
+    }
+    type Person {
+      firstname: String
+      lastname: String
+    }
+query: |
+  query {
+    pet(id: "1") {
+      name
+      ... @defer { # the @defer on the hydrated field has no effect at the moment
+        owner {
+          firstname
+          ... @defer {
+            lastname
+          }
+        }
+      }
+    }
+  }
+variables: { }
+serviceCalls:
+  - serviceName: "petService"
+    request:
+      query: |
+        query {
+          pet(id: "1") {
+            __typename__hydration__owner: __typename
+            name
+            hydration__owner__ownerId: ownerId
+          }
+        }
+      variables: { }
+    # language=JSON
+    response: |-
+      {
+        "data": {
+          "pet": {
+            "name": "Figaro",
+            "hydration__owner__ownerId": "100",
+            "__typename__hydration__owner": "Pet"
+          }
+        },
+        "extensions": {}
+      }
+  - serviceName: "personService"
+    request:
+      query: |
+        query {
+          person(id: "100") {
+            firstname
+            ... @defer {
+              lastname
+            }
+          }
+        }
+      variables: { }
+    # language=JSON
+    response: |-
+      {
+        "data": {
+          "person": {
+            "firstname": "Ziggy"
+          }
+        },
+        "extensions": {}
+      }
+# language=JSON
+response: |-
+  {
+    "data": {
+      "pet": {
+        "name": "Figaro",
+        "owner": {
+          "firstname": "Ziggy"
+        }
+      }
+    },
+    "extensions": {}
+  }

--- a/test/src/test/resources/fixtures/defer/defer-with-label.yml
+++ b/test/src/test/resources/fixtures/defer/defer-with-label.yml
@@ -1,0 +1,71 @@
+name: "defer with label"
+enabled: true
+overallSchema:
+  service: |
+    directive @defer(if: Boolean, label: String) on FRAGMENT_SPREAD | INLINE_FRAGMENT
+    
+    type Query {
+      defer: DeferApi
+    }
+    
+    type DeferApi {
+      hello: String
+      slow: String
+    }
+underlyingSchema:
+  service: |
+    directive @defer(if: Boolean, label: String) on FRAGMENT_SPREAD | INLINE_FRAGMENT
+    
+    type Query {
+      defer: DeferApi
+    }
+    
+    type DeferApi {
+      hello: String
+      slow: String
+    }
+query: |
+  query {
+    defer {
+      hello
+      ... @defer(label: "slow-defer") {
+        slow
+      }
+    }
+  }
+variables: { }
+serviceCalls:
+  - serviceName: "service"
+    request:
+      query: |
+        query {
+          defer {
+            hello
+            ... @defer(label: "slow-defer") {
+              slow
+            }
+          }
+        }
+      variables: { }
+    # language=JSON
+    response: |-
+      {
+        "data": {
+          "defer": {
+            "hello": "world",
+            "slow": "🐌"
+          }
+        },
+        "extensions": {}
+      }
+# language=JSON
+response: |-
+  {
+    "data": {
+      "defer": {
+        "hello": "world",
+        "slow": "🐌"
+      }
+    },
+    "extensions": {}
+  }


### PR DESCRIPTION
Please make sure you consider the following:

- [ ] Add tests that use __typename in queries
- [ ] Does this change work with all nadel transformations (rename, type rename, hydration, etc)? Add tests for this.
- [ ] Is it worth using hints for this change in order to be able to enable a percentage rollout?
- [ ] Do we need to add integration tests for this change in the graphql gateway?
- [ ] Do we need a pollinator check for this?
