### PR TITLE
Kotest assertions

### DIFF
--- a/lib/src/test/kotlin/graphql/nadel/engine/instrumentation/NadelInstrumentationTimerTest.kt
+++ b/lib/src/test/kotlin/graphql/nadel/engine/instrumentation/NadelInstrumentationTimerTest.kt
@@ -1,7 +1,6 @@
 package graphql.nadel.engine.instrumentation
 
 import graphql.execution.instrumentation.InstrumentationState
-import graphql.nadel.engine.transform.hydration.batch.NadelBatchHydrationTransform
 import graphql.nadel.instrumentation.NadelInstrumentation
 import graphql.nadel.instrumentation.parameters.NadelInstrumentationTimingParameters
 import graphql.nadel.instrumentation.parameters.NadelInstrumentationTimingParameters.ChildStep
@@ -293,7 +292,7 @@ class NadelInstrumentationTimerTest : DescribeSpec({
             }
 
             // then
-            assert(instrumentationParams.isEmpty())
+            instrumentationParams.shouldBeEmpty()
 
             // when
             batchTimer.submit()

--- a/lib/src/test/kotlin/graphql/nadel/validation/NadelEnumValidationTest.kt
+++ b/lib/src/test/kotlin/graphql/nadel/validation/NadelEnumValidationTest.kt
@@ -3,6 +3,8 @@ package graphql.nadel.validation
 import graphql.nadel.validation.NadelSchemaValidationError.MissingUnderlyingEnumValue
 import graphql.nadel.validation.util.assertSingleOfType
 import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.shouldBe
 
 class NadelEnumValidationTest : DescribeSpec({
     describe("validate") {
@@ -39,7 +41,7 @@ class NadelEnumValidationTest : DescribeSpec({
             )
 
             val errors = validate(fixture)
-            assert(errors.isEmpty())
+            errors.shouldBeEmpty()
         }
 
         it("passes if enum was renamed") {
@@ -75,7 +77,7 @@ class NadelEnumValidationTest : DescribeSpec({
             )
 
             val errors = validate(fixture)
-            assert(errors.isEmpty())
+            errors.shouldBeEmpty()
         }
 
         it("fails if enum value does not exist in underlying type") {
@@ -115,8 +117,8 @@ class NadelEnumValidationTest : DescribeSpec({
             assert(errors.isNotEmpty())
 
             val error = errors.assertSingleOfType<MissingUnderlyingEnumValue>()
-            assert(error.service.name == "promos")
-            assert(error.overallValue.name == "P2")
+            error.service.name.shouldBe("promos")
+            error.overallValue.name.shouldBe("P2")
         }
     }
 })

--- a/lib/src/test/kotlin/graphql/nadel/validation/NadelFieldValidationTest.kt
+++ b/lib/src/test/kotlin/graphql/nadel/validation/NadelFieldValidationTest.kt
@@ -7,6 +7,8 @@ import graphql.nadel.validation.NadelSchemaValidationError.MissingUnderlyingFiel
 import graphql.nadel.validation.util.assertSingleOfType
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.datatest.withData
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.shouldBe
 
 val namespaceDirectiveDef = """
     directive @namespaced on FIELD_DEFINITION
@@ -33,7 +35,7 @@ class NadelFieldValidationTest : DescribeSpec({
             )
 
             val errors = validate(fixture)
-            assert(errors.map { it.message }.isEmpty())
+            errors.map { it.message }.shouldBeEmpty()
         }
 
         it("fails if argument value is missing") {
@@ -58,11 +60,11 @@ class NadelFieldValidationTest : DescribeSpec({
             assert(errors.map { it.message }.isNotEmpty())
 
             val error = errors.assertSingleOfType<MissingArgumentOnUnderlying>()
-            assert(error.parentType.overall.name == "Query")
-            assert(error.parentType.underlying.name == "Query")
-            assert(error.overallField.name == "echo")
-            assert(error.subject == error.overallField)
-            assert(error.argument.name == "world")
+            error.parentType.overall.name.shouldBe("Query")
+            error.parentType.underlying.name.shouldBe("Query")
+            error.overallField.name.shouldBe("echo")
+            error.subject.shouldBe(error.overallField)
+            error.argument.name.shouldBe("world")
         }
 
         it("passes if overall argument value is stricter") {
@@ -84,7 +86,7 @@ class NadelFieldValidationTest : DescribeSpec({
             )
 
             val errors = validate(fixture)
-            assert(errors.map { it.message }.isEmpty())
+            errors.map { it.message }.shouldBeEmpty()
         }
 
         it("passes if overall argument value is stricter with more wrappings") {
@@ -106,7 +108,7 @@ class NadelFieldValidationTest : DescribeSpec({
             )
 
             val errors = validate(fixture)
-            assert(errors.map { it.message }.isEmpty())
+            errors.map { it.message }.shouldBeEmpty()
         }
 
         it("passes if overall argument value is stricter with more wrappings 2") {
@@ -131,12 +133,12 @@ class NadelFieldValidationTest : DescribeSpec({
             assert(errors.map { it.message }.isNotEmpty())
 
             val error = errors.assertSingleOfType<IncompatibleArgumentInputType>()
-            assert(error.parentType.overall.name == "Query")
-            assert(error.parentType.underlying.name == "Query")
-            assert(error.overallInputArg.type.unwrapAll().name == "Boolean")
-            assert(error.subject == error.overallInputArg)
-            assert(error.overallField.name == "echo")
-            assert(error.overallInputArg.name == "world")
+            error.parentType.overall.name.shouldBe("Query")
+            error.parentType.underlying.name.shouldBe("Query")
+            error.overallInputArg.type.unwrapAll().name.shouldBe("Boolean")
+            error.subject.shouldBe(error.overallInputArg)
+            error.overallField.name.shouldBe("echo")
+            error.overallInputArg.name.shouldBe("world")
         }
 
         context("fails if argument type list wrappings are not equal") {
@@ -172,12 +174,12 @@ class NadelFieldValidationTest : DescribeSpec({
                 assert(errors.map { it.message }.isNotEmpty())
 
                 val error = errors.assertSingleOfType<IncompatibleArgumentInputType>()
-                assert(error.parentType.overall.name == "Query")
-                assert(error.parentType.underlying.name == "Query")
-                assert(error.subject == error.overallInputArg)
-                assert(error.overallField.name == "echo")
-                assert(error.overallInputArg.name == "world")
-                assert(error.overallInputArg.type.unwrapAll().name == error.overallInputArg.type.unwrapAll().name)
+                error.parentType.overall.name.shouldBe("Query")
+                error.parentType.underlying.name.shouldBe("Query")
+                error.subject.shouldBe(error.overallInputArg)
+                error.overallField.name.shouldBe("echo")
+                error.overallInputArg.name.shouldBe("world")
+                error.overallInputArg.type.unwrapAll().name.shouldBe(error.overallInputArg.type.unwrapAll().name)
             }
         }
 
@@ -203,10 +205,10 @@ class NadelFieldValidationTest : DescribeSpec({
             assert(errors.map { it.message }.isNotEmpty())
 
             val error = errors.assertSingleOfType<IncompatibleArgumentInputType>()
-            assert(error.parentType.overall.name == "Query")
-            assert(error.parentType.underlying.name == "Query")
-            assert(error.overallInputArg.type.unwrapAll().name == "Boolean")
-            assert(error.subject == error.overallInputArg)
+            error.parentType.overall.name.shouldBe("Query")
+            error.parentType.underlying.name.shouldBe("Query")
+            error.overallInputArg.type.unwrapAll().name.shouldBe("Boolean")
+            error.subject.shouldBe(error.overallInputArg)
         }
 
         it("fails if argument value is not matching") {
@@ -231,11 +233,11 @@ class NadelFieldValidationTest : DescribeSpec({
             assert(errors.map { it.message }.isNotEmpty())
 
             val error = errors.assertSingleOfType<IncompatibleArgumentInputType>()
-            assert(error.parentType.overall.name == "Query")
-            assert(error.parentType.underlying.name == "Query")
-            assert(error.overallInputArg.type.unwrapAll().name == "Boolean")
-            assert(error.underlyingInputArg.type.unwrapAll().name == "String")
-            assert(error.subject == error.overallInputArg)
+            error.parentType.overall.name.shouldBe("Query")
+            error.parentType.underlying.name.shouldBe("Query")
+            error.overallInputArg.type.unwrapAll().name.shouldBe("Boolean")
+            error.underlyingInputArg.type.unwrapAll().name.shouldBe("String")
+            error.subject.shouldBe(error.overallInputArg)
         }
 
         it("checks the output type") {
@@ -276,10 +278,10 @@ class NadelFieldValidationTest : DescribeSpec({
             assert(errors.map { it.message }.isNotEmpty())
 
             val error = errors.assertSingleOfType<MissingUnderlyingField>()
-            assert(error.parentType.overall.name == "Echo")
-            assert(error.parentType.underlying.name == "Echo")
-            assert(error.overallField.name == "hello")
-            assert(error.subject == error.overallField)
+            error.parentType.overall.name.shouldBe("Echo")
+            error.parentType.underlying.name.shouldBe("Echo")
+            error.overallField.name.shouldBe("hello")
+            error.subject.shouldBe(error.overallField)
         }
 
         it("handles types whose fields are contributed from multiple services") {
@@ -341,7 +343,7 @@ class NadelFieldValidationTest : DescribeSpec({
             )
 
             val errors = validate(fixture)
-            assert(errors.map { it.message }.isEmpty())
+            errors.map { it.message }.shouldBeEmpty()
         }
 
         it("fails if field in namespace does not exist") {
@@ -406,11 +408,11 @@ class NadelFieldValidationTest : DescribeSpec({
             assert(errors.map { it.message }.isNotEmpty())
 
             val error = errors.assertSingleOfType<MissingUnderlyingField>()
-            assert(error.service.name == "echo")
-            assert(error.parentType.overall.name == "TestQuery")
-            assert(error.parentType.underlying.name == "TestQuery")
-            assert(error.overallField.name == "worlds")
-            assert(error.subject == error.overallField)
+            error.service.name.shouldBe("echo")
+            error.parentType.overall.name.shouldBe("TestQuery")
+            error.parentType.underlying.name.shouldBe("TestQuery")
+            error.overallField.name.shouldBe("worlds")
+            error.subject.shouldBe(error.overallField)
         }
 
         it("checks mutation and subscription namespaced fields") {
@@ -535,28 +537,28 @@ class NadelFieldValidationTest : DescribeSpec({
             val queryError = errors.assertSingleOfType<MissingUnderlyingField> { error ->
                 error.parentType.overall.name == "TestQuery"
             }
-            assert(queryError.service.name == "echo")
-            assert(queryError.parentType.underlying.name == "TestQuery")
-            assert(queryError.overallField.name == "worlds")
-            assert(queryError.subject == queryError.overallField)
+            queryError.service.name.shouldBe("echo")
+            queryError.parentType.underlying.name.shouldBe("TestQuery")
+            queryError.overallField.name.shouldBe("worlds")
+            queryError.subject.shouldBe(queryError.overallField)
 
             val mutationError = errors.assertSingleOfType<MissingUnderlyingField> { error ->
                 error.parentType.overall.name == "TestMutation"
             }
-            assert(mutationError.service.name == "echo")
-            assert(mutationError.parentType.underlying.name == "TestMutation")
-            assert(mutationError.overallField.name == "active")
-            assert(mutationError.subject == mutationError.overallField)
+            mutationError.service.name.shouldBe("echo")
+            mutationError.parentType.underlying.name.shouldBe("TestMutation")
+            mutationError.overallField.name.shouldBe("active")
+            mutationError.subject.shouldBe(mutationError.overallField)
 
             val subscriptionError = errors.assertSingleOfType<MissingUnderlyingField> { error ->
                 error.parentType.overall.name == "TestSubscription"
             }
-            assert(subscriptionError.service.name == "issues")
-            assert(subscriptionError.parentType.underlying.name == "TestSubscription")
-            assert(subscriptionError.overallField.name == "issue")
-            assert(subscriptionError.subject == subscriptionError.overallField)
+            subscriptionError.service.name.shouldBe("issues")
+            subscriptionError.parentType.underlying.name.shouldBe("TestSubscription")
+            subscriptionError.overallField.name.shouldBe("issue")
+            subscriptionError.subject.shouldBe(subscriptionError.overallField)
 
-            assert(errors.count { it is MissingUnderlyingField } == 3)
+            errors.count { it is MissingUnderlyingField }.shouldBe(3)
         }
 
         it("passes if hydrated type is not present in underlying") {
@@ -608,7 +610,7 @@ class NadelFieldValidationTest : DescribeSpec({
             )
 
             val errors = validate(fixture)
-            assert(errors.isEmpty())
+            errors.shouldBeEmpty()
         }
 
         it("fails if fields declared in extensions are missing in underlying") {
@@ -643,10 +645,10 @@ class NadelFieldValidationTest : DescribeSpec({
             )
 
             val errors = validate(fixture)
-            assert(errors.size == 1)
+            errors.size.shouldBe(1)
 
             val error = errors.assertSingleOfType<NadelSchemaValidationError>()
-            assert(error.message == "Could not find overall field TypeA.fieldFromExtension on the underlying type TypeA on service test")
+            error.message.shouldBe("Could not find overall field TypeA.fieldFromExtension on the underlying type TypeA on service test")
         }
 
         it("fails if fields in extended Query are missing in underlying") {
@@ -670,11 +672,11 @@ class NadelFieldValidationTest : DescribeSpec({
 
             val errors = validate(fixture)
 
-            assert(errors.size == 1)
+            errors.size.shouldBe(1)
 
             val error = errors.assertSingleOfType<NadelSchemaValidationError>()
 
-            assert(error.message == "The overall field Query.fieldA defines argument id which does not exist in service test field Query.fieldA")
+            error.message.shouldBe("The overall field Query.fieldA defines argument id which does not exist in service test field Query.fieldA")
         }
     }
 })

--- a/lib/src/test/kotlin/graphql/nadel/validation/NadelHydrationArgumentValidationTest.kt
+++ b/lib/src/test/kotlin/graphql/nadel/validation/NadelHydrationArgumentValidationTest.kt
@@ -9,6 +9,8 @@ import graphql.nadel.validation.NadelSchemaValidationError.StaticArgIsNotAssigna
 import graphql.nadel.validation.util.assertSingleOfType
 import graphql.schema.GraphQLTypeUtil
 import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.shouldBe
 
 private const val source = "$" + "source"
 private const val argument = "$" + "argument"
@@ -75,15 +77,15 @@ class NadelHydrationArgumentValidationTest : DescribeSpec({
 
             val error = errors.assertSingleOfType<IncompatibleHydrationArgumentType>()
             //actor field arg:
-            assert(error.parentType.overall.name == "JiraIssue")
-            assert(error.overallField.name == "creator")
-            assert(error.remoteArg.name == "id")
-            assert(GraphQLTypeUtil.simplePrint(error.actorArgInputType) == "Int")
+            error.parentType.overall.name.shouldBe("JiraIssue")
+            error.overallField.name.shouldBe("creator")
+            error.remoteArg.name.shouldBe("id")
+            GraphQLTypeUtil.simplePrint(error.actorArgInputType).shouldBe("Int")
             // supplied hydration for arg:
-            assert(error.parentType.underlying.name == "Issue")
+            error.parentType.underlying.name.shouldBe("Issue")
             val remoteArgumentSource = error.remoteArg.remoteArgumentSource as RemoteArgumentSource.ObjectField
-            assert(remoteArgumentSource.pathToField.joinToString(separator = ".") == "creator")
-            assert(GraphQLTypeUtil.simplePrint(error.hydrationType) == "ID!")
+            remoteArgumentSource.pathToField.joinToString(separator = ".").shouldBe("creator")
+            GraphQLTypeUtil.simplePrint(error.hydrationType).shouldBe("ID!")
         }
 
         it("allows a source field of type String to be assigned to actor field argument of type ID") {
@@ -138,7 +140,7 @@ class NadelHydrationArgumentValidationTest : DescribeSpec({
                 ),
             )
             val errors = validate(fixture)
-            assert(errors.map { it.message }.isEmpty())
+            errors.map { it.message }.shouldBeEmpty()
         }
 
         it("allows a source field of type Int to be assigned to actor field argument of type ID") {
@@ -193,7 +195,7 @@ class NadelHydrationArgumentValidationTest : DescribeSpec({
                 ),
             )
             val errors = validate(fixture)
-            assert(errors.map { it.message }.isEmpty())
+            errors.map { it.message }.shouldBeEmpty()
         }
 
         it("allows a non-null source field to be applied to a nullable actor field argument") {
@@ -248,7 +250,7 @@ class NadelHydrationArgumentValidationTest : DescribeSpec({
                 ),
             )
             val errors = validate(fixture)
-            assert(errors.map { it.message }.isEmpty())
+            errors.map { it.message }.shouldBeEmpty()
         }
 
         it("allows a nullable source field to be applied to a non-null actor field argument") {
@@ -303,7 +305,7 @@ class NadelHydrationArgumentValidationTest : DescribeSpec({
                 ),
             )
             val errors = validate(fixture)
-            assert(errors.map { it.message }.isEmpty())
+            errors.map { it.message }.shouldBeEmpty()
         }
 
         it("fails when trying to assign a nullable input argument to a non-null actor field argument") {
@@ -365,14 +367,14 @@ class NadelHydrationArgumentValidationTest : DescribeSpec({
 
             val error = errors.assertSingleOfType<IncompatibleHydrationArgumentType>()
             // required actor field arg:
-            assert(error.parentType.overall.name == "JiraIssue")
-            assert(error.overallField.name == "creator")
-            assert(error.remoteArg.name == "id")
-            assert(GraphQLTypeUtil.simplePrint(error.actorArgInputType) == "ID!")
+            error.parentType.overall.name.shouldBe("JiraIssue")
+            error.overallField.name.shouldBe("creator")
+            error.remoteArg.name.shouldBe("id")
+            GraphQLTypeUtil.simplePrint(error.actorArgInputType).shouldBe("ID!")
             // supplied hydration for arg:
             val remoteArgumentSource = error.remoteArg.remoteArgumentSource as RemoteArgumentSource.FieldArgument
-            assert(remoteArgumentSource.argumentName == "creatorId")
-            assert(GraphQLTypeUtil.simplePrint(error.hydrationType) == "ID")
+            remoteArgumentSource.argumentName.shouldBe("creatorId")
+            GraphQLTypeUtil.simplePrint(error.hydrationType).shouldBe("ID")
         }
 
         it("actor field array arg assignability is allowed (batch hydration)") {
@@ -427,7 +429,7 @@ class NadelHydrationArgumentValidationTest : DescribeSpec({
                 ),
             )
             val errors = validate(fixture)
-            assert(errors.map { it.message }.isEmpty())
+            errors.map { it.message }.shouldBeEmpty()
         }
 
         it("testing array - compatible list of lists passes validation") {
@@ -482,7 +484,7 @@ class NadelHydrationArgumentValidationTest : DescribeSpec({
                 ),
             )
             val errors = validate(fixture)
-            assert(errors.map { it.message }.isEmpty())
+            errors.map { it.message }.shouldBeEmpty()
         }
 
         it("testing array - incompatible list of lists fails validation") {
@@ -545,15 +547,15 @@ class NadelHydrationArgumentValidationTest : DescribeSpec({
 
             val error = errors.assertSingleOfType<IncompatibleHydrationArgumentType>()
             // required actor field arg:
-            assert(error.parentType.overall.name == "JiraIssue")
-            assert(error.overallField.name == "creator")
-            assert(error.remoteArg.name == "ids")
-            assert(GraphQLTypeUtil.simplePrint(error.actorArgInputType) == "[[String!]!]!")
+            error.parentType.overall.name.shouldBe("JiraIssue")
+            error.overallField.name.shouldBe("creator")
+            error.remoteArg.name.shouldBe("ids")
+            GraphQLTypeUtil.simplePrint(error.actorArgInputType).shouldBe("[[String!]!]!")
             // supplied hydration for arg:
-            assert(error.parentType.underlying.name == "Issue")
+            error.parentType.underlying.name.shouldBe("Issue")
             val remoteArgumentSource = error.remoteArg.remoteArgumentSource as RemoteArgumentSource.ObjectField
-            assert(remoteArgumentSource.pathToField.joinToString(separator = ".") == "creators")
-            assert(GraphQLTypeUtil.simplePrint(error.hydrationType) == "[[Int!]!]!")
+            remoteArgumentSource.pathToField.joinToString(separator = ".").shouldBe("creators")
+            GraphQLTypeUtil.simplePrint(error.hydrationType).shouldBe("[[Int!]!]!")
         }
 
         it("input object - validation allows compatible input objects") {
@@ -621,7 +623,7 @@ class NadelHydrationArgumentValidationTest : DescribeSpec({
                 ),
             )
             val errors = validate(fixture)
-            assert(errors.map { it.message }.isEmpty())
+            errors.map { it.message }.shouldBeEmpty()
         }
 
         it("input object - fails if incompatible input objects (missing field)") {
@@ -699,15 +701,15 @@ class NadelHydrationArgumentValidationTest : DescribeSpec({
 
             val error = errors.assertSingleOfType<MissingFieldInHydratedInputObject>()
             // assert the missing type is the correct one
-            assert(error.missingFieldName == "middleName")
+            error.missingFieldName.shouldBe("middleName")
             // required actor field arg:
-            assert(error.parentType.overall.name == "JiraIssue")
-            assert(error.overallField.name == "creator")
-            assert(error.remoteArg.name == "name")
+            error.parentType.overall.name.shouldBe("JiraIssue")
+            error.overallField.name.shouldBe("creator")
+            error.remoteArg.name.shouldBe("name")
             // supplied hydration for arg:
-            assert(error.parentType.underlying.name == "Issue")
+            error.parentType.underlying.name.shouldBe("Issue")
             val remoteArgumentSource = error.remoteArg.remoteArgumentSource as RemoteArgumentSource.ObjectField
-            assert(remoteArgumentSource.pathToField.joinToString(separator = ".") == "creator")
+            remoteArgumentSource.pathToField.joinToString(separator = ".").shouldBe("creator")
         }
 
         it("input object - validation allows a valid array nested inside object") {
@@ -778,7 +780,7 @@ class NadelHydrationArgumentValidationTest : DescribeSpec({
                 ),
             )
             val errors = validate(fixture)
-            assert(errors.map { it.message }.isEmpty())
+            errors.map { it.message }.shouldBeEmpty()
         }
 
         it("input object - allows a valid input nested inside an input") {
@@ -860,7 +862,7 @@ class NadelHydrationArgumentValidationTest : DescribeSpec({
                 ),
             )
             val errors = validate(fixture)
-            assert(errors.map { it.message }.isEmpty())
+            errors.map { it.message }.shouldBeEmpty()
         }
 
         it("input object - fails validation an invalid type inside input inside another input") {
@@ -948,13 +950,13 @@ class NadelHydrationArgumentValidationTest : DescribeSpec({
             // using value from Issue.creator but the types are not compatible
             val error = errors.assertSingleOfType<IncompatibleFieldInHydratedInputObject>()
             // required actor field arg:
-            assert(error.parentType.overall.name == "JiraIssue")
-            assert(error.overallField.name == "creator")
-            assert(error.remoteArg.name == "userInfo")
+            error.parentType.overall.name.shouldBe("JiraIssue")
+            error.overallField.name.shouldBe("creator")
+            error.remoteArg.name.shouldBe("userInfo")
             // supplied hydration for arg:
-            assert(error.parentType.underlying.name == "Issue")
+            error.parentType.underlying.name.shouldBe("Issue")
             val remoteArgumentSource = error.remoteArg.remoteArgumentSource as RemoteArgumentSource.ObjectField
-            assert(remoteArgumentSource.pathToField.joinToString(separator = ".") == "creator")
+            remoteArgumentSource.pathToField.joinToString(separator = ".").shouldBe("creator")
 
         }
 
@@ -1023,7 +1025,7 @@ class NadelHydrationArgumentValidationTest : DescribeSpec({
                 ),
             )
             val errors = validate(fixture)
-            assert(errors.map { it.message }.isEmpty())
+            errors.map { it.message }.shouldBeEmpty()
         }
 
         it("testing array - validation fails on incompatible array of objects") {
@@ -1101,15 +1103,15 @@ class NadelHydrationArgumentValidationTest : DescribeSpec({
 
             val error = errors.assertSingleOfType<IncompatibleHydrationArgumentType>()
             // required actor field arg:
-            assert(error.parentType.overall.name == "JiraIssue")
-            assert(error.overallField.name == "creators")
-            assert(error.remoteArg.name == "names")
-            assert(GraphQLTypeUtil.simplePrint(error.actorArgInputType) == "[FullNameInput]!")
+            error.parentType.overall.name.shouldBe("JiraIssue")
+            error.overallField.name.shouldBe("creators")
+            error.remoteArg.name.shouldBe("names")
+            GraphQLTypeUtil.simplePrint(error.actorArgInputType).shouldBe("[FullNameInput]!")
             // supplied hydration for arg:
-            assert(error.parentType.underlying.name == "Issue")
+            error.parentType.underlying.name.shouldBe("Issue")
             val remoteArgumentSource = error.remoteArg.remoteArgumentSource as RemoteArgumentSource.ObjectField
-            assert(remoteArgumentSource.pathToField.joinToString(separator = ".") == "creators")
-            assert(GraphQLTypeUtil.simplePrint(error.hydrationType) == "[FullName]!")
+            remoteArgumentSource.pathToField.joinToString(separator = ".").shouldBe("creators")
+            GraphQLTypeUtil.simplePrint(error.hydrationType).shouldBe("[FullName]!")
 
         }
 
@@ -1172,12 +1174,12 @@ class NadelHydrationArgumentValidationTest : DescribeSpec({
 
             val error = errors.assertSingleOfType<IncompatibleHydrationArgumentType>()
             // required actor field arg:
-            assert(error.parentType.overall.name == "JiraIssue")
-            assert(error.overallField.name == "creator")
-            assert(error.remoteArg.name == "someArg")
-            assert(GraphQLTypeUtil.simplePrint(error.actorArgInputType) == "Int!")
+            error.parentType.overall.name.shouldBe("JiraIssue")
+            error.overallField.name.shouldBe("creator")
+            error.remoteArg.name.shouldBe("someArg")
+            GraphQLTypeUtil.simplePrint(error.actorArgInputType).shouldBe("Int!")
             // supplied hydration for arg:
-            assert(GraphQLTypeUtil.simplePrint(error.hydrationType) == "ID!")
+            GraphQLTypeUtil.simplePrint(error.hydrationType).shouldBe("ID!")
 
         }
 
@@ -1256,15 +1258,15 @@ class NadelHydrationArgumentValidationTest : DescribeSpec({
 
             val error = errors.assertSingleOfType<IncompatibleHydrationArgumentType>()
             // required actor field arg:
-            assert(error.parentType.overall.name == "JiraIssue")
-            assert(error.overallField.name == "creators")
-            assert(error.remoteArg.name == "id")
-            assert(GraphQLTypeUtil.simplePrint(error.actorArgInputType) == "[UserInput]")
+            error.parentType.overall.name.shouldBe("JiraIssue")
+            error.overallField.name.shouldBe("creators")
+            error.remoteArg.name.shouldBe("id")
+            GraphQLTypeUtil.simplePrint(error.actorArgInputType).shouldBe("[UserInput]")
             // supplied hydration for arg:
-            assert(error.parentType.underlying.name == "Issue")
+            error.parentType.underlying.name.shouldBe("Issue")
             val remoteArgumentSource = error.remoteArg.remoteArgumentSource as RemoteArgumentSource.ObjectField
-            assert(remoteArgumentSource.pathToField.joinToString(separator = ".") == "creators")
-            assert(GraphQLTypeUtil.simplePrint(error.hydrationType) == "[UserRef]")
+            remoteArgumentSource.pathToField.joinToString(separator = ".").shouldBe("creators")
+            GraphQLTypeUtil.simplePrint(error.hydrationType).shouldBe("[UserRef]")
         }
 
         it("Batch hydration edge case - feeding an ID into an [ID] arg is allowed") {
@@ -1322,7 +1324,7 @@ class NadelHydrationArgumentValidationTest : DescribeSpec({
             )
 
             val errors = validate(fixture)
-            assert(errors.isEmpty())
+            errors.shouldBeEmpty()
 
         }
 
@@ -1377,7 +1379,7 @@ class NadelHydrationArgumentValidationTest : DescribeSpec({
                 ),
             )
             val errors = validate(fixture)
-            assert(errors.isEmpty())
+            errors.shouldBeEmpty()
         }
 
         it("passes a valid enum hydration argument") {
@@ -1474,7 +1476,7 @@ class NadelHydrationArgumentValidationTest : DescribeSpec({
                 ),
             )
             val errors = validate(fixture)
-            assert(errors.map { it.message }.isEmpty())
+            errors.map { it.message }.shouldBeEmpty()
         }
 
         it("fails validation on mismatching enums hydration argument") {
@@ -1565,15 +1567,15 @@ class NadelHydrationArgumentValidationTest : DescribeSpec({
 
             val error = errors.assertSingleOfType<IncompatibleHydrationArgumentType>()
             //actor field arg:
-            assert(error.parentType.overall.name == "JiraIssue")
-            assert(error.overallField.name == "creator")
-            assert(error.remoteArg.name == "providerType")
-            assert(GraphQLTypeUtil.simplePrint(error.actorArgInputType) == "SomeOtherEnumType")
+            error.parentType.overall.name.shouldBe("JiraIssue")
+            error.overallField.name.shouldBe("creator")
+            error.remoteArg.name.shouldBe("providerType")
+            GraphQLTypeUtil.simplePrint(error.actorArgInputType).shouldBe("SomeOtherEnumType")
             // supplied hydration for arg:
-            assert(error.parentType.underlying.name == "Issue")
+            error.parentType.underlying.name.shouldBe("Issue")
             val remoteArgumentSource = error.remoteArg.remoteArgumentSource as RemoteArgumentSource.ObjectField
-            assert(remoteArgumentSource.pathToField.joinToString(separator = ".") == "providerType")
-            assert(GraphQLTypeUtil.simplePrint(error.hydrationType) == "ProviderType")
+            remoteArgumentSource.pathToField.joinToString(separator = ".").shouldBe("providerType")
+            GraphQLTypeUtil.simplePrint(error.hydrationType).shouldBe("ProviderType")
         }
     }
     describe("Hydration static arg validation") {
@@ -1637,10 +1639,10 @@ class NadelHydrationArgumentValidationTest : DescribeSpec({
 
             val error = errors.assertSingleOfType<StaticArgIsNotAssignable>()
             //actor field arg:
-            assert(error.parentType.overall.name == "JiraIssue")
-            assert(error.overallField.name == "creator")
-            assert(error.remoteArg.name == "id")
-            assert(GraphQLTypeUtil.simplePrint(error.actorArgInputType) == "Int")
+            error.parentType.overall.name.shouldBe("JiraIssue")
+            error.overallField.name.shouldBe("creator")
+            error.remoteArg.name.shouldBe("id")
+            GraphQLTypeUtil.simplePrint(error.actorArgInputType).shouldBe("Int")
         }
 
         it("allows a source field of type String to be assigned to actor field argument of type ID") {
@@ -1695,7 +1697,7 @@ class NadelHydrationArgumentValidationTest : DescribeSpec({
                 ),
             )
             val errors = validate(fixture)
-            assert(errors.map { it.message }.isEmpty())
+            errors.map { it.message }.shouldBeEmpty()
         }
 
         it("allows a source field of type Int to be assigned to actor field argument of type ID") {
@@ -1750,7 +1752,7 @@ class NadelHydrationArgumentValidationTest : DescribeSpec({
                 ),
             )
             val errors = validate(fixture)
-            assert(errors.map { it.message }.isEmpty())
+            errors.map { it.message }.shouldBeEmpty()
         }
 
         it("batch hydration is not allowed with only static args (i.e. when there is no \$source arg)") {
@@ -1860,7 +1862,7 @@ class NadelHydrationArgumentValidationTest : DescribeSpec({
                 ),
             )
             val errors = validate(fixture)
-            assert(errors.map { it.message }.isEmpty())
+            errors.map { it.message }.shouldBeEmpty()
         }
 
         it("testing array - incompatible list of lists fails validation") {
@@ -1924,10 +1926,10 @@ class NadelHydrationArgumentValidationTest : DescribeSpec({
 
             val error = errors.assertSingleOfType<StaticArgIsNotAssignable>()
             //actor field arg:
-            assert(error.parentType.overall.name == "JiraIssue")
-            assert(error.overallField.name == "creator")
-            assert(error.remoteArg.name == "ids")
-            assert(GraphQLTypeUtil.simplePrint(error.actorArgInputType) == "[[String!]!]!")
+            error.parentType.overall.name.shouldBe("JiraIssue")
+            error.overallField.name.shouldBe("creator")
+            error.remoteArg.name.shouldBe("ids")
+            GraphQLTypeUtil.simplePrint(error.actorArgInputType).shouldBe("[[String!]!]!")
         }
 
         it("input object - validation allows compatible input objects") {
@@ -1995,7 +1997,7 @@ class NadelHydrationArgumentValidationTest : DescribeSpec({
                 ),
             )
             val errors = validate(fixture)
-            assert(errors.map { it.message }.isEmpty())
+            errors.map { it.message }.shouldBeEmpty()
         }
 
         it("fails if incompatible input objects (missing field)") {
@@ -2073,10 +2075,10 @@ class NadelHydrationArgumentValidationTest : DescribeSpec({
 
             val error = errors.assertSingleOfType<StaticArgIsNotAssignable>()
             //actor field arg:
-            assert(error.parentType.overall.name == "JiraIssue")
-            assert(error.overallField.name == "creator")
-            assert(error.remoteArg.name == "name")
-            assert(GraphQLTypeUtil.simplePrint(error.actorArgInputType) == "FullNameInput!")
+            error.parentType.overall.name.shouldBe("JiraIssue")
+            error.overallField.name.shouldBe("creator")
+            error.remoteArg.name.shouldBe("name")
+            GraphQLTypeUtil.simplePrint(error.actorArgInputType).shouldBe("FullNameInput!")
         }
 
         it("validation allows a valid array nested inside object") {
@@ -2154,7 +2156,7 @@ class NadelHydrationArgumentValidationTest : DescribeSpec({
                 ),
             )
             val errors = validate(fixture)
-            assert(errors.map { it.message }.isEmpty())
+            errors.map { it.message }.shouldBeEmpty()
         }
 
         it("allows a valid object nested inside an object") {
@@ -2245,7 +2247,7 @@ class NadelHydrationArgumentValidationTest : DescribeSpec({
                 ),
             )
             val errors = validate(fixture)
-            assert(errors.map { it.message }.isEmpty())
+            errors.map { it.message }.shouldBeEmpty()
         }
 
         it("fails validation an invalid scalar type inside object inside another object") {
@@ -2344,10 +2346,10 @@ class NadelHydrationArgumentValidationTest : DescribeSpec({
 
             val error = errors.assertSingleOfType<StaticArgIsNotAssignable>()
             //actor field arg:
-            assert(error.parentType.overall.name == "JiraIssue")
-            assert(error.overallField.name == "creator")
-            assert(error.remoteArg.name == "userInfo")
-            assert(GraphQLTypeUtil.simplePrint(error.actorArgInputType) == "UserBasicInfo!")
+            error.parentType.overall.name.shouldBe("JiraIssue")
+            error.overallField.name.shouldBe("creator")
+            error.remoteArg.name.shouldBe("userInfo")
+            GraphQLTypeUtil.simplePrint(error.actorArgInputType).shouldBe("UserBasicInfo!")
 
         }
 
@@ -2432,7 +2434,7 @@ class NadelHydrationArgumentValidationTest : DescribeSpec({
                 ),
             )
             val errors = validate(fixture)
-            assert(errors.map { it.message }.isEmpty())
+            errors.map { it.message }.shouldBeEmpty()
         }
 
         it("testing array - validation fails on incompatible array of objects") {
@@ -2526,10 +2528,10 @@ class NadelHydrationArgumentValidationTest : DescribeSpec({
 
             val error = errors.assertSingleOfType<StaticArgIsNotAssignable>()
             //actor field arg:
-            assert(error.parentType.overall.name == "JiraIssue")
-            assert(error.overallField.name == "creator")
-            assert(error.remoteArg.name == "names")
-            assert(GraphQLTypeUtil.simplePrint(error.actorArgInputType) == "[FullNameInput]!")
+            error.parentType.overall.name.shouldBe("JiraIssue")
+            error.overallField.name.shouldBe("creator")
+            error.remoteArg.name.shouldBe("names")
+            GraphQLTypeUtil.simplePrint(error.actorArgInputType).shouldBe("[FullNameInput]!")
         }
     }
 })

--- a/lib/src/test/kotlin/graphql/nadel/validation/NadelHydrationValidationTest.kt
+++ b/lib/src/test/kotlin/graphql/nadel/validation/NadelHydrationValidationTest.kt
@@ -14,6 +14,8 @@ import graphql.nadel.validation.NadelSchemaValidationError.NonExistentHydrationA
 import graphql.nadel.validation.util.assertSingleOfType
 import graphql.schema.GraphQLNamedType
 import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.shouldBe
 
 private const val source = "$" + "source"
 private const val argument = "$" + "argument"
@@ -71,7 +73,7 @@ class NadelHydrationValidationTest : DescribeSpec({
             )
 
             val errors = validate(fixture)
-            assert(errors.map { it.message }.isEmpty())
+            errors.map { it.message }.shouldBeEmpty()
         }
 
         it("fails when batch hydration with multiple \$source args") {
@@ -127,9 +129,9 @@ class NadelHydrationValidationTest : DescribeSpec({
             )
 
             val errors = validate(fixture)
-            assert(errors.size == 1)
+            errors.size.shouldBe(1)
             assert(errors.single() is NadelSchemaValidationError.MultipleSourceArgsInBatchHydration)
-            assert(errors.single().message == "Multiple \$source.xxx arguments are not supported for batch hydration. Field: JiraIssue.creator")
+            errors.single().message.shouldBe("Multiple \$source.xxx arguments are not supported for batch hydration. Field: JiraIssue.creator")
         }
 
         it("fails when batch hydration with no \$source args") {
@@ -184,9 +186,9 @@ class NadelHydrationValidationTest : DescribeSpec({
             )
 
             val errors = validate(fixture)
-            assert(errors.size == 1)
+            errors.size.shouldBe(1)
             assert(errors.single() is NadelSchemaValidationError.NoSourceArgsInBatchHydration)
-            assert(errors.single().message == "No \$source.xxx arguments for batch hydration. Field: JiraIssue.creator")
+            errors.single().message.shouldBe("No \$source.xxx arguments for batch hydration. Field: JiraIssue.creator")
         }
 
         it("passes when batch hydration with a single \$source arg and an \$argument arg") {
@@ -241,7 +243,7 @@ class NadelHydrationValidationTest : DescribeSpec({
             )
 
             val errors = validate(fixture)
-            assert(errors.isEmpty())
+            errors.shouldBeEmpty()
         }
 
         it("fails if non-existent hydration reference field") {
@@ -349,12 +351,12 @@ class NadelHydrationValidationTest : DescribeSpec({
 
             val errors = validate(fixture)
 
-            assert(errors.size == 1)
+            errors.size.shouldBe(1)
             val error = errors.assertSingleOfType<MissingHydrationActorField>()
-            assert(error.service.name == "issues")
-            assert(error.hydration.serviceName == "users")
-            assert(error.overallField.name == "creator")
-            assert(error.parentType.overall.name == "Issue")
+            error.service.name.shouldBe("issues")
+            error.hydration.serviceName.shouldBe("users")
+            error.overallField.name.shouldBe("creator")
+            error.parentType.overall.name.shouldBe("Issue")
         }
 
         it("fails if hydrated field has rename") {
@@ -412,9 +414,9 @@ class NadelHydrationValidationTest : DescribeSpec({
             assert(errors.map { it.message }.isNotEmpty())
 
             val error = errors.assertSingleOfType<CannotRenameHydratedField>()
-            assert(error.parentType.overall.name == "JiraIssue")
-            assert(error.parentType.underlying.name == "Issue")
-            assert(error.overallField.name == "creator")
+            error.parentType.overall.name.shouldBe("JiraIssue")
+            error.parentType.underlying.name.shouldBe("Issue")
+            error.overallField.name.shouldBe("creator")
         }
 
         it("can extend type with hydration") {
@@ -470,7 +472,7 @@ class NadelHydrationValidationTest : DescribeSpec({
             )
 
             val errors = validate(fixture)
-            assert(errors.map { it.message }.isEmpty())
+            errors.map { it.message }.shouldBeEmpty()
         }
 
         it("fails if hydration actor service does not exist") {
@@ -526,11 +528,11 @@ class NadelHydrationValidationTest : DescribeSpec({
             assert(errors.map { it.message }.isNotEmpty())
 
             val error = errors.assertSingleOfType<MissingHydrationActorService>()
-            assert(error.parentType.overall.name == "JiraIssue")
-            assert(error.parentType.underlying.name == "Issue")
-            assert(error.overallField.name == "creator")
-            assert(error.subject == error.overallField)
-            assert(error.hydration.serviceName == "userService")
+            error.parentType.overall.name.shouldBe("JiraIssue")
+            error.parentType.underlying.name.shouldBe("Issue")
+            error.overallField.name.shouldBe("creator")
+            error.subject.shouldBe(error.overallField)
+            error.hydration.serviceName.shouldBe("userService")
         }
 
         it("fails if hydrated field is not nullable") {
@@ -585,9 +587,9 @@ class NadelHydrationValidationTest : DescribeSpec({
             assert(errors.map { it.message }.isNotEmpty())
 
             val error = errors.assertSingleOfType<HydrationFieldMustBeNullable>()
-            assert(error.parentType.overall.name == "JiraIssue")
-            assert(error.parentType.underlying.name == "Issue")
-            assert(error.overallField.name == "creator")
+            error.parentType.overall.name.shouldBe("JiraIssue")
+            error.parentType.underlying.name.shouldBe("Issue")
+            error.overallField.name.shouldBe("creator")
         }
 
         it("fails if hydration actor field does not exist") {
@@ -639,11 +641,11 @@ class NadelHydrationValidationTest : DescribeSpec({
             assert(errors.map { it.message }.isNotEmpty())
 
             val error = errors.assertSingleOfType<MissingHydrationActorField>()
-            assert(error.parentType.overall.name == "Issue")
-            assert(error.parentType.underlying.name == "Issue")
-            assert(error.overallField.name == "creator")
-            assert(error.hydration.pathToActorField == listOf("userById"))
-            assert(error.overallField == error.subject)
+            error.parentType.overall.name.shouldBe("Issue")
+            error.parentType.underlying.name.shouldBe("Issue")
+            error.overallField.name.shouldBe("creator")
+            error.hydration.pathToActorField.shouldBe(listOf("userById"))
+            error.overallField.shouldBe(error.subject)
         }
 
         it("fails if hydration argument references non existent field") {
@@ -698,10 +700,10 @@ class NadelHydrationValidationTest : DescribeSpec({
             assert(errors.map { it.message }.isNotEmpty())
 
             val error = errors.assertSingleOfType<MissingHydrationFieldValueSource>()
-            assert(error.parentType.overall.name == "Issue")
-            assert(error.parentType.underlying.name == "Issue")
-            assert(error.overallField.name == "creator")
-            assert(error.remoteArgSource.pathToField == listOf("creatorId"))
+            error.parentType.overall.name.shouldBe("Issue")
+            error.parentType.underlying.name.shouldBe("Issue")
+            error.overallField.name.shouldBe("creator")
+            error.remoteArgSource.pathToField.shouldBe(listOf("creatorId"))
         }
 
         it("fails if hydration argument references non existent argument") {
@@ -761,10 +763,10 @@ class NadelHydrationValidationTest : DescribeSpec({
             assert(errors.map { it.message }.isNotEmpty())
 
             val error = errors.assertSingleOfType<MissingHydrationArgumentValueSource>()
-            assert(error.parentType.overall.name == "Issue")
-            assert(error.parentType.underlying.name == "Issue")
-            assert(error.overallField.name == "creator")
-            assert(error.remoteArgSource.argumentName == "secrets")
+            error.parentType.overall.name.shouldBe("Issue")
+            error.parentType.underlying.name.shouldBe("Issue")
+            error.overallField.name.shouldBe("creator")
+            error.remoteArgSource.argumentName.shouldBe("secrets")
         }
 
         it("fails if hydration argument references non existent remote argument") {
@@ -824,10 +826,10 @@ class NadelHydrationValidationTest : DescribeSpec({
             assert(errors.map { it.message }.isNotEmpty())
 
             val error = errors.assertSingleOfType<NonExistentHydrationActorFieldArgument>()
-            assert(error.parentType.overall.name == "Issue")
-            assert(error.parentType.underlying.name == "Issue")
-            assert(error.overallField.name == "creator")
-            assert(error.argument == "someArg")
+            error.parentType.overall.name.shouldBe("Issue")
+            error.parentType.underlying.name.shouldBe("Issue")
+            error.overallField.name.shouldBe("creator")
+            error.argument.shouldBe("someArg")
         }
 
         it("fails if hydration defines duplicated arguments") {
@@ -888,10 +890,10 @@ class NadelHydrationValidationTest : DescribeSpec({
             assert(errors.map { it.message }.isNotEmpty())
 
             val error = errors.assertSingleOfType<DuplicatedHydrationArgument>()
-            assert(error.parentType.overall.name == "Issue")
-            assert(error.parentType.underlying.name == "Issue")
-            assert(error.overallField.name == "creator")
-            assert(error.duplicates.map { it.name }.toSet() == setOf("id"))
+            error.parentType.overall.name.shouldBe("Issue")
+            error.parentType.underlying.name.shouldBe("Issue")
+            error.overallField.name.shouldBe("creator")
+            error.duplicates.map { it.name }.toSet().shouldBe(setOf("id"))
         }
 
         it("fails if hydration field has missing non-nullable arguments with underlying top level fields") {
@@ -950,10 +952,10 @@ class NadelHydrationValidationTest : DescribeSpec({
             assert(errors.map { it.message }.isNotEmpty())
 
             val error = errors.assertSingleOfType<MissingRequiredHydrationActorFieldArgument>()
-            assert(error.parentType.overall.name == "Issue")
-            assert(error.parentType.underlying.name == "Issue")
-            assert(error.overallField.name == "creator")
-            assert(error.argument == "other")
+            error.parentType.overall.name.shouldBe("Issue")
+            error.parentType.underlying.name.shouldBe("Issue")
+            error.overallField.name.shouldBe("creator")
+            error.argument.shouldBe("other")
         }
 
         it("passes if hydration field has missing nullable arguments with underlying top level fields") {
@@ -1009,7 +1011,7 @@ class NadelHydrationValidationTest : DescribeSpec({
             )
 
             val errors = validate(fixture)
-            assert(errors.map { it.message }.isEmpty())
+            errors.map { it.message }.shouldBeEmpty()
         }
 
         it("checks the output type of the actor field against the output type of the hydrated field") {
@@ -1082,10 +1084,10 @@ class NadelHydrationValidationTest : DescribeSpec({
             assert(errors.map { it.message }.isNotEmpty())
 
             val error = errors.assertSingleOfType<HydrationIncompatibleOutputType>()
-            assert(error.parentType.overall.name == "Issue")
-            assert(error.overallField.name == "creator")
-            assert(error.subject == error.overallField)
-            assert(error.incompatibleOutputType.name == "Account")
+            error.parentType.overall.name.shouldBe("Issue")
+            error.overallField.name.shouldBe("creator")
+            error.subject.shouldBe(error.overallField)
+            error.incompatibleOutputType.name.shouldBe("Account")
         }
 
         it("fails if one of the hydration return types is not in the union") {
@@ -1153,10 +1155,10 @@ class NadelHydrationValidationTest : DescribeSpec({
             val errors = validate(fixture)
             assert(errors.isNotEmpty())
             val error = errors.singleOfType<HydrationIncompatibleOutputType>()
-            assert(error.parentType.overall.name == "Issue")
-            assert(error.actorField.name == "externalUser")
-            assert((error.actorField.type as GraphQLNamedType).name == "ExternalUser")
-            assert(error.incompatibleOutputType.name == "ExternalUser")
+            error.parentType.overall.name.shouldBe("Issue")
+            error.actorField.name.shouldBe("externalUser")
+            (error.actorField.type as GraphQLNamedType).name.shouldBe("ExternalUser")
+            error.incompatibleOutputType.name.shouldBe("ExternalUser")
         }
 
         it("fails if actor output type does not implement interface") {
@@ -1229,9 +1231,9 @@ class NadelHydrationValidationTest : DescribeSpec({
             val errors = validate(fixture)
             assert(errors.isNotEmpty())
             val error = errors.singleOfType<HydrationIncompatibleOutputType>()
-            assert(error.parentType.overall.name == "Issue")
-            assert(error.actorField.name == "externalUser")
-            assert(error.incompatibleOutputType.name == "ExternalUser")
+            error.parentType.overall.name.shouldBe("Issue")
+            error.actorField.name.shouldBe("externalUser")
+            error.incompatibleOutputType.name.shouldBe("ExternalUser")
         }
 
         it("passes if actor output type implements the interface") {
@@ -1302,7 +1304,7 @@ class NadelHydrationValidationTest : DescribeSpec({
             )
 
             val errors = validate(fixture)
-            assert(errors.map { it.message }.isEmpty())
+            errors.map { it.message }.shouldBeEmpty()
         }
 
         it("passes if actor output type belongs in union") {
@@ -1369,7 +1371,7 @@ class NadelHydrationValidationTest : DescribeSpec({
             )
 
             val errors = validate(fixture)
-            assert(errors.map { it.message }.isEmpty())
+            errors.map { it.message }.shouldBeEmpty()
         }
     }
 })

--- a/lib/src/test/kotlin/graphql/nadel/validation/NadelInputValidationTest.kt
+++ b/lib/src/test/kotlin/graphql/nadel/validation/NadelInputValidationTest.kt
@@ -7,6 +7,8 @@ import graphql.nadel.validation.NadelSchemaValidationError.MissingUnderlyingInpu
 import graphql.nadel.validation.util.assertSingleOfType
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.datatest.withData
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.shouldBe
 
 class NadelInputValidationTest : DescribeSpec({
     describe("validate") {
@@ -63,7 +65,7 @@ class NadelInputValidationTest : DescribeSpec({
             )
 
             val errors = validate(fixture)
-            assert(errors.map { it.message }.isEmpty())
+            errors.map { it.message }.shouldBeEmpty()
         }
 
         it("passes if all input values exist in underlying type and input types match accounting for rename") {
@@ -99,7 +101,7 @@ class NadelInputValidationTest : DescribeSpec({
             )
 
             val errors = validate(fixture)
-            assert(errors.map { it.message }.isEmpty())
+            errors.map { it.message }.shouldBeEmpty()
         }
 
         it("passes if input type was renamed") {
@@ -148,7 +150,7 @@ class NadelInputValidationTest : DescribeSpec({
             )
 
             val errors = validate(fixture)
-            assert(errors.map { it.message }.isEmpty())
+            errors.map { it.message }.shouldBeEmpty()
         }
 
         it("fails if input field in renamed type does not exist in underlying type") {
@@ -200,11 +202,11 @@ class NadelInputValidationTest : DescribeSpec({
             assert(errors.map { it.message }.isNotEmpty())
 
             val error = errors.assertSingleOfType<MissingUnderlyingInputField>()
-            assert(error.service.name == "test")
-            assert(error.parentType.overall.name == "Role")
-            assert(error.parentType.underlying.name == "PayFilter")
-            assert(error.overallField.name == "m")
-            assert(error.subject == error.overallField)
+            error.service.name.shouldBe("test")
+            error.parentType.overall.name.shouldBe("Role")
+            error.parentType.underlying.name.shouldBe("PayFilter")
+            error.overallField.name.shouldBe("m")
+            error.subject.shouldBe(error.overallField)
         }
 
         it("fails if input field does not exist in underlying type") {
@@ -256,11 +258,11 @@ class NadelInputValidationTest : DescribeSpec({
             assert(errors.map { it.message }.isNotEmpty())
 
             val error = errors.assertSingleOfType<MissingUnderlyingInputField>()
-            assert(error.service.name == "test")
-            assert(error.parentType.overall.name == "Role")
-            assert(error.parentType.underlying.name == error.parentType.overall.name)
-            assert(error.overallField.name == "m")
-            assert(error.subject == error.overallField)
+            error.service.name.shouldBe("test")
+            error.parentType.overall.name.shouldBe("Role")
+            error.parentType.underlying.name.shouldBe(error.parentType.overall.name)
+            error.overallField.name.shouldBe("m")
+            error.subject.shouldBe(error.overallField)
         }
 
         it("fails if input types dont match") {
@@ -302,12 +304,12 @@ class NadelInputValidationTest : DescribeSpec({
             assert(errors.map { it.message }.isNotEmpty())
 
             val error = errors.assertSingleOfType<IncompatibleFieldInputType>()
-            assert(error.service.name == "test")
-            assert(error.parentType.overall.name == "Role")
-            assert(error.parentType.underlying.name == error.parentType.overall.name)
-            assert(error.overallInputField.type.unwrapAll().name == "Boss")
-            assert(error.underlyingInputField.type.unwrapAll().name == "Manager")
-            assert(error.subject == error.overallInputField)
+            error.service.name.shouldBe("test")
+            error.parentType.overall.name.shouldBe("Role")
+            error.parentType.underlying.name.shouldBe(error.parentType.overall.name)
+            error.overallInputField.type.unwrapAll().name.shouldBe("Boss")
+            error.underlyingInputField.type.unwrapAll().name.shouldBe("Manager")
+            error.subject.shouldBe(error.overallInputField)
         }
 
         it("fails if overall input is less strict") {
@@ -340,12 +342,12 @@ class NadelInputValidationTest : DescribeSpec({
             assert(errors.map { it.message }.isNotEmpty())
 
             val error = errors.assertSingleOfType<IncompatibleFieldInputType>()
-            assert(error.service.name == "test")
-            assert(error.parentType.overall.name == "Role")
-            assert(error.parentType.underlying.name == error.parentType.overall.name)
+            error.service.name.shouldBe("test")
+            error.parentType.overall.name.shouldBe("Role")
+            error.parentType.underlying.name.shouldBe(error.parentType.overall.name)
             assert(!error.overallInputField.type.isNonNull)
             assert(error.underlyingInputField.type.isNonNull)
-            assert(error.subject == error.overallInputField)
+            error.subject.shouldBe(error.overallInputField)
         }
 
         it("passes if underlying input type is less strict") {
@@ -375,7 +377,7 @@ class NadelInputValidationTest : DescribeSpec({
             )
 
             val errors = validate(fixture)
-            assert(errors.map { it.message }.isEmpty())
+            errors.map { it.message }.shouldBeEmpty()
         }
 
         it("passes if underlying input type is less strict with more wrappings") {
@@ -405,7 +407,7 @@ class NadelInputValidationTest : DescribeSpec({
             )
 
             val errors = validate(fixture)
-            assert(errors.map { it.message }.isEmpty())
+            errors.map { it.message }.shouldBeEmpty()
         }
 
         context("fails if argument type list wrappings are not equal") {
@@ -448,11 +450,11 @@ class NadelInputValidationTest : DescribeSpec({
                 val errors = validate(fixture)
 
                 val error = errors.assertSingleOfType<IncompatibleFieldInputType>()
-                assert(error.service.name == "test")
-                assert(error.parentType.overall.name == "Role")
-                assert(error.parentType.underlying.name == error.parentType.overall.name)
-                assert(error.overallInputField.type.unwrapAll().name == error.underlyingInputField.type.unwrapAll().name)
-                assert(error.overallInputField.name == "m")
+                error.service.name.shouldBe("test")
+                error.parentType.overall.name.shouldBe("Role")
+                error.parentType.underlying.name.shouldBe(error.parentType.overall.name)
+                error.overallInputField.type.unwrapAll().name.shouldBe(error.underlyingInputField.type.unwrapAll().name)
+                error.overallInputField.name.shouldBe("m")
             }
         }
     }

--- a/lib/src/test/kotlin/graphql/nadel/validation/NadelInterfaceValidationTest.kt
+++ b/lib/src/test/kotlin/graphql/nadel/validation/NadelInterfaceValidationTest.kt
@@ -4,6 +4,8 @@ import graphql.nadel.validation.NadelSchemaValidationError.MissingConcreteTypes
 import graphql.nadel.validation.NadelSchemaValidationError.MissingUnderlyingField
 import graphql.nadel.validation.util.assertSingleOfType
 import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.shouldBe
 
 class NadelInterfaceValidationTest : DescribeSpec({
     describe("validate") {
@@ -48,7 +50,7 @@ class NadelInterfaceValidationTest : DescribeSpec({
             )
 
             val errors = validate(fixture)
-            assert(errors.map { it.message }.isEmpty())
+            errors.map { it.message }.shouldBeEmpty()
         }
 
         it("passes if there are valid renamed implementations of the interface") {
@@ -100,7 +102,7 @@ class NadelInterfaceValidationTest : DescribeSpec({
             )
 
             val errors = validate(fixture)
-            assert(errors.map { it.message }.isEmpty())
+            errors.map { it.message }.shouldBeEmpty()
         }
 
         it("fails if renamed implementation of interface is missing fields") {
@@ -154,10 +156,10 @@ class NadelInterfaceValidationTest : DescribeSpec({
             assert(errors.map { it.message }.isNotEmpty())
 
             val error = errors.assertSingleOfType<MissingUnderlyingField>()
-            assert(error.parentType.overall.name == "Human")
-            assert(error.parentType.underlying.name == "Person")
-            assert(error.overallField.name == "age")
-            assert(error.service.name == "entities")
+            error.parentType.overall.name.shouldBe("Human")
+            error.parentType.underlying.name.shouldBe("Person")
+            error.overallField.name.shouldBe("age")
+            error.service.name.shouldBe("entities")
         }
 
         it("it fails if there are no concrete implementations of interface") {
@@ -194,8 +196,8 @@ class NadelInterfaceValidationTest : DescribeSpec({
             assert(errors.map { it.message }.isNotEmpty())
 
             val error = errors.assertSingleOfType<MissingConcreteTypes>()
-            assert(error.interfaceType.overall.name == "Entity")
-            assert(error.interfaceType.service.name == "entities")
+            error.interfaceType.overall.name.shouldBe("Entity")
+            error.interfaceType.service.name.shouldBe("entities")
         }
 
         it("it passes if shared interfaces have concrete types on all services") {
@@ -262,7 +264,7 @@ class NadelInterfaceValidationTest : DescribeSpec({
             )
 
             val errors = validate(fixture)
-            assert(errors.map { it.message }.isEmpty())
+            errors.map { it.message }.shouldBeEmpty()
         }
 
         it("it fails if shared interface does not have concrete implementation in one service") {
@@ -320,8 +322,8 @@ class NadelInterfaceValidationTest : DescribeSpec({
             assert(errors.map { it.message }.isNotEmpty())
 
             val error = errors.assertSingleOfType<MissingConcreteTypes>()
-            assert(error.interfaceType.overall.name == "Entity")
-            assert(error.interfaceType.service.name == "entities")
+            error.interfaceType.overall.name.shouldBe("Entity")
+            error.interfaceType.service.name.shouldBe("entities")
         }
 
         it("it fails if shared interface does not have concrete implementation in multiple service") {
@@ -430,10 +432,10 @@ class NadelInterfaceValidationTest : DescribeSpec({
                 .none { it == "cats" })
 
             val error = errors.assertSingleOfType<MissingConcreteTypes> { it.interfaceType.service.name == "dogs" }
-            assert(error.interfaceType.overall.name == "QueryErrorExtension")
+            error.interfaceType.overall.name.shouldBe("QueryErrorExtension")
 
             val error2 = errors.assertSingleOfType<MissingConcreteTypes> { it.interfaceType.service.name == "humans" }
-            assert(error2.interfaceType.overall.name == "QueryErrorExtension")
+            error2.interfaceType.overall.name.shouldBe("QueryErrorExtension")
         }
 
         it("it does not fail if there is concrete implementation but not exposed") {
@@ -471,7 +473,7 @@ class NadelInterfaceValidationTest : DescribeSpec({
             )
 
             val errors = validate(fixture)
-            assert(errors.map { it.message }.isEmpty())
+            errors.map { it.message }.shouldBeEmpty()
         }
     }
 })

--- a/lib/src/test/kotlin/graphql/nadel/validation/NadelNamespaceValidationTest.kt
+++ b/lib/src/test/kotlin/graphql/nadel/validation/NadelNamespaceValidationTest.kt
@@ -3,6 +3,8 @@ package graphql.nadel.validation
 import graphql.nadel.validation.NadelSchemaValidationError.NamespacedTypeMustBeObject
 import graphql.nadel.validation.util.assertSingleOfType
 import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.shouldBe
 
 class NadelNamespaceValidationTest : DescribeSpec({
     describe("validate") {
@@ -47,7 +49,7 @@ class NadelNamespaceValidationTest : DescribeSpec({
             )
 
             val errors = validate(fixture)
-            assert(errors.map { it.message }.isEmpty())
+            errors.map { it.message }.shouldBeEmpty()
         }
 
         it("fails if namespaced type is an interface") {
@@ -100,7 +102,7 @@ class NadelNamespaceValidationTest : DescribeSpec({
             assert(errors.map { it.message }.isNotEmpty())
 
             val error = errors.assertSingleOfType<NamespacedTypeMustBeObject>()
-            assert(error.subject.name == "IssueQuery")
+            error.subject.name.shouldBe("IssueQuery")
         }
 
         it("fails if namespaced type is an enum") {
@@ -149,7 +151,7 @@ class NadelNamespaceValidationTest : DescribeSpec({
             assert(errors.map { it.message }.isNotEmpty())
 
             val error = errors.assertSingleOfType<NamespacedTypeMustBeObject>()
-            assert(error.subject.name == "IssueQuery")
+            error.subject.name.shouldBe("IssueQuery")
         }
     }
 })

--- a/lib/src/test/kotlin/graphql/nadel/validation/NadelPolymorphicHydrationValidationTest.kt
+++ b/lib/src/test/kotlin/graphql/nadel/validation/NadelPolymorphicHydrationValidationTest.kt
@@ -9,6 +9,8 @@ import graphql.nadel.validation.NadelSchemaValidationError.MissingUnderlyingType
 import graphql.nadel.validation.util.assertSingleOfType
 import graphql.schema.GraphQLNamedType
 import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.shouldBe
 
 private const val source = "$" + "source"
 
@@ -95,7 +97,7 @@ class NadelPolymorphicHydrationValidationTest : DescribeSpec({
             )
 
             val errors = validate(fixture)
-            assert(!errors.map { it.message }.isEmpty())
+            errors.map { it.message }.shouldBeEmpty()
         }
 
         it("fails if one of polymorphic hydrations references non existent field") {
@@ -182,10 +184,10 @@ class NadelPolymorphicHydrationValidationTest : DescribeSpec({
             assert(errors.map { it.message }.isNotEmpty())
 
             val error = errors.singleOfType<MissingHydrationActorField>()
-            assert(error.service.name == "issues")
-            assert(error.parentType.overall.name == "Issue")
-            assert(error.overallField.name == "creator")
-            assert(error.hydration.pathToActorField == listOf("internalUser"))
+            error.service.name.shouldBe("issues")
+            error.parentType.overall.name.shouldBe("Issue")
+            error.overallField.name.shouldBe("creator")
+            error.hydration.pathToActorField.shouldBe(listOf("internalUser"))
         }
 
         it("fails if a mix of batched and non-batched hydrations is used") {
@@ -272,8 +274,8 @@ class NadelPolymorphicHydrationValidationTest : DescribeSpec({
             assert(errors.map { it.message }.isNotEmpty())
 
             val error = errors.assertSingleOfType<HydrationsMismatch>()
-            assert(error.parentType.overall.name == "Issue")
-            assert(error.overallField.name == "creator")
+            error.parentType.overall.name.shouldBe("Issue")
+            error.overallField.name.shouldBe("creator")
         }
 
         it("can detect if polymorphic hydration from the same service returns a type that does not exist in the underlying schema") {
@@ -333,8 +335,8 @@ class NadelPolymorphicHydrationValidationTest : DescribeSpec({
 
             val errors = validate(fixture)
             val error = errors.assertSingleOfType<MissingUnderlyingType>()
-            assert(error.overallType.name == "Issue")
-            assert(error.service.name == "issues")
+            error.overallType.name.shouldBe("Issue")
+            error.service.name.shouldBe("issues")
         }
 
         it("can detect if polymorphic hydration from the same service references a type that does not exist in the underlying schema") {
@@ -403,8 +405,8 @@ class NadelPolymorphicHydrationValidationTest : DescribeSpec({
 
             val errors = validate(fixture)
             val error = errors.assertSingleOfType<MissingUnderlyingType>()
-            assert(error.overallType.name == "Comment")
-            assert(error.service.name == "issues")
+            error.overallType.name.shouldBe("Comment")
+            error.service.name.shouldBe("issues")
         }
 
         it("passes if polymorphic hydration is valid when actor field returns a renamed type") {
@@ -477,7 +479,7 @@ class NadelPolymorphicHydrationValidationTest : DescribeSpec({
             )
 
             val errors = validate(fixture)
-            assert(errors.map { it.message }.isEmpty())
+            errors.map { it.message }.shouldBeEmpty()
         }
 
         it("fails if return type is not a union") {
@@ -552,8 +554,8 @@ class NadelPolymorphicHydrationValidationTest : DescribeSpec({
             val errors = validate(fixture)
             assert(errors.isNotEmpty())
             val error = errors.filterIsInstance<FieldWithPolymorphicHydrationMustReturnAUnion>().single()
-            assert(error.parentType.overall.name == "Issue")
-            assert(error.overallField.name == "creator")
+            error.parentType.overall.name.shouldBe("Issue")
+            error.overallField.name.shouldBe("creator")
         }
 
         it("fails if one of the hydrations' return types is not in the union") {
@@ -628,10 +630,10 @@ class NadelPolymorphicHydrationValidationTest : DescribeSpec({
             val errors = validate(fixture)
             assert(errors.isNotEmpty())
             val error = errors.singleOfType<HydrationIncompatibleOutputType>()
-            assert(error.parentType.overall.name == "Issue")
-            assert(error.actorField.name == "externalUser")
-            assert((error.actorField.type as GraphQLNamedType).name == "ExternalUser")
-            assert(error.incompatibleOutputType.name == "ExternalUser")
+            error.parentType.overall.name.shouldBe("Issue")
+            error.actorField.name.shouldBe("externalUser")
+            (error.actorField.type as GraphQLNamedType).name.shouldBe("ExternalUser")
+            error.incompatibleOutputType.name.shouldBe("ExternalUser")
         }
     }
 })

--- a/lib/src/test/kotlin/graphql/nadel/validation/NadelPolymorphicHydrationValidationTest.kt
+++ b/lib/src/test/kotlin/graphql/nadel/validation/NadelPolymorphicHydrationValidationTest.kt
@@ -95,7 +95,7 @@ class NadelPolymorphicHydrationValidationTest : DescribeSpec({
             )
 
             val errors = validate(fixture)
-            assert(errors.map { it.message }.isEmpty())
+            assert(!errors.map { it.message }.isEmpty())
         }
 
         it("fails if one of polymorphic hydrations references non existent field") {

--- a/lib/src/test/kotlin/graphql/nadel/validation/NadelRenameValidationTest.kt
+++ b/lib/src/test/kotlin/graphql/nadel/validation/NadelRenameValidationTest.kt
@@ -7,6 +7,8 @@ import graphql.nadel.validation.NadelSchemaValidationError.MissingRename
 import graphql.nadel.validation.NadelSchemaValidationError.MissingUnderlyingType
 import graphql.nadel.validation.util.assertSingleOfType
 import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.shouldBe
 
 val renameDirectiveDef = """
     directive @renamed(
@@ -38,7 +40,7 @@ class NadelRenameValidationTest : DescribeSpec({
             )
 
             val errors = validate(fixture)
-            assert(errors.isEmpty())
+            errors.shouldBeEmpty()
         }
 
         it("passes if rename references existing underlying type") {
@@ -68,7 +70,7 @@ class NadelRenameValidationTest : DescribeSpec({
             )
 
             val errors = validate(fixture)
-            assert(errors.isEmpty())
+            errors.shouldBeEmpty()
         }
 
         it("raises error if type is renamed twice") {
@@ -106,9 +108,9 @@ class NadelRenameValidationTest : DescribeSpec({
             assert(errors.map { it.message }.isNotEmpty())
 
             val error = errors.assertSingleOfType<DuplicatedUnderlyingType>()
-            assert(error.service.name == "test")
-            assert(error.duplicates.map { it.overall.name }.toSet() == setOf("User", "Profile"))
-            assert(error.duplicates.map { it.underlying.name }.toSet().singleOrNull() == "Account")
+            error.service.name.shouldBe("test")
+            error.duplicates.map { it.overall.name }.toSet().shouldBe(setOf("User", "Profile"))
+            error.duplicates.map { it.underlying.name }.toSet().singleOrNull().shouldBe("Account")
         }
 
         it("allows fields to be duplicated") {
@@ -152,7 +154,7 @@ class NadelRenameValidationTest : DescribeSpec({
             )
 
             val errors = validate(fixture)
-            assert(errors.map { it.message }.isEmpty())
+            errors.map { it.message }.shouldBeEmpty()
         }
 
         // When we say implicitly renamed, we refer to the fact that the output type of the field
@@ -209,10 +211,10 @@ class NadelRenameValidationTest : DescribeSpec({
             assert(errors.map { it.message }.isNotEmpty())
 
             val incompatibleTypeName = errors.assertSingleOfType<IncompatibleFieldOutputType>()
-            assert(incompatibleTypeName.parentType.overall.name == "Query")
-            assert(incompatibleTypeName.parentType.underlying.name == "Query")
-            assert(incompatibleTypeName.overallField.type.unwrapAll().name == "Test")
-            assert(incompatibleTypeName.underlyingField.type.unwrapAll().name == "Account")
+            incompatibleTypeName.parentType.overall.name.shouldBe("Query")
+            incompatibleTypeName.parentType.underlying.name.shouldBe("Query")
+            incompatibleTypeName.overallField.type.unwrapAll().name.shouldBe("Test")
+            incompatibleTypeName.underlyingField.type.unwrapAll().name.shouldBe("Account")
         }
 
         xit("passes if field uses renamed shared type") {
@@ -290,11 +292,11 @@ class NadelRenameValidationTest : DescribeSpec({
             assert(errors.map { it.message }.isNotEmpty())
 
             val error = errors.assertSingleOfType<MissingRename>()
-            assert(error.service.name == "test")
-            assert(error.subject.name == "test")
-            assert(error.overallField.name == "test")
-            assert(error.parentType.overall.name == "Query")
-            assert(error.parentType.underlying.name == "Query")
+            error.service.name.shouldBe("test")
+            error.subject.name.shouldBe("test")
+            error.overallField.name.shouldBe("test")
+            error.parentType.overall.name.shouldBe("Query")
+            error.parentType.underlying.name.shouldBe("Query")
         }
 
         it("raises error if renamed type references non existent underlying type") {
@@ -328,8 +330,8 @@ class NadelRenameValidationTest : DescribeSpec({
             assert(errors.map { it.message }.isNotEmpty())
 
             val error = errors.assertSingleOfType<MissingUnderlyingType>()
-            assert(error.subject.name == "User")
-            assert(error.overallType.name == "User")
+            error.subject.name.shouldBe("User")
+            error.overallType.name.shouldBe("User")
         }
     }
 })

--- a/lib/src/test/kotlin/graphql/nadel/validation/NadelSchemaValidationTest.kt
+++ b/lib/src/test/kotlin/graphql/nadel/validation/NadelSchemaValidationTest.kt
@@ -2,6 +2,7 @@ package graphql.nadel.validation
 
 import graphql.nadel.NadelSchemas.Companion.newNadelSchemas
 import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.collections.shouldBeEmpty
 
 class NadelSchemaValidationTest : DescribeSpec({
     describe("validate") {
@@ -24,7 +25,7 @@ class NadelSchemaValidationTest : DescribeSpec({
             )
 
             val errors = validate(fixture)
-            assert(errors.isEmpty())
+            errors.shouldBeEmpty()
         }
     }
 })

--- a/lib/src/test/kotlin/graphql/nadel/validation/NadelTypeValidationTest.kt
+++ b/lib/src/test/kotlin/graphql/nadel/validation/NadelTypeValidationTest.kt
@@ -8,6 +8,8 @@ import graphql.nadel.validation.NadelSchemaValidationError.MissingUnderlyingInpu
 import graphql.nadel.validation.NadelSchemaValidationError.MissingUnderlyingType
 import graphql.nadel.validation.util.assertSingleOfType
 import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.shouldBe
 import kotlin.time.Duration.Companion.seconds
 
 class NadelTypeValidationTest : DescribeSpec({
@@ -43,7 +45,7 @@ class NadelTypeValidationTest : DescribeSpec({
             )
 
             val errors = validate(fixture)
-            assert(errors.map { it.message }.isEmpty())
+            errors.map { it.message }.shouldBeEmpty()
         }
 
         it("fails if a type is implicitly renamed") {
@@ -87,13 +89,13 @@ class NadelTypeValidationTest : DescribeSpec({
             assert(errors.map { it.message }.isNotEmpty())
 
             val missingTypeError = errors.assertSingleOfType<MissingUnderlyingType>()
-            assert(missingTypeError.service.name == "delta")
-            assert(missingTypeError.overallType.name == "Echo")
+            missingTypeError.service.name.shouldBe("delta")
+            missingTypeError.overallType.name.shouldBe("Echo")
 
             val fieldTypeError = errors.assertSingleOfType<IncompatibleFieldOutputType>()
-            assert(fieldTypeError.service.name == "delta")
-            assert(fieldTypeError.overallField.name == "delta")
-            assert(fieldTypeError.parentType.overall.name == "Query")
+            fieldTypeError.service.name.shouldBe("delta")
+            fieldTypeError.overallField.name.shouldBe("delta")
+            fieldTypeError.parentType.overall.name.shouldBe("Query")
         }
 
         it("does not crash on schema definition") {
@@ -130,7 +132,7 @@ class NadelTypeValidationTest : DescribeSpec({
             )
 
             val errors = validate(fixture)
-            assert(errors.map { it.message }.isEmpty())
+            errors.map { it.message }.shouldBeEmpty()
         }
 
         it("cannot have a synthetic union") {
@@ -204,7 +206,7 @@ class NadelTypeValidationTest : DescribeSpec({
             )
 
             val errors = validate(fixture)
-            assert(errors.map { it.message }.isEmpty())
+            errors.map { it.message }.shouldBeEmpty()
         }
 
         it("prohibits synthetic union if not exclusively used for @hydrated fields") {
@@ -247,8 +249,8 @@ class NadelTypeValidationTest : DescribeSpec({
             assert(errors.map { it.message }.isNotEmpty())
 
             val error = errors.assertSingleOfType<MissingUnderlyingType>()
-            assert(error.service.name == "test")
-            assert(error.overallType.name == "Something")
+            error.service.name.shouldBe("test")
+            error.overallType.name.shouldBe("Something")
         }
 
         it("tracks visited types to avoid stack overflow").config(timeout = 1.seconds) {
@@ -288,7 +290,7 @@ class NadelTypeValidationTest : DescribeSpec({
             )
 
             val errors = validate(fixture)
-            assert(errors.map { it.message }.isEmpty())
+            errors.map { it.message }.shouldBeEmpty()
         }
 
         it("fails if underlying type is duplicated via renames") {
@@ -328,9 +330,9 @@ class NadelTypeValidationTest : DescribeSpec({
             assert(errors.map { it.message }.isNotEmpty())
 
             val error = errors.assertSingleOfType<DuplicatedUnderlyingType>()
-            assert(error.service.name == "test")
-            assert(error.duplicates.map { it.overall.name }.toSet() == setOf("World", "Microcosm"))
-            assert(error.duplicates.map { it.underlying.name }.toSet() == setOf("World"))
+            error.service.name.shouldBe("test")
+            error.duplicates.map { it.overall.name }.toSet().shouldBe(setOf("World", "Microcosm"))
+            error.duplicates.map { it.underlying.name }.toSet().shouldBe(setOf("World"))
         }
 
         it("treats service named shared as fake service for holding types") {
@@ -358,7 +360,7 @@ class NadelTypeValidationTest : DescribeSpec({
             )
 
             val errors = validate(fixture)
-            assert(errors.map { it.message }.isEmpty())
+            errors.map { it.message }.shouldBeEmpty()
         }
 
         it("picks up types only used at output type") {
@@ -405,8 +407,8 @@ class NadelTypeValidationTest : DescribeSpec({
             assert(errors.map { it.message }.isNotEmpty())
 
             val error = errors.assertSingleOfType<MissingUnderlyingField>()
-            assert(error.service.name == "users")
-            assert(error.overallField.name == "nextgenSpecific")
+            error.service.name.shouldBe("users")
+            error.overallField.name.shouldBe("nextgenSpecific")
         }
 
         it("picks up types defined in other services and used in unions") {
@@ -470,8 +472,8 @@ class NadelTypeValidationTest : DescribeSpec({
             assert(errors.map { it.message }.isNotEmpty())
 
             val error = errors.assertSingleOfType<MissingUnderlyingField>()
-            assert(error.service.name == "users")
-            assert(error.overallField.name == "nextgenSpecific")
+            error.service.name.shouldBe("users")
+            error.overallField.name.shouldBe("nextgenSpecific")
         }
 
         it("validates extension union member if defined by own service") {
@@ -517,8 +519,8 @@ class NadelTypeValidationTest : DescribeSpec({
             val errors = validate(fixture)
             assert(errors.map { it.message }.isNotEmpty())
             val error = errors.assertSingleOfType<MissingUnderlyingType>()
-            assert(error.service.name == "users")
-            assert(error.overallType.name == "Issue")
+            error.service.name.shouldBe("users")
+            error.overallType.name.shouldBe("Issue")
         }
 
         it("validates external member if service defines it") {
@@ -567,9 +569,9 @@ class NadelTypeValidationTest : DescribeSpec({
             val errors = validate(fixture)
             assert(errors.map { it.message }.isNotEmpty())
             val error = errors.assertSingleOfType<MissingUnderlyingField>()
-            assert(error.service.name == "users")
-            assert(error.parentType.overall.name == "Issue")
-            assert(error.overallField.name == "id")
+            error.service.name.shouldBe("users")
+            error.parentType.overall.name.shouldBe("Issue")
+            error.overallField.name.shouldBe("id")
         }
 
         it("picks up types defined in other services used as input types") {
@@ -613,9 +615,9 @@ class NadelTypeValidationTest : DescribeSpec({
             assert(errors.map { it.message }.isNotEmpty())
 
             val error = errors.assertSingleOfType<MissingUnderlyingInputField>()
-            assert(error.service.name == "users")
-            assert(error.parentType.overall.name == "UserFilter")
-            assert(error.overallField.name == "a")
+            error.service.name.shouldBe("users")
+            error.parentType.overall.name.shouldBe("UserFilter")
+            error.overallField.name.shouldBe("a")
         }
 
         it("picks up types not directly referenced") {
@@ -686,20 +688,20 @@ class NadelTypeValidationTest : DescribeSpec({
             )
 
             val errors = validate(fixture)
-            assert(errors.map { it.message }.size == 3)
+            errors.map { it.message }.size.shouldBe(3)
 
             val missingField = errors.assertSingleOfType<MissingUnderlyingField>()
-            assert(missingField.service.name == "users")
-            assert(missingField.parentType.overall.name == "Issue")
-            assert(missingField.overallField.name == "epic")
+            missingField.service.name.shouldBe("users")
+            missingField.parentType.overall.name.shouldBe("Issue")
+            missingField.overallField.name.shouldBe("epic")
 
             val missingIssueFilter = errors.assertSingleOfType<MissingUnderlyingType> {
                 it.overallType.name == "IssueFilter"
             }
-            assert(missingIssueFilter.service.name == "users")
+            missingIssueFilter.service.name.shouldBe("users")
 
             val missingEpic = errors.assertSingleOfType<MissingUnderlyingType> { it.overallType.name == "Epic" }
-            assert(missingEpic.service.name == "users")
+            missingEpic.service.name.shouldBe("users")
         }
 
         it("fails if type kinds are incompatible") {
@@ -736,9 +738,9 @@ class NadelTypeValidationTest : DescribeSpec({
             assert(errors.map { it.message }.isNotEmpty())
 
             val error = errors.assertSingleOfType<IncompatibleType>()
-            assert(error.schemaElement.service.name == "test")
-            assert(error.schemaElement.overall.name == "World")
-            assert(error.schemaElement.underlying.name == "World")
+            error.schemaElement.service.name.shouldBe("test")
+            error.schemaElement.overall.name.shouldBe("World")
+            error.schemaElement.underlying.name.shouldBe("World")
         }
 
         it("fails if renamed type kinds are incompatible") {
@@ -775,9 +777,9 @@ class NadelTypeValidationTest : DescribeSpec({
             assert(errors.map { it.message }.isNotEmpty())
 
             val error = errors.assertSingleOfType<IncompatibleType>()
-            assert(error.schemaElement.service.name == "test")
-            assert(error.schemaElement.overall.name == "World")
-            assert(error.schemaElement.underlying.name == "Pluto")
+            error.schemaElement.service.name.shouldBe("test")
+            error.schemaElement.overall.name.shouldBe("World")
+            error.schemaElement.underlying.name.shouldBe("Pluto")
         }
 
         it("can validate shared types") {
@@ -861,20 +863,20 @@ class NadelTypeValidationTest : DescribeSpec({
             val missingNextPage = errors.assertSingleOfType<MissingUnderlyingField> {
                 it.overallField.name == "hasNextPage"
             }
-            assert(missingNextPage.service.name == "jira")
-            assert(missingNextPage.parentType.overall.name == "PageInfo")
+            missingNextPage.service.name.shouldBe("jira")
+            missingNextPage.parentType.overall.name.shouldBe("PageInfo")
 
             val missingPrevPage = errors.assertSingleOfType<MissingUnderlyingField> {
                 it.overallField.name == "hasPreviousPage"
             }
-            assert(missingPrevPage.service.name == "jira")
-            assert(missingPrevPage.parentType.overall.name == "PageInfo")
+            missingPrevPage.service.name.shouldBe("jira")
+            missingPrevPage.parentType.overall.name.shouldBe("PageInfo")
 
             val missingStartCursor = errors.assertSingleOfType<MissingUnderlyingField> {
                 it.overallField.name == "startCursor"
             }
-            assert(missingStartCursor.service.name == "users")
-            assert(missingStartCursor.parentType.overall.name == "PageInfo")
+            missingStartCursor.service.name.shouldBe("users")
+            missingStartCursor.parentType.overall.name.shouldBe("PageInfo")
         }
     }
 
@@ -919,11 +921,11 @@ class NadelTypeValidationTest : DescribeSpec({
             assert(errors.map { it.message }.isNotEmpty())
 
             val error = errors.assertSingleOfType<IncompatibleFieldOutputType>()
-            assert(error.parentType.overall.name == "Echo")
-            assert(error.parentType.underlying.name == "Echo")
-            assert(error.overallField.name == "world")
-            assert(error.underlyingField.name == "world")
-            assert(error.subject == error.overallField)
+            error.parentType.overall.name.shouldBe("Echo")
+            error.parentType.underlying.name.shouldBe("Echo")
+            error.overallField.name.shouldBe("world")
+            error.underlyingField.name.shouldBe("world")
+            error.subject.shouldBe(error.overallField)
         }
 
         it("passes if underlying output type is non null but overall output type is nullable") {
@@ -963,7 +965,7 @@ class NadelTypeValidationTest : DescribeSpec({
             )
 
             val errors = validate(fixture)
-            assert(errors.map { it.message }.isEmpty())
+            errors.map { it.message }.shouldBeEmpty()
         }
 
         it("fails if array dimensions are wrong") {
@@ -1007,10 +1009,10 @@ class NadelTypeValidationTest : DescribeSpec({
                 assert(errors.map { it.message }.isNotEmpty())
 
                 val error = errors.assertSingleOfType<IncompatibleFieldOutputType>()
-                assert(error.parentType.overall.name == "Query")
-                assert(error.parentType.underlying.name == "Query")
-                assert(error.overallField.name == "worlds")
-                assert(error.underlyingField.name == "worlds")
+                error.parentType.overall.name.shouldBe("Query")
+                error.parentType.underlying.name.shouldBe("Query")
+                error.overallField.name.shouldBe("worlds")
+                error.underlyingField.name.shouldBe("worlds")
             }
         }
 
@@ -1054,7 +1056,7 @@ class NadelTypeValidationTest : DescribeSpec({
             assert(errors.map { it.message }.isNotEmpty())
 
             // We could say .none but this will print out the perpetrator
-            assert(errors.firstOrNull { it !is IncompatibleFieldOutputType } == null)
+            errors.firstOrNull { it !is IncompatibleFieldOutputType }.shouldBe(null)
         }
 
         it("fails if underlying output array type is nullable but overall array type is not null") {
@@ -1097,9 +1099,9 @@ class NadelTypeValidationTest : DescribeSpec({
             assert(errors.map { it.message }.isNotEmpty())
 
             val error = errors.assertSingleOfType<IncompatibleFieldOutputType>()
-            assert(error.parentType.overall.name == "Echo")
-            assert(error.parentType.underlying.name == "Echo")
-            assert(error.overallField.name == "worlds")
+            error.parentType.overall.name.shouldBe("Echo")
+            error.parentType.underlying.name.shouldBe("Echo")
+            error.overallField.name.shouldBe("worlds")
         }
 
         it("passes even if output type is renamed") {
@@ -1139,7 +1141,7 @@ class NadelTypeValidationTest : DescribeSpec({
             )
 
             val errors = validate(fixture)
-            assert(errors.map { it.message }.isEmpty())
+            errors.map { it.message }.shouldBeEmpty()
         }
     }
 })


### PR DESCRIPTION
Please make sure you consider the following:

- [ ] Add tests that use __typename in queries
- [ ] Does this change work with all nadel transformations (rename, type rename, hydration, etc)? Add tests for this.
- [ ] Is it worth using hints for this change in order to be able to enable a percentage rollout?
- [ ] Do we need to add integration tests for this change in the graphql gateway?
- [ ] Do we need a pollinator check for this?
