### PR TITLE
Avoid hasNext=true on the last incremental payload

### DIFF
--- a/lib/src/main/java/graphql/nadel/engine/NadelIncrementalResultAccumulator.kt
+++ b/lib/src/main/java/graphql/nadel/engine/NadelIncrementalResultAccumulator.kt
@@ -115,14 +115,6 @@ class NadelIncrementalResultAccumulator(
             }
 
         if (readyAccumulators.isEmpty()) {
-            if(!hasNext) {
-                // We have to return hasNext=false to indicate to clients that there's no more data coming.
-                // Note: the spec allows an empty payload which only contains hastNext=false to be returned.
-                return DelayedIncrementalPartialResultImpl.newIncrementalExecutionResult()
-                    .incrementalItems(emptyList())
-                    .hasNext(false)
-                    .build()
-            }
             return null
         }
 

--- a/lib/src/main/java/graphql/nadel/engine/NadelIncrementalResultAccumulator.kt
+++ b/lib/src/main/java/graphql/nadel/engine/NadelIncrementalResultAccumulator.kt
@@ -40,7 +40,7 @@ import graphql.normalized.incremental.NormalizedDeferredExecution
  * the user.
  */
 class NadelIncrementalResultAccumulator(
-    private val operation: ExecutableNormalizedOperation,
+    operation: ExecutableNormalizedOperation,
 ) {
     data class DeferAccumulatorKey(
         val incrementalPayloadPath: List<Any>,
@@ -115,6 +115,14 @@ class NadelIncrementalResultAccumulator(
             }
 
         if (readyAccumulators.isEmpty()) {
+            if(!hasNext) {
+                // We have to return hasNext=false to indicate to clients that there's no more data coming.
+                // Note: the spec allows an empty payload which only contains hastNext=false to be returned.
+                return DelayedIncrementalPartialResultImpl.newIncrementalExecutionResult()
+                    .incrementalItems(emptyList())
+                    .hasNext(false)
+                    .build()
+            }
             return null
         }
 

--- a/lib/src/main/java/graphql/nadel/engine/NadelIncrementalResultSupport.kt
+++ b/lib/src/main/java/graphql/nadel/engine/NadelIncrementalResultSupport.kt
@@ -2,7 +2,6 @@ package graphql.nadel.engine
 
 import graphql.incremental.DelayedIncrementalPartialResult
 import graphql.nadel.engine.NadelIncrementalResultSupport.OutstandingJobCounter.OutstandingJobHandle
-import graphql.nadel.engine.util.copy
 import graphql.nadel.util.getLogger
 import graphql.normalized.ExecutableNormalizedOperation
 import kotlinx.coroutines.CompletableDeferred
@@ -10,7 +9,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.cancel
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
@@ -143,21 +141,6 @@ class NadelIncrementalResultSupport internal constructor(
 
         // Unblocks work to yield results to the channel
         initialCompletionLock.complete(Unit)
-    }
-
-    fun close() {
-        coroutineScope.cancel()
-    }
-
-    private fun quickCopy(
-        subject: DelayedIncrementalPartialResult,
-        hasNext: Boolean,
-    ): DelayedIncrementalPartialResult {
-        return if (subject.hasNext() == hasNext) {
-            subject
-        } else {
-            subject.copy(hasNext = hasNext)
-        }
     }
 
     /**

--- a/lib/src/main/java/graphql/nadel/engine/transform/hydration/NadelHydrationTransform.kt
+++ b/lib/src/main/java/graphql/nadel/engine/transform/hydration/NadelHydrationTransform.kt
@@ -239,6 +239,10 @@ internal class NadelHydrationTransform(
                 )
             }
 
+        if(preparedHydrations.isEmpty()) {
+            return
+        }
+
         // This isn't really right… but we start with this
         val label = overallField.deferredExecutions.firstNotNullOfOrNull { it.label }
 

--- a/lib/src/test/kotlin/graphql/nadel/engine/NadelIncrementalResultAccumulatorTest.kt
+++ b/lib/src/test/kotlin/graphql/nadel/engine/NadelIncrementalResultAccumulatorTest.kt
@@ -174,7 +174,7 @@ class NadelIncrementalResultAccumulatorTest {
                 )
 
                 // Then
-                val result = accumulator.getIncrementalPartialResult(false)
+                val result = accumulator.getIncrementalPartialResult(true)
                 assertTrue(result == null)
             }
         }

--- a/lib/src/test/kotlin/graphql/nadel/engine/NadelIncrementalResultAccumulatorTest.kt
+++ b/lib/src/test/kotlin/graphql/nadel/engine/NadelIncrementalResultAccumulatorTest.kt
@@ -174,40 +174,10 @@ class NadelIncrementalResultAccumulatorTest {
                 )
 
                 // Then
-                val result = accumulator.getIncrementalPartialResult(true)
+                val result = accumulator.getIncrementalPartialResult(false)
                 assertTrue(result == null)
             }
         }
-    }
-
-    @Test
-    fun `yields empty payload if hasNext=false and accumulator is empty`() {
-        val accumulator = makeAccumulator(
-            query = """
-                        query {
-                          issue(id: "1") {
-                            ... @defer {
-                              id
-                              assignee {
-                                name
-                              }
-                            }
-                          }
-                        }
-                    """.trimIndent(),
-        )
-
-        // When
-        accumulator.accumulate(
-            DelayedIncrementalPartialResultImpl.newIncrementalExecutionResult()
-                .incrementalItems(emptyList())
-                .build(),
-        )
-
-        // Then
-        val result = accumulator.getIncrementalPartialResult(false)
-        assertTrue(result!!.incremental!!.isEmpty())
-        assertFalse(result.hasNext())
     }
 
     @Test

--- a/lib/src/test/kotlin/graphql/nadel/engine/NadelIncrementalResultAccumulatorTest.kt
+++ b/lib/src/test/kotlin/graphql/nadel/engine/NadelIncrementalResultAccumulatorTest.kt
@@ -181,6 +181,36 @@ class NadelIncrementalResultAccumulatorTest {
     }
 
     @Test
+    fun `yields empty payload if hasNext=false and accumulator is empty`() {
+        val accumulator = makeAccumulator(
+            query = """
+                        query {
+                          issue(id: "1") {
+                            ... @defer {
+                              id
+                              assignee {
+                                name
+                              }
+                            }
+                          }
+                        }
+                    """.trimIndent(),
+        )
+
+        // When
+        accumulator.accumulate(
+            DelayedIncrementalPartialResultImpl.newIncrementalExecutionResult()
+                .incrementalItems(emptyList())
+                .build(),
+        )
+
+        // Then
+        val result = accumulator.getIncrementalPartialResult(false)
+        assertTrue(result!!.incremental!!.isEmpty())
+        assertFalse(result.hasNext())
+    }
+
+    @Test
     fun `yields list elements that are complete`() {
         val accumulator = makeAccumulator(
             query = """

--- a/lib/src/test/kotlin/graphql/nadel/engine/NadelIncrementalResultSupportTest.kt
+++ b/lib/src/test/kotlin/graphql/nadel/engine/NadelIncrementalResultSupportTest.kt
@@ -373,7 +373,11 @@ class NadelIncrementalResultSupportTest {
         // Then
         subject.onInitialResultComplete()
 
-        assertTrue(channel.toList().isEmpty())
+        val elements = channel.toList()
+
+        assertTrue(elements.size == 1)
+        assertFalse(elements[0].hasNext())
+        assertTrue(elements[0].incremental!!.isEmpty())
 
         verifyOrder {
             accumulator.accumulate(any())

--- a/test/src/test/kotlin/graphql/nadel/tests/next/NadelIntegrationTest.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/next/NadelIntegrationTest.kt
@@ -379,7 +379,9 @@ abstract class NadelIntegrationTest(
             // Note: there exists a IncrementalExecutionResult.getIncremental but that is part of the initial result
             assertTrue(result is IncrementalExecutionResult)
 
-            // Fuck why delayed & incremental?? Shouldn't incremental == delayed? Why is there an optional synchronous incremental??
+            // Note: the spec allows for a list of "incremental" results which is sent as part of the initial
+            // result (so not delivered in a delayed fashion). This var represents the incremental results that were
+            // sent in a delayed fashion.
             val actualDelayedResponses = incrementalResults!!
 
             // Should only have one element that says hasNext=false, and it should be the last one


### PR DESCRIPTION
The computation of `hasNext` is somewhat flaky, as we can see in the occasional failure of `HydrationDeferGroupingTest`.

The failure occurs because sometimes the last deferred payload contains `hasNext=true`. 
This is possible since not all results from an outstanding job will be converted to a deferred payload and sent to the results channel.

So we might have something like this
1. defer task A starts -> outstanding jobs count is 1
2. defer task B starts  -> outstanding jobs count is 2
3. defer task A completes and results on a non-null defer payload after being processed by the accumulator -> outstanding jobs count is 1, so hasNext=true
4. defer task B completes and results in null, so no events are emitted and the publisher finishes producing.

The last (and only) event that was actually emitted has hasNext=true, so clients will hang waiting for a completion event forever.

Note: this PR doesn't fix the flaky test (yet)