### PR TITLE
Fix polymorphic hydration parallelism

### DIFF
--- a/test/src/test/resources/fixtures/new hydration/polymorphic hydrations/new-batch-polymorphic-hydrations-are-executed-in-parallel.yml
+++ b/test/src/test/resources/fixtures/new hydration/polymorphic hydrations/new-batch-polymorphic-hydrations-are-executed-in-parallel.yml
@@ -1,0 +1,259 @@
+name: "new batch polymorphic hydrations are executed in parallel"
+enabled: true
+# language=GraphQL
+overallSchema:
+  pets: |
+    type Query {
+      petById(ids: [ID]): [Pet]
+    }
+
+    type Pet {
+      id: ID
+      breed: String
+    }
+  people: |
+    type Query {
+      humanById(ids: [ID]): [Human]
+    }
+
+    type Human {
+      id: ID
+      name: String
+    }
+  foo: |
+    type Query {
+      foo: [Foo]
+    }
+
+    type Foo {
+      id: ID
+      dataId: ID
+      data: Data
+      @hydrated(
+        service: "pets"
+        field: "petById"
+        arguments: [
+          {name: "ids" value: "$source.dataId"}
+        ]
+      )
+      @hydrated(
+        service: "people"
+        field: "humanById"
+        arguments: [
+          {name: "ids" value: "$source.dataId"}
+        ]
+      )
+    }
+
+    union Data = Pet | Human
+# language=GraphQL
+underlyingSchema:
+  pets: |
+    type Query {
+      petById(ids: [ID]): [Pet]
+    }
+
+    type Pet {
+      id: ID
+      breed: String
+    }
+  people: |
+    type Query {
+      humanById(ids: [ID]): [Human]
+    }
+
+    type Human {
+      id: ID
+      name: String
+    }
+  foo: |
+    type Query {
+      foo: [Foo]
+    }
+
+    type Foo {
+      id: ID
+      dataId: ID
+    }
+# language=GraphQL
+query: |
+  query {
+    foo {
+      __typename
+      id
+      data {
+        ... on Pet {
+          __typename
+          id
+          breed
+        }
+        ... on Human {
+          __typename
+          id
+          name
+        }
+      }
+    }
+  }
+variables: { }
+serviceCalls:
+  - serviceName: "foo"
+    request:
+      # language=GraphQL
+      query: |
+        query {
+          foo {
+            __typename
+            __typename__batch_hydration__data: __typename
+            batch_hydration__data__dataId: dataId
+            batch_hydration__data__dataId: dataId
+            id
+          }
+        }
+      variables: { }
+    # language=JSON
+    response: |-
+      {
+        "data": {
+          "foo": [
+            {
+              "__typename": "Foo",
+              "__typename__batch_hydration__data": "Foo",
+              "batch_hydration__data__dataId": "PET-0",
+              "id": "FOO-0"
+            },
+            {
+              "__typename": "Foo",
+              "__typename__batch_hydration__data": "Foo",
+              "batch_hydration__data__dataId": "HUMAN-0",
+              "id": "FOO-1"
+            },
+            {
+              "__typename": "Foo",
+              "__typename__batch_hydration__data": "Foo",
+              "batch_hydration__data__dataId": "PET-1",
+              "id": "FOO-2"
+            },
+            {
+              "__typename": "Foo",
+              "__typename__batch_hydration__data": "Foo",
+              "batch_hydration__data__dataId": "HUMAN-1",
+              "id": "FOO-3"
+            }
+          ]
+        },
+        "extensions": {}
+      }
+  - serviceName: "pets"
+    request:
+      # language=GraphQL
+      query: |
+        query {
+          petById(ids: ["PET-0", "PET-1"]) {
+            __typename
+            breed
+            id
+            batch_hydration__data__id: id
+          }
+        }
+      variables: { }
+    # language=JSON
+    response: |-
+      {
+        "data": {
+          "petById": [
+            {
+              "__typename": "Pet",
+              "breed": "Akita",
+              "id": "PET-0",
+              "batch_hydration__data__id": "PET-0"
+            },
+            {
+              "__typename": "Pet",
+              "breed": "Labrador",
+              "id": "PET-1",
+              "batch_hydration__data__id": "PET-1"
+            }
+          ]
+        },
+        "extensions": {}
+      }
+  - serviceName: "people"
+    request:
+      # language=GraphQL
+      query: |
+        query {
+          humanById(ids: ["HUMAN-0", "HUMAN-1"]) {
+            __typename
+            id
+            batch_hydration__data__id: id
+            name
+          }
+        }
+      variables: { }
+    # language=JSON
+    response: |-
+      {
+        "data": {
+          "humanById": [
+            {
+              "__typename": "Human",
+              "id": "HUMAN-0",
+              "batch_hydration__data__id": "HUMAN-0",
+              "name": "Fanny Longbottom"
+            },
+            {
+              "__typename": "Human",
+              "id": "HUMAN-1",
+              "batch_hydration__data__id": "HUMAN-1",
+              "name": "John Doe"
+            }
+          ]
+        },
+        "extensions": {}
+      }
+# language=JSON
+response: |-
+  {
+    "data": {
+      "foo": [
+        {
+          "__typename": "Foo",
+          "id": "FOO-0",
+          "data": {
+            "__typename": "Pet",
+            "id": "PET-0",
+            "breed": "Akita"
+          }
+        },
+        {
+          "__typename": "Foo",
+          "id": "FOO-1",
+          "data": {
+            "__typename": "Human",
+            "id": "HUMAN-0",
+            "name": "Fanny Longbottom"
+          }
+        },
+        {
+          "__typename": "Foo",
+          "id": "FOO-2",
+          "data": {
+            "__typename": "Pet",
+            "id": "PET-1",
+            "breed": "Labrador"
+          }
+        },
+        {
+          "__typename": "Foo",
+          "id": "FOO-3",
+          "data": {
+            "__typename": "Human",
+            "id": "HUMAN-1",
+            "name": "John Doe"
+          }
+        }
+      ]
+    },
+    "extensions": {}
+  }


### PR DESCRIPTION
Please make sure you consider the following:

- [ ] Add tests that use __typename in queries
- [ ] Does this change work with all nadel transformations (rename, type rename, hydration, etc)? Add tests for this.
- [ ] Is it worth using hints for this change in order to be able to enable a percentage rollout?
- [ ] Do we need to add integration tests for this change in the graphql gateway?
- [ ] Do we need a pollinator check for this?
