### PR TITLE
add defer types to test fixture

### DIFF
--- a/test/src/test/kotlin/graphql/nadel/tests/EngineTests.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/EngineTests.kt
@@ -180,10 +180,9 @@ private suspend fun execute(
 
                                 if (indexOfCall != null) {
                                     val serviceCall = serviceCalls.removeAt(indexOfCall)
-                                    if( serviceCall.incrementalResponse != null){
+                                    if (serviceCall.incrementalResponse != null) {
                                         serviceCall.incrementalResponse.initialResponse //for now, just return initial response
-                                    }
-                                    else {
+                                    } else {
                                         serviceCall.response!!
                                     }
                                 } else {

--- a/test/src/test/kotlin/graphql/nadel/tests/EngineTests.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/EngineTests.kt
@@ -180,7 +180,12 @@ private suspend fun execute(
 
                                 if (indexOfCall != null) {
                                     val serviceCall = serviceCalls.removeAt(indexOfCall)
-                                    serviceCall.response
+                                    if( serviceCall.incrementalResponse != null){
+                                        serviceCall.incrementalResponse.initialResponse //for now, just return initial response
+                                    }
+                                    else {
+                                        serviceCall.response!!
+                                    }
                                 } else {
                                     fail(
                                         """Unable to match service call 

--- a/test/src/test/kotlin/graphql/nadel/tests/EngineTests.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/EngineTests.kt
@@ -168,6 +168,18 @@ private suspend fun execute(
                             )
                             printSyncLine(actualQuery)
 
+                            fun failWithFixtureContext(message: String): Nothing {
+                                fail(
+                                    """${message}
+                                        |   fixture : '${fixture.name}' 
+                                        |   service : '${serviceName}' 
+                                        |   query : '${actualQuery}' 
+                                        |   variables : '${actualVariables}' 
+                                        |   operation : '${actualOperationName}' 
+                                        """.trimMargin()
+                                )
+                            }
+
                             val response = synchronized(serviceCalls) {
                                 val indexOfCall = serviceCalls
                                     .indexOfFirst {
@@ -180,21 +192,20 @@ private suspend fun execute(
 
                                 if (indexOfCall != null) {
                                     val serviceCall = serviceCalls.removeAt(indexOfCall)
-                                    if (serviceCall.incrementalResponse != null) {
+                                    val response = serviceCall.response
+                                    if (serviceCall.incrementalResponse != null && response != null) {
+                                        failWithFixtureContext("Fixture cannot have both a response and an incrementalResponse.")
+                                    }
+                                    else if (serviceCall.incrementalResponse != null) {
                                         serviceCall.incrementalResponse.initialResponse //for now, just return initial response
-                                    } else {
-                                        serviceCall.response!!
+                                    } else if (response != null) {
+                                        response
+                                    }
+                                    else {
+                                        failWithFixtureContext("Fixture had no response")
                                     }
                                 } else {
-                                    fail(
-                                        """Unable to match service call 
-                                        |   fixture : '${fixture.name}' 
-                                        |   service : '${serviceName}' 
-                                        |   query : '${actualQuery}' 
-                                        |   variables : '${actualVariables}' 
-                                        |   operation : '${actualOperationName}' 
-                                        """.trimMargin()
-                                    )
+                                    failWithFixtureContext("Unable to match service call")
                                 }
                             }
 

--- a/test/src/test/kotlin/graphql/nadel/tests/TestFixture.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/TestFixture.kt
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonInclude.Include.NON_DEFAULT
 import com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL
 import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.core.type.TypeReference
 import com.fasterxml.jackson.module.kotlin.readValue
 import graphql.language.AstSorter
 import graphql.language.Document
@@ -103,7 +104,7 @@ data class IncrementalResponse(
     @JsonProperty("initialResponse")
     val initialResponseJsonString: String,
     @JsonProperty("delayedResponses")
-    val delayedResponsesJsonString: String?,
+    val delayedResponsesJsonString: String,
 )
 {
     @get:JsonIgnore
@@ -112,9 +113,7 @@ data class IncrementalResponse(
     }
 
     @get:JsonIgnore
-    val delayedResponses: JsonMap? by lazy {
-        delayedResponsesJsonString?.let {
-            jsonObjectMapper.readValue(it)
-        }
+    val delayedResponses: List<JsonMap> by lazy {
+        jsonObjectMapper.readValue(delayedResponsesJsonString, object : TypeReference<List<JsonMap>>() {})
     }
 }

--- a/test/src/test/kotlin/graphql/nadel/tests/TestFixture.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/TestFixture.kt
@@ -27,8 +27,14 @@ data class TestFixture(
     @JsonInclude(NON_NULL)
     val operationName: String? = null,
     val serviceCalls: List<ServiceCall>,
+
+
     @JsonProperty("response")
     val responseJsonString: String?,
+
+    @JsonProperty("incrementalResponse")
+    val incrementalResponseJsonString: IncrementalResponse?,
+
     @JsonInclude(NON_NULL)
     val exception: ExpectedException?,
 ) {
@@ -41,12 +47,17 @@ data class TestFixture(
 data class ServiceCall(
     val serviceName: String,
     val request: Request,
+
     @JsonProperty("response")
-    val responseJsonString: String,
+    val responseJsonString: String?,
+
+    val incrementalResponse: IncrementalResponse?,
 ) {
     @get:JsonIgnore
-    val response: JsonMap by lazy {
-        jsonObjectMapper.readValue(responseJsonString)
+    val response: JsonMap? by lazy {
+        responseJsonString?.let {
+            jsonObjectMapper.readValue(it)
+        }
     }
 
     data class Request(
@@ -86,5 +97,24 @@ data class ExpectedException(
                 },
             ),
         )
+    }
+}
+data class IncrementalResponse(
+    @JsonProperty("initialResponse")
+    val initialResponseJsonString: String,
+    @JsonProperty("delayedResponses")
+    val delayedResponsesJsonString: String?,
+)
+{
+    @get:JsonIgnore
+    val initialResponse: JsonMap by lazy {
+        jsonObjectMapper.readValue(initialResponseJsonString)
+    }
+
+    @get:JsonIgnore
+    val delayedResponses: JsonMap? by lazy {
+        delayedResponsesJsonString?.let {
+            jsonObjectMapper.readValue(it)
+        }
     }
 }

--- a/test/src/test/kotlin/graphql/nadel/tests/TestFixture.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/TestFixture.kt
@@ -28,14 +28,10 @@ data class TestFixture(
     @JsonInclude(NON_NULL)
     val operationName: String? = null,
     val serviceCalls: List<ServiceCall>,
-
-
     @JsonProperty("response")
     val responseJsonString: String?,
-
     @JsonProperty("incrementalResponse")
     val incrementalResponseJsonString: IncrementalResponse?,
-
     @JsonInclude(NON_NULL)
     val exception: ExpectedException?,
 ) {
@@ -48,10 +44,8 @@ data class TestFixture(
 data class ServiceCall(
     val serviceName: String,
     val request: Request,
-
     @JsonProperty("response")
     val responseJsonString: String?,
-
     val incrementalResponse: IncrementalResponse?,
 ) {
     @get:JsonIgnore
@@ -100,13 +94,13 @@ data class ExpectedException(
         )
     }
 }
+
 data class IncrementalResponse(
     @JsonProperty("initialResponse")
     val initialResponseJsonString: String,
     @JsonProperty("delayedResponses")
     val delayedResponsesJsonString: String,
-)
-{
+) {
     @get:JsonIgnore
     val initialResponse: JsonMap by lazy {
         jsonObjectMapper.readValue(initialResponseJsonString)

--- a/test/src/test/resources/fixtures/defer/defer-with-label.yml
+++ b/test/src/test/resources/fixtures/defer/defer-with-label.yml
@@ -48,25 +48,61 @@ serviceCalls:
         }
       variables: { }
     # language=JSON
-    response: |-
-      {
-        "data": {
-          "defer": {
-            "hello": "world"
-          }
-        },
-        "extensions": {}
-      }
+    incrementalResponse:
+      # Note: currently this just returns initialResponse, but have included delayedResponse to ensure no errors with the TestFixture types
+      initialResponse: |-
+        {
+          "hasNext": true,
+          "data": {
+            "defer": {
+              "hello": "world"
+            }
+          },
+          "extensions": {}
+        }
+      delayedResponses: |-
+        {
+          "hasNext": false,
+          "incremental": [{
+            "data": {
+              "slow": "snail"
+
+            }
+          }]
+        }
+
 # language=JSON
 
     # This is just checking that  can generate queries containing @defer.
     # The response below will change once defer work is implemented.
-response: |-
-  {
-    "data": {
-      "defer": {
-        "hello": "world"
-      }
-    },
-    "extensions": {}
-  }
+#response: |-
+#  {
+#    "data": {
+#      "defer": {
+#        "hello": "world"
+#      }
+#    },
+#    "extensions": {}
+#  }
+
+incrementalResponse:
+  initialResponse: |-
+    {
+      "hasNext": true,
+      "data": {
+        "defer": {
+          "hello": "world"
+        }
+      },
+      "extensions": {}
+    }
+  delayedResponses: |-
+    {
+      "hasNext": false,
+      "incremental": [{
+        "data": {
+          "slow": "snail"
+
+        }
+      }]
+    }

--- a/test/src/test/resources/fixtures/defer/defer-with-label.yml
+++ b/test/src/test/resources/fixtures/defer/defer-with-label.yml
@@ -61,15 +61,16 @@ serviceCalls:
           "extensions": {}
         }
       delayedResponses: |-
-        {
+        [{
           "hasNext": false,
           "incremental": [{
             "data": {
               "slow": "snail"
-
+  
             }
           }]
-        }
+        }]
+
 
 # language=JSON
 
@@ -97,12 +98,12 @@ incrementalResponse:
       "extensions": {}
     }
   delayedResponses: |-
-    {
+    [{
       "hasNext": false,
       "incremental": [{
         "data": {
           "slow": "snail"
-
+  
         }
       }]
-    }
+    }]

--- a/test/src/test/resources/fixtures/defer/defer-with-label.yml
+++ b/test/src/test/resources/fixtures/defer/defer-with-label.yml
@@ -71,21 +71,7 @@ serviceCalls:
           }]
         }]
 
-
 # language=JSON
-
-    # This is just checking that  can generate queries containing @defer.
-    # The response below will change once defer work is implemented.
-#response: |-
-#  {
-#    "data": {
-#      "defer": {
-#        "hello": "world"
-#      }
-#    },
-#    "extensions": {}
-#  }
-
 incrementalResponse:
   initialResponse: |-
     {


### PR DESCRIPTION
Note: the tests arent asserting the incremental responses yet for deferred requests, it is just using the initial responses at the moment, the work for the incremental responses is in progress and will be in a follow-up PR. 
The aim of this PR is just to add all the types of the test fixture. 