### PR TITLE
put shared renamed types in unions behind a hint

### DIFF
--- a/lib/src/main/java/graphql/nadel/NadelExecutionHints.kt
+++ b/lib/src/main/java/graphql/nadel/NadelExecutionHints.kt
@@ -1,8 +1,9 @@
 package graphql.nadel
 
 import graphql.nadel.hints.AllDocumentVariablesHint
-import graphql.nadel.hints.NadelDeferSupportHint
 import graphql.nadel.hints.LegacyOperationNamesHint
+import graphql.nadel.hints.NadelDeferSupportHint
+import graphql.nadel.hints.NadelSharedTypeRenamesHint
 import graphql.nadel.hints.NewBatchHydrationGroupingHint
 import graphql.nadel.hints.NewResultMergerAndNamespacedTypename
 
@@ -12,6 +13,7 @@ data class NadelExecutionHints(
     val newResultMergerAndNamespacedTypename: NewResultMergerAndNamespacedTypename,
     val newBatchHydrationGrouping: NewBatchHydrationGroupingHint,
     val deferSupport: NadelDeferSupportHint,
+    val sharedTypeRenames: NadelSharedTypeRenamesHint,
 ) {
     /**
      * Returns a builder with the same field values as this object.
@@ -29,6 +31,7 @@ data class NadelExecutionHints(
         private var newResultMergerAndNamespacedTypename = NewResultMergerAndNamespacedTypename { false }
         private var newBatchHydrationGrouping = NewBatchHydrationGroupingHint { false }
         private var deferSupport = NadelDeferSupportHint { false }
+        private var sharedTypeRenames = NadelSharedTypeRenamesHint { false }
 
         constructor()
 
@@ -63,13 +66,19 @@ data class NadelExecutionHints(
             return this
         }
 
+        fun sharedTypeRenames(flag: NadelSharedTypeRenamesHint): Builder {
+            sharedTypeRenames = flag
+            return this
+        }
+
         fun build(): NadelExecutionHints {
             return NadelExecutionHints(
                 legacyOperationNames,
                 allDocumentVariablesHint,
                 newResultMergerAndNamespacedTypename,
                 newBatchHydrationGrouping,
-                deferSupport
+                deferSupport,
+                sharedTypeRenames,
             )
         }
     }

--- a/lib/src/main/java/graphql/nadel/Service.kt
+++ b/lib/src/main/java/graphql/nadel/Service.kt
@@ -17,4 +17,9 @@ open class Service(
      * These are the GraphQL definitions that a service contributes to the OVERALL schema.
      */
     val definitionRegistry: NadelDefinitionRegistry,
-)
+
+    ) {
+    override fun toString(): String {
+        return "Service{name='$name'}"
+    }
+}

--- a/lib/src/main/java/graphql/nadel/engine/transform/NadelServiceTypeFilterTransform.kt
+++ b/lib/src/main/java/graphql/nadel/engine/transform/NadelServiceTypeFilterTransform.kt
@@ -91,14 +91,13 @@ class NadelServiceTypeFilterTransform : NadelTransform<State> {
         // Transforms are applied to hydration fields as well, and those fields always reference
         // elements from the underlying schema
         val underlyingTypeNamesOwnedByService = executionBlueprint.getUnderlyingTypeNamesForService(service)
-
         val fieldObjectTypeNamesOwnedByService = overallField.objectTypeNames
             .filter {
                 // it is MUCH quicker to compare membership in 2 sets rather than
                 // concat 1 giant set and then check
                 it in typeNamesOwnedByService
                     || it in underlyingTypeNamesOwnedByService
-                    || executionBlueprint.getUnderlyingTypeName(it) in underlyingTypeNamesOwnedByService
+                    || (executionContext.hints.sharedTypeRenames(service) && executionBlueprint.getUnderlyingTypeName(it) in underlyingTypeNamesOwnedByService)
             }
 
         // All types are owned by service

--- a/lib/src/main/java/graphql/nadel/engine/transform/NadelTypeRenameResultTransform.kt
+++ b/lib/src/main/java/graphql/nadel/engine/transform/NadelTypeRenameResultTransform.kt
@@ -77,16 +77,17 @@ internal class NadelTypeRenameResultTransform : NadelTransform<State> {
                 underlyingTypeName = underlyingTypeName,
             )
 
-            val typeName: String = if (
-                !executionContext.hints.sharedTypeRenames(service) ||
-                overallField.objectTypeNames.contains(overallTypeName)
-            ) {
-                overallTypeName
-            } else {
-                overallField.objectTypeNames.singleOrNull {
-                    executionBlueprint.getRename(it)?.underlyingName == underlyingTypeName
+            val typeName: String = if (executionContext.hints.sharedTypeRenames(service)) {
+                if (overallField.objectTypeNames.contains(overallTypeName)) {
+                    overallTypeName
+                } else {
+                    overallField.objectTypeNames.singleOrNull {
+                        executionBlueprint.getRename(it)?.underlyingName == underlyingTypeName
+                    } ?: overallTypeName
                 }
-            } ?: overallTypeName
+            } else {
+                overallTypeName
+            }
             NadelResultInstruction.Set(
                 subject = parentNode,
                 key = NadelResultKey(overallField.resultKey),

--- a/lib/src/main/java/graphql/nadel/engine/transform/NadelTypeRenameResultTransform.kt
+++ b/lib/src/main/java/graphql/nadel/engine/transform/NadelTypeRenameResultTransform.kt
@@ -77,13 +77,16 @@ internal class NadelTypeRenameResultTransform : NadelTransform<State> {
                 underlyingTypeName = underlyingTypeName,
             )
 
-            val typeName: String = if (overallField.objectTypeNames.contains(overallTypeName)) {
+            val typeName: String = if (
+                !executionContext.hints.sharedTypeRenames(service) ||
+                overallField.objectTypeNames.contains(overallTypeName)
+            ) {
                 overallTypeName
             } else {
-                overallField.objectTypeNames.single {
+                overallField.objectTypeNames.singleOrNull {
                     executionBlueprint.getRename(it)?.underlyingName == underlyingTypeName
                 }
-            }
+            } ?: overallTypeName
             NadelResultInstruction.Set(
                 subject = parentNode,
                 key = NadelResultKey(overallField.resultKey),

--- a/lib/src/main/java/graphql/nadel/engine/transform/query/NadelQueryTransformer.kt
+++ b/lib/src/main/java/graphql/nadel/engine/transform/query/NadelQueryTransformer.kt
@@ -168,8 +168,14 @@ class NadelQueryTransformer private constructor(
     }
 
     private fun getUnderlyingTypeNames(objectTypeNames: Collection<String>): List<String> {
-        return objectTypeNames.map {
-            executionBlueprint.getUnderlyingTypeName(service, overallTypeName = it)
+        return if (executionContext.hints.sharedTypeRenames(service)) {
+            objectTypeNames.map {
+                executionBlueprint.getUnderlyingTypeName(overallTypeName = it)
+            }
+        } else {
+            objectTypeNames.map {
+                executionBlueprint.getUnderlyingTypeName(service, overallTypeName = it)
+            }
         }
     }
 

--- a/lib/src/main/java/graphql/nadel/hints/NadelSharedTypeRenamesHint.kt
+++ b/lib/src/main/java/graphql/nadel/hints/NadelSharedTypeRenamesHint.kt
@@ -1,0 +1,10 @@
+package graphql.nadel.hints
+
+import graphql.nadel.Service
+
+fun interface NadelSharedTypeRenamesHint {
+    /**
+     * handle renaming of shared types in unions
+     */
+    operator fun invoke(service: Service): Boolean
+}

--- a/test/src/test/kotlin/graphql/nadel/tests/hooks/shared-types-rename.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/hooks/shared-types-rename.kt
@@ -1,0 +1,20 @@
+package graphql.nadel.tests.hooks
+
+import graphql.nadel.NadelExecutionInput
+import graphql.nadel.tests.EngineTestHook
+import graphql.nadel.tests.UseHook
+
+abstract class `shared-types-rename` : EngineTestHook {
+    override fun makeExecutionInput(
+        builder: NadelExecutionInput.Builder,
+    ): NadelExecutionInput.Builder {
+        return builder.transformExecutionHints {
+            it.sharedTypeRenames {
+                true
+            }
+        }
+    }
+}
+
+@UseHook
+class `renamed-type-in-union-declared-in-another-service` : `shared-types-rename`()

--- a/test/src/test/resources/fixtures/renames/types/renamed-type-in-union-declared-in-another-service.yml
+++ b/test/src/test/resources/fixtures/renames/types/renamed-type-in-union-declared-in-another-service.yml
@@ -1,4 +1,4 @@
-name: "renamed type in union 1"
+name: "renamed type in union declared in another service"
 enabled: true
 # language=GraphQL
 overallSchema:
@@ -42,6 +42,12 @@ query: |
   query {
     nodes {
       __typename
+      ... on Issue {
+        id
+      }
+      ... on JiraComment {
+        id
+      }
     }
   }
 variables: { }
@@ -49,10 +55,16 @@ serviceCalls:
   - serviceName: "IssueService"
     request:
       # language=GraphQL
-      query: |
+      query: |-
         {
           nodes {
             __typename
+            ... on Comment {
+              id
+            }
+            ... on Issue {
+              id
+            }
           }
         }
       variables: { }
@@ -62,10 +74,12 @@ serviceCalls:
         "data": {
           "nodes": [
             {
-              "__typename": "Issue"
+              "__typename": "Issue",
+              "id": "1"
             },
             {
-              "__typename": "Comment"
+              "__typename": "Comment",
+              "id": "2"
             }
           ]
         },
@@ -77,10 +91,12 @@ response: |-
     "data": {
       "nodes": [
         {
-          "__typename": "Issue"
+          "__typename": "Issue",
+          "id": "1"
         },
         {
-          "__typename": "JiraComment"
+          "__typename": "JiraComment",
+          "id": "2"
         }
       ]
     },

--- a/test/src/test/resources/fixtures/renames/types/renamed-type-in-union-declared-in-same-service.yml
+++ b/test/src/test/resources/fixtures/renames/types/renamed-type-in-union-declared-in-same-service.yml
@@ -1,4 +1,4 @@
-name: "renamed type in union 2"
+name: "renamed type in union declared in same service"
 enabled: true
 # language=GraphQL
 overallSchema:

--- a/test/src/test/resources/fixtures/renames/types/renamed-type-in-union-declared-in-same-service.yml
+++ b/test/src/test/resources/fixtures/renames/types/renamed-type-in-union-declared-in-same-service.yml
@@ -42,6 +42,12 @@ query: |
   query {
     nodes {
       __typename
+      ... on Issue {
+        id
+      }
+      ... on JiraComment {
+        id
+      }
     }
   }
 variables: { }
@@ -53,6 +59,12 @@ serviceCalls:
         {
           nodes {
             __typename
+            ... on Comment {
+              id
+            }
+            ... on Issue {
+              id
+            }
           }
         }
       variables: { }
@@ -62,10 +74,12 @@ serviceCalls:
         "data": {
           "nodes": [
             {
-              "__typename": "Issue"
+              "__typename": "Issue",
+              "id": "1"
             },
             {
-              "__typename": "Comment"
+              "__typename": "Comment",
+              "id": "2"
             }
           ]
         },
@@ -77,10 +91,12 @@ response: |-
     "data": {
       "nodes": [
         {
-          "__typename": "Issue"
+          "__typename": "Issue",
+          "id": "1"
         },
         {
-          "__typename": "JiraComment"
+          "__typename": "JiraComment",
+          "id": "2"
         }
       ]
     },


### PR DESCRIPTION
Please make sure you consider the following:

- [ ] Add tests that use __typename in queries
- [ ] Does this change work with all nadel transformations (rename, type rename, hydration, etc)? Add tests for this.
- [ ] Is it worth using hints for this change in order to be able to enable a percentage rollout?
- [ ] Do we need to add integration tests for this change in the graphql gateway?
- [ ] Do we need a pollinator check for this?


that's a follow up on https://github.com/atlassian-labs/nadel/pull/537
I put all changes that were done there behind a hint so we can have a safer rollout
also in that PR I missed one branch, fixed that and covered with a test