### PR TITLE
add graphql long to wiring factory

### DIFF
--- a/lib/src/main/java/graphql/nadel/schema/NeverWiringFactory.kt
+++ b/lib/src/main/java/graphql/nadel/schema/NeverWiringFactory.kt
@@ -1,6 +1,9 @@
 package graphql.nadel.schema
 
 import graphql.Assert.assertShouldNeverHappen
+import graphql.GraphQLContext
+import graphql.execution.CoercedVariables
+import graphql.language.Value
 import graphql.scalars.ExtendedScalars
 import graphql.schema.Coercing
 import graphql.schema.DataFetcher
@@ -12,9 +15,10 @@ import graphql.schema.idl.ScalarInfo
 import graphql.schema.idl.ScalarWiringEnvironment
 import graphql.schema.idl.UnionWiringEnvironment
 import graphql.schema.idl.WiringFactory
+import java.util.Locale
 
 /**
- * This wiring factory is designed to be NEVER called and will assert if it ever is.  Nadel
+ * This wiring factory is designed to be NEVER called and will assert if it ever is. Nadel
  * uses this for the overall schema and also in part for the underlying schema by default.
  */
 open class NeverWiringFactory : WiringFactory {
@@ -24,31 +28,55 @@ open class NeverWiringFactory : WiringFactory {
     }
 
     override fun getScalar(environment: ScalarWiringEnvironment): GraphQLScalarType? {
-        val scalarName = environment.scalarTypeDefinition.name
-        if (scalarName == ExtendedScalars.Json.name) {
-            return ExtendedScalars.Json
+        return when (val scalarName = environment.scalarTypeDefinition.name) {
+            ExtendedScalars.Json.name -> {
+                ExtendedScalars.Json
+            }
+            ExtendedScalars.GraphQLLong.name -> {
+                ExtendedScalars.GraphQLLong
+            }
+            else -> {
+                GraphQLScalarType.newScalar()
+                    .name(scalarName)
+                    .definition(environment.scalarTypeDefinition)
+                    .coercing(object : Coercing<Any?, Any?> {
+                        override fun serialize(
+                            dataFetcherResult: Any,
+                            graphQLContext: GraphQLContext,
+                            locale: Locale,
+                        ): Any? {
+                            return assertShouldNeverHappen(
+                                "This %s scalar coercing should NEVER be called from Nadel",
+                                scalarName
+                            )
+                        }
+
+                        override fun parseValue(
+                            input: Any,
+                            graphQLContext: GraphQLContext,
+                            locale: Locale,
+                        ): Any? {
+                            return assertShouldNeverHappen(
+                                "This %s scalar coercing should NEVER be called from Nadel",
+                                scalarName
+                            )
+                        }
+
+                        override fun parseLiteral(
+                            input: Value<*>,
+                            variables: CoercedVariables,
+                            graphQLContext: GraphQLContext,
+                            locale: Locale,
+                        ): Any? {
+                            return assertShouldNeverHappen(
+                                "This %s scalar coercing should NEVER be called from Nadel",
+                                scalarName
+                            )
+                        }
+                    })
+                    .build()
+            }
         }
-        return GraphQLScalarType
-            .newScalar()
-            .name(scalarName)
-            .definition(environment.scalarTypeDefinition)
-            .coercing(object : Coercing<Any?, Any?> {
-                override fun serialize(dataFetcherResult: Any): Any? {
-                    return assertShouldNeverHappen("This %s scalar coercing should NEVER be called from Nadel",
-                        scalarName)
-                }
-
-                override fun parseValue(input: Any): Any {
-                    return assertShouldNeverHappen("This %s scalar coercing should NEVER be called from Nadel",
-                        scalarName)
-                }
-
-                override fun parseLiteral(input: Any): Any {
-                    return assertShouldNeverHappen("This %s scalar coercing should NEVER be called from Nadel",
-                        scalarName)
-                }
-            })
-            .build()
     }
 
     override fun providesTypeResolver(environment: InterfaceWiringEnvironment): Boolean {

--- a/test/src/test/resources/fixtures/scalars/long-scalar-argument-with-default-values.yml
+++ b/test/src/test/resources/fixtures/scalars/long-scalar-argument-with-default-values.yml
@@ -1,22 +1,22 @@
-name: "long scalar is passthrough and can be anything technically"
+name: "long scalar argument with default values"
 enabled: true
 # language=GraphQL
 overallSchema:
   service: |
     type Query {
-      aField: Long
+      getFoo(arg: Long = 123): String
     }
     scalar Long
 # language=GraphQL
 underlyingSchema:
   service: |
     type Query {
-      aField: Long
+      getFoo(arg: Long = 123): String
     }
     scalar Long
 query: |
   query {
-    aField
+    getFoo(arg: 15)
   }
 variables: { }
 serviceCalls:
@@ -25,14 +25,14 @@ serviceCalls:
       # language=GraphQL
       query: |
         query {
-          aField
+          getFoo(arg: 15)
         }
       variables: { }
     # language=JSON
     response: |-
       {
         "data": {
-          "aField": "KFC Good"
+          "getFoo": "KFC Good"
         },
         "extensions": {}
       }
@@ -40,6 +40,6 @@ serviceCalls:
 response: |-
   {
     "data": {
-      "aField": "KFC Good"
+      "getFoo": "KFC Good"
     }
   }


### PR DESCRIPTION
Please make sure you consider the following:

- [ ] Add tests that use __typename in queries
- [ ] Does this change work with all nadel transformations (rename, type rename, hydration, etc)? Add tests for this.
- [ ] Is it worth using hints for this change in order to be able to enable a percentage rollout?
- [ ] Do we need to add integration tests for this change in the graphql gateway?
- [ ] Do we need a pollinator check for this?
