### PR TITLE
Fix top level hydration

### DIFF
--- a/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/batchHydration/BatchHydrationAtQueryTypeTest.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/batchHydration/BatchHydrationAtQueryTypeTest.kt
@@ -1,0 +1,62 @@
+package graphql.nadel.tests.next.fixtures.batchHydration
+
+import graphql.nadel.engine.util.strictAssociateBy
+import graphql.nadel.tests.next.NadelIntegrationTest
+
+class BatchHydrationAtQueryTypeTest : NadelIntegrationTest(
+    query = """
+        query {
+          myIssues {
+            title
+          }
+        }
+    """.trimIndent(),
+    services = listOf(
+        Service(
+            name = "issues",
+            overallSchema = """
+                type Query {
+                  issuesByIds(ids: [ID!]!): [Issue]
+                  myIssueKeys(limit: Int! = 25): [ID!] @hidden
+                  myIssues: [Issue]
+                    @hydrated(
+                      service: "issues"
+                      field: "issuesByIds"
+                      arguments: [{name: "ids", value: "$source.myIssueKeys"}]
+                      identifiedBy: "id"
+                    )
+                }
+                type Issue {
+                  id: ID!
+                  title: String
+                }
+            """.trimIndent(),
+            runtimeWiring = { wiring ->
+                data class Issue(
+                    val id: String,
+                    val title: String,
+                )
+
+                val issuesByIds = listOf(
+                    Issue(id = "hello", title = "Hello there"),
+                    Issue(id = "afternoon", title = "Good afternoon"),
+                    Issue(id = "bye", title = "Farewell"),
+                ).strictAssociateBy { it.id }
+
+                wiring
+                    .type("Query") { type ->
+                        type
+                            .dataFetcher("issuesByIds") { env ->
+                                env.getArgument<List<String>>("ids")
+                                    ?.map {
+                                        issuesByIds[it]
+                                    }
+                            }
+                            .dataFetcher("myIssueKeys") { env ->
+                                listOf("hello", "bye")
+                            }
+                    }
+            },
+        ),
+    ),
+)

--- a/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/batchHydration/BatchHydrationAtQueryTypeTestSnapshot.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/batchHydration/BatchHydrationAtQueryTypeTestSnapshot.kt
@@ -1,0 +1,113 @@
+// @formatter:off
+package graphql.nadel.tests.next.fixtures.batchHydration
+
+import graphql.nadel.tests.next.ExpectedNadelResult
+import graphql.nadel.tests.next.ExpectedServiceCall
+import graphql.nadel.tests.next.TestSnapshot
+import graphql.nadel.tests.next.listOfJsonStrings
+import kotlin.Suppress
+import kotlin.collections.List
+import kotlin.collections.listOf
+
+private suspend fun main() {
+    graphql.nadel.tests.next.update<BatchHydrationAtQueryTypeTest>()
+}
+
+/**
+ * This class is generated. Do NOT modify.
+ *
+ * Refer to [graphql.nadel.tests.next.UpdateTestSnapshots
+ */
+@Suppress("unused")
+public class BatchHydrationAtQueryTypeTestSnapshot : TestSnapshot() {
+    override val calls: List<ExpectedServiceCall> = listOf(
+            ExpectedServiceCall(
+                service = "issues",
+                query = """
+                | {
+                |   batch_hydration__myIssues__myIssueKeys: myIssueKeys
+                |   __typename__batch_hydration__myIssues: __typename
+                | }
+                """.trimMargin(),
+                variables = "{}",
+                result = """
+                | {
+                |   "data": {
+                |     "batch_hydration__myIssues__myIssueKeys": [
+                |       "hello",
+                |       "bye"
+                |     ],
+                |     "__typename__batch_hydration__myIssues": "Query"
+                |   }
+                | }
+                """.trimMargin(),
+                delayedResults = listOfJsonStrings(
+                ),
+            ),
+            ExpectedServiceCall(
+                service = "issues",
+                query = """
+                | {
+                |   issuesByIds(ids: ["hello", "bye"]) {
+                |     title
+                |     batch_hydration__myIssues__id: id
+                |   }
+                | }
+                """.trimMargin(),
+                variables = "{}",
+                result = """
+                | {
+                |   "data": {
+                |     "issuesByIds": [
+                |       {
+                |         "title": "Hello there",
+                |         "batch_hydration__myIssues__id": "hello"
+                |       },
+                |       {
+                |         "title": "Farewell",
+                |         "batch_hydration__myIssues__id": "bye"
+                |       }
+                |     ]
+                |   }
+                | }
+                """.trimMargin(),
+                delayedResults = listOfJsonStrings(
+                ),
+            ),
+        )
+
+    /**
+     * ```json
+     * {
+     *   "data": {
+     *     "myIssues": [
+     *       {
+     *         "title": "Hello there"
+     *       },
+     *       {
+     *         "title": "Farewell"
+     *       }
+     *     ]
+     *   }
+     * }
+     * ```
+     */
+    override val result: ExpectedNadelResult = ExpectedNadelResult(
+            result = """
+            | {
+            |   "data": {
+            |     "myIssues": [
+            |       {
+            |         "title": "Hello there"
+            |       },
+            |       {
+            |         "title": "Farewell"
+            |       }
+            |     ]
+            |   }
+            | }
+            """.trimMargin(),
+            delayedResults = listOfJsonStrings(
+            ),
+        )
+}

--- a/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/hydration/HydrationAtQueryTypeTest.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/hydration/HydrationAtQueryTypeTest.kt
@@ -1,0 +1,58 @@
+package graphql.nadel.tests.next.fixtures.hydration
+
+import graphql.nadel.engine.util.strictAssociateBy
+import graphql.nadel.tests.next.NadelIntegrationTest
+
+class HydrationAtQueryTypeTest : NadelIntegrationTest(
+    query = """
+        query {
+          myIssue {
+            title
+          }
+        }
+    """.trimIndent(),
+    services = listOf(
+        Service(
+            name = "issues",
+            overallSchema = """
+                type Query {
+                  issueById(id: ID!): Issue
+                  myIssueKey: ID! @hidden
+                  myIssue: Issue
+                    @hydrated(
+                      service: "issues"
+                      field: "issueById"
+                      arguments: [{name: "id", value: "$source.myIssueKey"}]
+                    )
+                }
+                type Issue {
+                  id: ID!
+                  title: String
+                }
+            """.trimIndent(),
+            runtimeWiring = { wiring ->
+                data class Issue(
+                    val id: String,
+                    val title: String,
+                )
+
+                val issuesByIds = listOf(
+                    Issue(id = "hello", title = "Hello there"),
+                    Issue(id = "afternoon", title = "Good afternoon"),
+                    Issue(id = "bye", title = "Farewell"),
+                ).strictAssociateBy { it.id }
+
+                wiring
+                    .type("Query") { type ->
+                        type
+                            .dataFetcher("issueById") { env ->
+                                issuesByIds[env.getArgument<String>("id")]
+                            }
+                            .dataFetcher("myIssueKey") { env ->
+                                "bye"
+                            }
+                    }
+            },
+        ),
+    ),
+)

--- a/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/hydration/HydrationAtQueryTypeTestSnapshot.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/hydration/HydrationAtQueryTypeTestSnapshot.kt
@@ -1,0 +1,92 @@
+// @formatter:off
+package graphql.nadel.tests.next.fixtures.hydration
+
+import graphql.nadel.tests.next.ExpectedNadelResult
+import graphql.nadel.tests.next.ExpectedServiceCall
+import graphql.nadel.tests.next.TestSnapshot
+import graphql.nadel.tests.next.listOfJsonStrings
+import kotlin.Suppress
+import kotlin.collections.List
+import kotlin.collections.listOf
+
+private suspend fun main() {
+    graphql.nadel.tests.next.update<HydrationAtQueryTypeTest>()
+}
+
+/**
+ * This class is generated. Do NOT modify.
+ *
+ * Refer to [graphql.nadel.tests.next.UpdateTestSnapshots
+ */
+@Suppress("unused")
+public class HydrationAtQueryTypeTestSnapshot : TestSnapshot() {
+    override val calls: List<ExpectedServiceCall> = listOf(
+            ExpectedServiceCall(
+                service = "issues",
+                query = """
+                | {
+                |   hydration__myIssue__myIssueKey: myIssueKey
+                |   __typename__hydration__myIssue: __typename
+                | }
+                """.trimMargin(),
+                variables = "{}",
+                result = """
+                | {
+                |   "data": {
+                |     "hydration__myIssue__myIssueKey": "bye",
+                |     "__typename__hydration__myIssue": "Query"
+                |   }
+                | }
+                """.trimMargin(),
+                delayedResults = listOfJsonStrings(
+                ),
+            ),
+            ExpectedServiceCall(
+                service = "issues",
+                query = """
+                | {
+                |   issueById(id: "bye") {
+                |     title
+                |   }
+                | }
+                """.trimMargin(),
+                variables = "{}",
+                result = """
+                | {
+                |   "data": {
+                |     "issueById": {
+                |       "title": "Farewell"
+                |     }
+                |   }
+                | }
+                """.trimMargin(),
+                delayedResults = listOfJsonStrings(
+                ),
+            ),
+        )
+
+    /**
+     * ```json
+     * {
+     *   "data": {
+     *     "myIssue": {
+     *       "title": "Farewell"
+     *     }
+     *   }
+     * }
+     * ```
+     */
+    override val result: ExpectedNadelResult = ExpectedNadelResult(
+            result = """
+            | {
+            |   "data": {
+            |     "myIssue": {
+            |       "title": "Farewell"
+            |     }
+            |   }
+            | }
+            """.trimMargin(),
+            delayedResults = listOfJsonStrings(
+            ),
+        )
+}


### PR DESCRIPTION
So the bug was that we couldn't find the service that owned a hydrated field, because we looked at the ownership of the parent type of the hydrated field, which for root level hydrations was the operation type.

Then on top of that, we didn't handle multple root level fields.

This PR fixes both.