### PR TITLE
renamed type in unions

### DIFF
--- a/lib/src/main/java/graphql/nadel/engine/blueprint/NadelExecutionBlueprint.kt
+++ b/lib/src/main/java/graphql/nadel/engine/blueprint/NadelExecutionBlueprint.kt
@@ -20,11 +20,12 @@ data class NadelOverallExecutionBlueprint(
     private val overallTypeNamesByService: Map<Service, Set<String>>,
     private val underlyingBlueprints: Map<String, NadelUnderlyingExecutionBlueprint>,
     private val coordinatesToService: Map<FieldCoordinates, Service>,
+    private val typeRenamesByOverallTypeName: Map<String, NadelTypeRenameInstruction>,
 ) {
 
     private fun setOfServiceTypes(
         map: Map<Service, Set<String>>,
-        service: Service
+        service: Service,
     ): Set<String> {
         return (map[service] ?: error("Could not find service: ${service.name}"))
     }
@@ -46,6 +47,14 @@ data class NadelOverallExecutionBlueprint(
             return overallTypeName
         }
         return getUnderlyingBlueprint(service).typeInstructions.getUnderlyingName(overallTypeName)
+    }
+
+    fun getUnderlyingTypeName(overallTypeName: String): String {
+        return typeRenamesByOverallTypeName[overallTypeName]?.underlyingName ?: overallTypeName
+    }
+
+    fun getRename(overallTypeName: String): NadelTypeRenameInstruction? {
+        return typeRenamesByOverallTypeName[overallTypeName]
     }
 
     fun getOverallTypeName(

--- a/lib/src/main/java/graphql/nadel/engine/blueprint/NadelExecutionBlueprintFactory.kt
+++ b/lib/src/main/java/graphql/nadel/engine/blueprint/NadelExecutionBlueprintFactory.kt
@@ -103,6 +103,7 @@ private class Factory(
             overallTypeNamesByService = overallTypeNamesByService,
             underlyingBlueprints = underlyingBlueprints,
             coordinatesToService = coordinatesToService,
+            typeRenamesByOverallTypeName = typeRenameInstructions,
         )
     }
 

--- a/lib/src/main/java/graphql/nadel/engine/transform/NadelServiceTypeFilterTransform.kt
+++ b/lib/src/main/java/graphql/nadel/engine/transform/NadelServiceTypeFilterTransform.kt
@@ -96,7 +96,9 @@ class NadelServiceTypeFilterTransform : NadelTransform<State> {
             .filter {
                 // it is MUCH quicker to compare membership in 2 sets rather than
                 // concat 1 giant set and then check
-                it in typeNamesOwnedByService || it in underlyingTypeNamesOwnedByService
+                it in typeNamesOwnedByService
+                    || it in underlyingTypeNamesOwnedByService
+                    || executionBlueprint.getUnderlyingTypeName(it) in underlyingTypeNamesOwnedByService
             }
 
         // All types are owned by service

--- a/lib/src/main/java/graphql/nadel/engine/transform/NadelTypeRenameResultTransform.kt
+++ b/lib/src/main/java/graphql/nadel/engine/transform/NadelTypeRenameResultTransform.kt
@@ -77,10 +77,17 @@ internal class NadelTypeRenameResultTransform : NadelTransform<State> {
                 underlyingTypeName = underlyingTypeName,
             )
 
+            val typeName: String = if (overallField.objectTypeNames.contains(overallTypeName)) {
+                overallTypeName
+            } else {
+                overallField.objectTypeNames.single {
+                    executionBlueprint.getRename(it)?.underlyingName == underlyingTypeName
+                }
+            }
             NadelResultInstruction.Set(
                 subject = parentNode,
                 key = NadelResultKey(overallField.resultKey),
-                newValue = JsonNode(overallTypeName),
+                newValue = JsonNode(typeName),
             )
         }
     }

--- a/test/src/test/resources/fixtures/renames/types/renamed-type-in-union-1.yml
+++ b/test/src/test/resources/fixtures/renames/types/renamed-type-in-union-1.yml
@@ -1,0 +1,88 @@
+name: "renamed type in union 1"
+enabled: true
+# language=GraphQL
+overallSchema:
+  IssueService: |
+    type Query {
+      nodes: [Node]
+    }
+    type Issue {
+      id: ID
+    }
+    union Node = Issue | JiraComment
+  CommentService: |
+    type Query {
+      comment: JiraComment
+    }
+    type JiraComment @renamed(from: "Comment") {
+      id: ID
+    }
+# language=GraphQL
+underlyingSchema:
+  IssueService: |
+    type Query {
+      nodes: [Node]
+    }
+    type Issue {
+      id: ID
+    }
+    type Comment {
+      id: ID
+    }
+    union Node = Issue | Comment
+  CommentService: |
+    type Query {
+      comment: Comment
+    }
+    type Comment {
+      id: ID
+    }
+# language=GraphQL
+query: |
+  query {
+    nodes {
+      __typename
+    }
+  }
+variables: { }
+serviceCalls:
+  - serviceName: "IssueService"
+    request:
+      # language=GraphQL
+      query: |
+        {
+          nodes {
+            __typename
+          }
+        }
+      variables: { }
+    # language=JSON
+    response: |-
+      {
+        "data": {
+          "nodes": [
+            {
+              "__typename": "Issue"
+            },
+            {
+              "__typename": "Comment"
+            }
+          ]
+        },
+        "extensions": {}
+      }
+# language=JSON
+response: |-
+  {
+    "data": {
+      "nodes": [
+        {
+          "__typename": "Issue"
+        },
+        {
+          "__typename": "JiraComment"
+        }
+      ]
+    },
+    "extensions": {}
+  }

--- a/test/src/test/resources/fixtures/renames/types/renamed-type-in-union-2.yml
+++ b/test/src/test/resources/fixtures/renames/types/renamed-type-in-union-2.yml
@@ -1,0 +1,88 @@
+name: "renamed type in union 2"
+enabled: true
+# language=GraphQL
+overallSchema:
+  IssueService: |
+    type Query {
+      nodes: [Node]
+    }
+    type Issue {
+      id: ID
+    }
+    union Node = Issue | JiraComment
+    type JiraComment @renamed(from: "Comment") {
+      id: ID
+    }
+  CommentService: |
+    type Query {
+      comment: JiraComment
+    }
+# language=GraphQL
+underlyingSchema:
+  IssueService: |
+    type Query {
+      nodes: [Node]
+    }
+    type Issue {
+      id: ID
+    }
+    type Comment {
+      id: ID
+    }
+    union Node = Issue | Comment
+  CommentService: |
+    type Query {
+      comment: Comment
+    }
+    type Comment {
+      id: ID
+    }
+# language=GraphQL
+query: |
+  query {
+    nodes {
+      __typename
+    }
+  }
+variables: { }
+serviceCalls:
+  - serviceName: "IssueService"
+    request:
+      # language=GraphQL
+      query: |
+        {
+          nodes {
+            __typename
+          }
+        }
+      variables: { }
+    # language=JSON
+    response: |-
+      {
+        "data": {
+          "nodes": [
+            {
+              "__typename": "Issue"
+            },
+            {
+              "__typename": "Comment"
+            }
+          ]
+        },
+        "extensions": {}
+      }
+# language=JSON
+response: |-
+  {
+    "data": {
+      "nodes": [
+        {
+          "__typename": "Issue"
+        },
+        {
+          "__typename": "JiraComment"
+        }
+      ]
+    },
+    "extensions": {}
+  }


### PR DESCRIPTION
Please make sure you consider the following:

- [x] Add tests that use __typename in queries
- [x] Does this change work with all nadel transformations (rename, type rename, hydration, etc)? Add tests for this.
- [x] Is it worth using hints for this change in order to be able to enable a percentage rollout?
- [x] Do we need to add integration tests for this change in the graphql gateway?
- [x] Do we need a pollinator check for this?
