### PR TITLE
Move partition instruction to Blueprint

### DIFF
--- a/lib/src/main/java/graphql/nadel/dsl/PartitionDefinition.kt
+++ b/lib/src/main/java/graphql/nadel/dsl/PartitionDefinition.kt
@@ -1,0 +1,5 @@
+package graphql.nadel.dsl
+
+data class NadelPartitionDefinition(
+    val pathToSplitPoint: List<String>,
+)

--- a/lib/src/main/java/graphql/nadel/engine/blueprint/NadelExecutionBlueprintFactory.kt
+++ b/lib/src/main/java/graphql/nadel/engine/blueprint/NadelExecutionBlueprintFactory.kt
@@ -189,7 +189,7 @@ private class Factory(
                         when (val mappingDefinition = getFieldMappingDefinition(field)) {
                             null -> {
                                 getUnderlyingServiceHydrations(field)
-                                    .map { makeHydrationFieldInstruction(type, field, it) }
+                                    .map { makeHydrationFieldInstruction(type, field, it) } + makePartitionInstruction(type, field)
                             }
                             else -> when (mappingDefinition.inputPath.size) {
                                 1 -> listOf(makeRenameInstruction(type, field, mappingDefinition))
@@ -468,6 +468,21 @@ private class Factory(
         return NadelRenameFieldInstruction(
             location = makeFieldCoordinates(parentType, field),
             underlyingName = mappingDefinition.inputPath.single(),
+        )
+    }
+
+    private fun makePartitionInstruction(
+        parentType: GraphQLObjectType,
+        field: GraphQLFieldDefinition,
+    ): List<NadelPartitionInstruction> {
+        val partitionDefinition = NadelDirectives.createPartitionDefinition(field)
+            ?: return emptyList()
+
+        return listOf(
+            NadelPartitionInstruction(
+                location = makeFieldCoordinates(parentType, field),
+                pathToPartitionArg = partitionDefinition.pathToSplitPoint,
+            )
         )
     }
 

--- a/lib/src/main/java/graphql/nadel/engine/blueprint/NadelFieldInstruction.kt
+++ b/lib/src/main/java/graphql/nadel/engine/blueprint/NadelFieldInstruction.kt
@@ -132,3 +132,8 @@ data class NadelRenameFieldInstruction(
 ) : NadelFieldInstruction() {
     val overallName: String get() = location.fieldName
 }
+
+data class NadelPartitionInstruction(
+    override val location: FieldCoordinates,
+    val pathToPartitionArg: List<String>,
+) : NadelFieldInstruction()

--- a/lib/src/main/java/graphql/nadel/engine/transform/partition/NadelPartitionTransform.kt
+++ b/lib/src/main/java/graphql/nadel/engine/transform/partition/NadelPartitionTransform.kt
@@ -63,9 +63,10 @@ internal class NadelPartitionTransform(
         val partitionInstructions = executionBlueprint.fieldInstructions
             .getTypeNameToInstructionMap<NadelPartitionInstruction>(overallField)
 
-        // We can't partition a field that has multiple partition instructions in different types
+        // We can't partition a field that has multiple partition instructions in different types. But, since
+        // @partition can only be applied to fields in operation and namespaced types, we don't have to worry abou
+        // this case.
         if (partitionInstructions.size != 1) {
-            // TODO add validation to ensure @partition is not used in a way that would result in a ENF to have multiple partition instructions
             return null
         }
 

--- a/lib/src/main/java/graphql/nadel/engine/transform/partition/NadelPartitionTransform.kt
+++ b/lib/src/main/java/graphql/nadel/engine/transform/partition/NadelPartitionTransform.kt
@@ -9,6 +9,9 @@ import graphql.nadel.ServiceExecutionResult
 import graphql.nadel.engine.NadelExecutionContext
 import graphql.nadel.engine.NadelServiceExecutionContext
 import graphql.nadel.engine.blueprint.NadelOverallExecutionBlueprint
+import graphql.nadel.engine.blueprint.NadelPartitionInstruction
+import graphql.nadel.engine.blueprint.NadelRenameFieldInstruction
+import graphql.nadel.engine.blueprint.getTypeNameToInstructionMap
 import graphql.nadel.engine.transform.NadelTransform
 import graphql.nadel.engine.transform.NadelTransformFieldResult
 import graphql.nadel.engine.transform.partition.NadelPartitionMutationPayloadMerger.isMutationPayloadLike
@@ -57,7 +60,17 @@ internal class NadelPartitionTransform(
             return null
         }
 
-        // TODO: This could be in the blueprint
+        val partitionInstructions = executionBlueprint.fieldInstructions
+            .getTypeNameToInstructionMap<NadelPartitionInstruction>(overallField)
+
+        // We can't partition a field that has multiple partition instructions in different types
+        if (partitionInstructions.size != 1) {
+            // TODO add validation to ensure @partition is not used in a way that would result in a ENF to have multiple partition instructions
+            return null
+        }
+
+        val pathToPartitionArg = partitionInstructions.values.single().pathToPartitionArg
+
         val fieldPartitionContext = partitionTransformHook.getFieldPartitionContext(
                 executionContext,
                 serviceExecutionContext,
@@ -67,14 +80,11 @@ internal class NadelPartitionTransform(
                 overallField,
                 hydrationDetails,
             )
-
-        if (fieldPartitionContext == null) {
-            // A field without a partition context can't be partitioned
+            ?: // A field without a partition context can't be partitioned
             return null
-        }
 
         val fieldPartition = NadelFieldPartition(
-            pathToPartitionArg = getPathToPartitionArg(overallField, executionBlueprint.engineSchema) ?: return null,
+            pathToPartitionArg = pathToPartitionArg,
             fieldPartitionContext = fieldPartitionContext,
             graphQLSchema = executionBlueprint.engineSchema,
             partitionKeyExtractor = partitionTransformHook.getPartitionKeyExtractor()
@@ -102,16 +112,6 @@ internal class NadelPartitionTransform(
             fieldPartitionContext = fieldPartitionContext,
             fieldPartitions = fieldPartitions
         )
-    }
-
-    private fun getPathToPartitionArg(overallField: ExecutableNormalizedField, schema: GraphQLSchema): List<String>?  {
-        val fieldDef = overallField.getFieldDefinitions(schema).first()
-        val routingDirective = fieldDef.getAppliedDirective(NadelDirectives.partitionDirectiveDefinition.name) ?: return null
-        val pathToSplitPoint = routingDirective.getArgument("pathToSplitPoint")
-            ?.argumentValue
-            ?.value as ArrayValue?
-
-        return pathToSplitPoint?.values?.map { it as StringValue }?.map { it.value }
     }
 
     override suspend fun transformField(
@@ -258,8 +258,6 @@ internal class NadelPartitionTransform(
                 )
             }
 
-        // TODO: Add "extensions" to the result?
-        // {"partitionedCall": true, "partitionsCalled": ["cloudId-1", "cloudId-2"]}
         return mergedData + errorInstructions
     }
 

--- a/lib/src/main/java/graphql/nadel/schema/NadelDirectives.kt
+++ b/lib/src/main/java/graphql/nadel/schema/NadelDirectives.kt
@@ -15,6 +15,7 @@ import graphql.nadel.dsl.NadelHydrationConditionDefinition
 import graphql.nadel.dsl.NadelHydrationConditionPredicateDefinition
 import graphql.nadel.dsl.NadelHydrationDefinition
 import graphql.nadel.dsl.NadelHydrationResultConditionDefinition
+import graphql.nadel.dsl.NadelPartitionDefinition
 import graphql.nadel.dsl.RemoteArgumentDefinition
 import graphql.nadel.dsl.RemoteArgumentSource
 import graphql.nadel.dsl.TypeMappingDefinition
@@ -408,6 +409,14 @@ object NadelDirectives {
         val from = getDirectiveValue<String>(directive, "from")
 
         return TypeMappingDefinition(underlyingName = from, overallName = directivesContainer.name)
+    }
+
+    internal fun createPartitionDefinition(fieldDefinition: GraphQLFieldDefinition): NadelPartitionDefinition? {
+        val directive = fieldDefinition.getAppliedDirective(partitionDirectiveDefinition.name)
+            ?: return null
+        val pathToSplitPoint = getDirectiveValue<List<String>>(directive, "pathToSplitPoint")
+
+        return NadelPartitionDefinition(pathToSplitPoint)
     }
 
     private inline fun <reified T : Any> getDirectiveValue(


### PR DESCRIPTION
2 benefits out of this:
- we move part of the computation out of request processing
- don't rely on `overallField.getFieldDefinitions()` calls in the transform, which can cause problems when used in conjunction with hydrations and renames