### PR TITLE
Basic support for virtual fields using hydration

### DIFF
--- a/lib/src/main/java/graphql/nadel/NadelExecutionHints.kt
+++ b/lib/src/main/java/graphql/nadel/NadelExecutionHints.kt
@@ -5,6 +5,7 @@ import graphql.nadel.hints.LegacyOperationNamesHint
 import graphql.nadel.hints.NadelDeferSupportHint
 import graphql.nadel.hints.NadelSharedTypeRenamesHint
 import graphql.nadel.hints.NadelShortCircuitEmptyQueryHint
+import graphql.nadel.hints.NadelVirtualTypeSupportHint
 import graphql.nadel.hints.NewBatchHydrationGroupingHint
 import graphql.nadel.hints.NewResultMergerAndNamespacedTypename
 
@@ -16,6 +17,7 @@ data class NadelExecutionHints(
     val deferSupport: NadelDeferSupportHint,
     val sharedTypeRenames: NadelSharedTypeRenamesHint,
     val shortCircuitEmptyQuery: NadelShortCircuitEmptyQueryHint,
+    val virtualTypeSupport: NadelVirtualTypeSupportHint,
 ) {
     /**
      * Returns a builder with the same field values as this object.
@@ -35,6 +37,7 @@ data class NadelExecutionHints(
         private var deferSupport = NadelDeferSupportHint { false }
         private var shortCircuitEmptyQuery = NadelShortCircuitEmptyQueryHint { false }
         private var sharedTypeRenames = NadelSharedTypeRenamesHint { false }
+        private var virtualTypeSupport = NadelVirtualTypeSupportHint { false }
 
         constructor()
 
@@ -80,6 +83,11 @@ data class NadelExecutionHints(
             return this
         }
 
+        fun virtualTypeSupport(flag: NadelVirtualTypeSupportHint): Builder {
+            virtualTypeSupport = flag
+            return this
+        }
+
         fun build(): NadelExecutionHints {
             return NadelExecutionHints(
                 legacyOperationNames,
@@ -89,6 +97,7 @@ data class NadelExecutionHints(
                 deferSupport,
                 sharedTypeRenames,
                 shortCircuitEmptyQuery,
+                virtualTypeSupport,
             )
         }
     }

--- a/lib/src/main/java/graphql/nadel/engine/blueprint/NadelExecutionBlueprintFactory.kt
+++ b/lib/src/main/java/graphql/nadel/engine/blueprint/NadelExecutionBlueprintFactory.kt
@@ -13,6 +13,7 @@ import graphql.nadel.dsl.FieldMappingDefinition
 import graphql.nadel.dsl.NadelHydrationDefinition
 import graphql.nadel.dsl.RemoteArgumentSource
 import graphql.nadel.dsl.TypeMappingDefinition
+import graphql.nadel.engine.blueprint.directives.isVirtualType
 import graphql.nadel.engine.blueprint.hydration.NadelBatchHydrationMatchStrategy
 import graphql.nadel.engine.blueprint.hydration.NadelHydrationActorInputDef
 import graphql.nadel.engine.blueprint.hydration.NadelHydrationActorInputDef.ValueSource.FieldResultValue
@@ -334,7 +335,7 @@ private class Factory(
                     return@mapNotNull null
                 }
 
-                val underlyingParentType = if (hydratedFieldParentType.hasAppliedDirective("virtualType")) {
+                val underlyingParentType = if (hydratedFieldParentType.isVirtualType()) {
                     hydratedFieldParentType
                 } else {
                     getUnderlyingType(hydratedFieldParentType, hydratedFieldDef)
@@ -554,7 +555,7 @@ private class Factory(
                 }
                 is RemoteArgumentSource.ObjectField -> {
                     // Ugh code still uses underlying schema, we need to pull these up to the overall schema
-                    val typeToLookAt = if (hydratedFieldParentType.hasAppliedDirective("virtualType")) {
+                    val typeToLookAt = if (hydratedFieldParentType.isVirtualType()) {
                         hydratedFieldParentType
                     } else {
                         getUnderlyingType(hydratedFieldParentType, hydratedFieldDef)

--- a/lib/src/main/java/graphql/nadel/engine/blueprint/NadelExecutionBlueprintFactory.kt
+++ b/lib/src/main/java/graphql/nadel/engine/blueprint/NadelExecutionBlueprintFactory.kt
@@ -335,14 +335,14 @@ private class Factory(
                     return@mapNotNull null
                 }
 
-                val underlyingParentType = if (hydratedFieldParentType.isVirtualType()) {
+                val typeToLookAt = if (hydratedFieldParentType.isVirtualType()) {
                     hydratedFieldParentType
                 } else {
                     getUnderlyingType(hydratedFieldParentType, hydratedFieldDef)
                         ?: error("No underlying type for: ${hydratedFieldParentType.name}")
                 }
 
-                val fieldDefs = underlyingParentType.getFieldsAlong(inputValueDef.valueSource.queryPathToField.segments)
+                val fieldDefs = typeToLookAt.getFieldsAlong(inputValueDef.valueSource.queryPathToField.segments)
                 inputValueDef.takeIf {
                     fieldDefs.any { fieldDef ->
                         fieldDef.type.unwrapNonNull().isList

--- a/lib/src/main/java/graphql/nadel/engine/blueprint/NadelExecutionBlueprintFactory.kt
+++ b/lib/src/main/java/graphql/nadel/engine/blueprint/NadelExecutionBlueprintFactory.kt
@@ -414,11 +414,6 @@ private class Factory(
             actorFieldDef = actorFieldDef,
             actorFieldContainer = actorFieldContainer,
             sourceFields = getBatchHydrationSourceFields(matchStrategy, hydrationArgs, condition),
-            virtualTypeContext = virtualTypeBlueprintFactory.makeVirtualTypeContext(
-                engineSchema = engineSchema,
-                containerType = parentType,
-                virtualFieldDef = hydratedFieldDef
-            ),
             condition = condition,
         )
     }

--- a/lib/src/main/java/graphql/nadel/engine/blueprint/NadelFieldInstruction.kt
+++ b/lib/src/main/java/graphql/nadel/engine/blueprint/NadelFieldInstruction.kt
@@ -3,8 +3,8 @@ package graphql.nadel.engine.blueprint
 import graphql.nadel.Service
 import graphql.nadel.engine.blueprint.hydration.NadelBatchHydrationMatchStrategy
 import graphql.nadel.engine.blueprint.hydration.NadelHydrationActorInputDef
-import graphql.nadel.engine.blueprint.hydration.NadelHydrationStrategy
 import graphql.nadel.engine.blueprint.hydration.NadelHydrationCondition
+import graphql.nadel.engine.blueprint.hydration.NadelHydrationStrategy
 import graphql.nadel.engine.transform.query.NadelQueryPath
 import graphql.schema.FieldCoordinates
 import graphql.schema.GraphQLFieldDefinition
@@ -88,6 +88,8 @@ interface NadelGenericHydrationInstruction {
      * The optional definition for conditional hydrations
      */
     val condition: NadelHydrationCondition?
+
+    val virtualTypeContext: NadelVirtualTypeContext?
 }
 
 data class NadelHydrationFieldInstruction(
@@ -102,6 +104,7 @@ data class NadelHydrationFieldInstruction(
     override val actorFieldDef: GraphQLFieldDefinition,
     override val actorFieldContainer: GraphQLFieldsContainer,
     override val condition: NadelHydrationCondition?,
+    override val virtualTypeContext: NadelVirtualTypeContext?,
     val hydrationStrategy: NadelHydrationStrategy,
 ) : NadelFieldInstruction(), NadelGenericHydrationInstruction
 
@@ -117,6 +120,7 @@ data class NadelBatchHydrationFieldInstruction(
     override val actorFieldDef: GraphQLFieldDefinition,
     override val actorFieldContainer: GraphQLFieldsContainer,
     override val condition: NadelHydrationCondition?,
+    override val virtualTypeContext: NadelVirtualTypeContext?,
     val batchSize: Int,
     val batchHydrationMatchStrategy: NadelBatchHydrationMatchStrategy,
 ) : NadelFieldInstruction(), NadelGenericHydrationInstruction

--- a/lib/src/main/java/graphql/nadel/engine/blueprint/NadelFieldInstruction.kt
+++ b/lib/src/main/java/graphql/nadel/engine/blueprint/NadelFieldInstruction.kt
@@ -88,8 +88,6 @@ interface NadelGenericHydrationInstruction {
      * The optional definition for conditional hydrations
      */
     val condition: NadelHydrationCondition?
-
-    val virtualTypeContext: NadelVirtualTypeContext?
 }
 
 data class NadelHydrationFieldInstruction(
@@ -104,7 +102,14 @@ data class NadelHydrationFieldInstruction(
     override val actorFieldDef: GraphQLFieldDefinition,
     override val actorFieldContainer: GraphQLFieldsContainer,
     override val condition: NadelHydrationCondition?,
-    override val virtualTypeContext: NadelVirtualTypeContext?,
+    /**
+     * Hydration can bring about virtual types.
+     *
+     * These types mirror the backing type, but can have things like hydration etc.
+     *
+     * This context provides a mapping between the virtual and backing types.
+     */
+    val virtualTypeContext: NadelVirtualTypeContext?,
     val hydrationStrategy: NadelHydrationStrategy,
 ) : NadelFieldInstruction(), NadelGenericHydrationInstruction
 
@@ -120,7 +125,6 @@ data class NadelBatchHydrationFieldInstruction(
     override val actorFieldDef: GraphQLFieldDefinition,
     override val actorFieldContainer: GraphQLFieldsContainer,
     override val condition: NadelHydrationCondition?,
-    override val virtualTypeContext: NadelVirtualTypeContext?,
     val batchSize: Int,
     val batchHydrationMatchStrategy: NadelBatchHydrationMatchStrategy,
 ) : NadelFieldInstruction(), NadelGenericHydrationInstruction

--- a/lib/src/main/java/graphql/nadel/engine/blueprint/NadelVirtualTypeBlueprintFactory.kt
+++ b/lib/src/main/java/graphql/nadel/engine/blueprint/NadelVirtualTypeBlueprintFactory.kt
@@ -1,0 +1,182 @@
+package graphql.nadel.engine.blueprint
+
+import graphql.nadel.engine.blueprint.directives.getHydrated
+import graphql.nadel.engine.blueprint.directives.getHydratedOrNull
+import graphql.nadel.engine.blueprint.directives.isHydration
+import graphql.nadel.engine.util.getFieldAt
+import graphql.nadel.engine.util.unwrapAll
+import graphql.schema.GraphQLFieldDefinition
+import graphql.schema.GraphQLObjectType
+import graphql.schema.GraphQLSchema
+
+internal class NadelVirtualTypeBlueprintFactory {
+    private data class FactoryContext(
+        val engineSchema: GraphQLSchema,
+    )
+
+    fun createVirtualTypeContexts(
+        engineSchema: GraphQLSchema,
+    ): List<NadelVirtualTypeContext> {
+        val factoryContext = FactoryContext(
+            engineSchema,
+        )
+
+        return with(factoryContext) {
+            createVirtualTypeContexts()
+        }
+    }
+
+    context(FactoryContext)
+    private fun createVirtualTypeContexts(): List<NadelVirtualTypeContext> {
+        return engineSchema
+            .typeMap
+            .values
+            .asSequence()
+            .filterIsInstance<GraphQLObjectType>()
+            .flatMap { containerType ->
+                containerType.fields
+                    .asSequence()
+                    .filter(GraphQLFieldDefinition::isHydration)
+                    .mapNotNull { virtualFieldDef ->
+                        makeVirtualTypeContext(containerType, virtualFieldDef)
+                    }
+            }
+            .toList()
+    }
+
+    fun makeVirtualTypeContext(
+        engineSchema: GraphQLSchema,
+        containerType: GraphQLObjectType,
+        virtualFieldDef: GraphQLFieldDefinition,
+    ): NadelVirtualTypeContext? {
+        val factoryContext = FactoryContext(
+            engineSchema,
+        )
+
+        return with(factoryContext) {
+            makeVirtualTypeContext(containerType, virtualFieldDef)
+        }
+    }
+
+    context(FactoryContext)
+    private fun makeVirtualTypeContext(
+        containerType: GraphQLObjectType,
+        virtualFieldDef: GraphQLFieldDefinition,
+    ): NadelVirtualTypeContext? {
+        val typeMappings = createTypeMappings(virtualFieldDef)
+
+        return if (typeMappings.isEmpty()) {
+            return null
+        } else {
+            NadelVirtualTypeContext(
+                virtualFieldContainer = containerType,
+                virtualField = virtualFieldDef,
+                virtualTypeToBackingType = typeMappings.virtualTypeToBackingTypeMap(),
+                backingTypeToVirtualType = typeMappings.backingTypeToVirtualTypeMap(),
+            )
+        }
+    }
+
+    context(FactoryContext)
+    private fun createTypeMappings(
+        virtualFieldDef: GraphQLFieldDefinition,
+    ): List<VirtualTypeMapping> {
+        val hydration = virtualFieldDef.getHydratedOrNull()
+            ?: return emptyList() // We should use the non-null method once we delete @hydratedFrom
+        val backingFieldDef = engineSchema.queryType.getFieldAt(hydration.backingField)!!
+        val backingType = backingFieldDef.type.unwrapAll() as? GraphQLObjectType
+            ?: return emptyList()
+        val virtualType = virtualFieldDef.type.unwrapAll() as? GraphQLObjectType
+            ?: return emptyList()
+
+        // Not a virtual type
+        if (virtualType.name == backingType.name) {
+            return emptyList()
+        }
+
+        return createTypeMappings(
+            backingType = backingType,
+            virtualType = virtualType,
+        )
+    }
+
+    context(FactoryContext)
+    private fun createTypeMappings(
+        backingType: GraphQLObjectType,
+        virtualType: GraphQLObjectType,
+    ): List<VirtualTypeMapping> {
+        return listOf(VirtualTypeMapping(virtualType, backingType)) + createTypeMappings(
+            virtualType = virtualType,
+            backingType = backingType,
+            visitedVirtualTypes = mutableSetOf(virtualType.name),
+        )
+    }
+
+    context(FactoryContext)
+    private fun createTypeMappings(
+        virtualType: GraphQLObjectType,
+        backingType: GraphQLObjectType,
+        visitedVirtualTypes: MutableSet<String>,
+    ): List<VirtualTypeMapping> {
+        return virtualType
+            .fields
+            .flatMap { virtualFieldDef ->
+                val virtualOutputType = virtualFieldDef.type.unwrapAll() as GraphQLObjectType
+                if (visitedVirtualTypes.visit(virtualOutputType.name)) {
+                    val backingFieldDef = backingType.getField(virtualFieldDef.name)
+                    val backingOutputType = backingFieldDef.type.unwrapAll() as GraphQLObjectType
+
+                    // Recursively create type mapping
+                    val childTypeMappings = createTypeMappings(
+                        visitedVirtualTypes = visitedVirtualTypes,
+                        virtualType = virtualType,
+                        backingType = backingType,
+                    )
+
+                    listOf(VirtualTypeMapping(virtualOutputType, backingOutputType)) + childTypeMappings
+                } else {
+                    emptyList()
+                }
+            }
+    }
+
+    data class VirtualTypeMapping(
+        val virtualType: GraphQLObjectType,
+        val backingType: GraphQLObjectType,
+    )
+
+    /**
+     * Util to create [Map]
+     */
+    private fun List<VirtualTypeMapping>.virtualTypeToBackingTypeMap(): Map<String, String> {
+        val mapping = mutableMapOf<String, String>()
+        forEach {
+            mapping[it.virtualType.name] = it.backingType.name
+        }
+        return mapping
+    }
+
+    /**
+     * Util to create [Map]
+     */
+    private fun List<VirtualTypeMapping>.backingTypeToVirtualTypeMap(): Map<String, String> {
+        val mapping = mutableMapOf<String, String>()
+        forEach {
+            mapping[it.backingType.name] = it.virtualType.name
+        }
+        return mapping
+    }
+}
+
+/**
+ * @return true if the element hasn't been visited before.
+ * Also mutates the [MutableSet] to mark it as visited.
+ */
+private fun MutableSet<String>.visit(element: String): Boolean {
+    return if (contains(element)) {
+        false
+    } else {
+        add(element)
+        true
+    }
+}

--- a/lib/src/main/java/graphql/nadel/engine/blueprint/NadelVirtualTypeBlueprintFactory.kt
+++ b/lib/src/main/java/graphql/nadel/engine/blueprint/NadelVirtualTypeBlueprintFactory.kt
@@ -1,6 +1,5 @@
 package graphql.nadel.engine.blueprint
 
-import graphql.nadel.engine.blueprint.directives.getHydrated
 import graphql.nadel.engine.blueprint.directives.getHydratedOrNull
 import graphql.nadel.engine.blueprint.directives.isHydration
 import graphql.nadel.engine.util.getFieldAt
@@ -121,7 +120,9 @@ internal class NadelVirtualTypeBlueprintFactory {
         return virtualType
             .fields
             .flatMap { virtualFieldDef ->
-                val virtualOutputType = virtualFieldDef.type.unwrapAll() as GraphQLObjectType
+                val virtualOutputType = virtualFieldDef.type.unwrapAll() as? GraphQLObjectType
+                    ?: return@flatMap emptyList()
+
                 if (visitedVirtualTypes.visit(virtualOutputType.name)) {
                     val backingFieldDef = backingType.getField(virtualFieldDef.name)
                     val backingOutputType = backingFieldDef.type.unwrapAll() as GraphQLObjectType
@@ -129,8 +130,8 @@ internal class NadelVirtualTypeBlueprintFactory {
                     // Recursively create type mapping
                     val childTypeMappings = createTypeMappings(
                         visitedVirtualTypes = visitedVirtualTypes,
-                        virtualType = virtualType,
-                        backingType = backingType,
+                        virtualType = virtualOutputType,
+                        backingType = backingOutputType,
                     )
 
                     listOf(VirtualTypeMapping(virtualOutputType, backingOutputType)) + childTypeMappings

--- a/lib/src/main/java/graphql/nadel/engine/blueprint/NadelVirtualTypeBlueprintFactory.kt
+++ b/lib/src/main/java/graphql/nadel/engine/blueprint/NadelVirtualTypeBlueprintFactory.kt
@@ -13,36 +13,6 @@ internal class NadelVirtualTypeBlueprintFactory {
         val engineSchema: GraphQLSchema,
     )
 
-    fun createVirtualTypeContexts(
-        engineSchema: GraphQLSchema,
-    ): List<NadelVirtualTypeContext> {
-        val factoryContext = FactoryContext(
-            engineSchema,
-        )
-
-        return with(factoryContext) {
-            createVirtualTypeContexts()
-        }
-    }
-
-    context(FactoryContext)
-    private fun createVirtualTypeContexts(): List<NadelVirtualTypeContext> {
-        return engineSchema
-            .typeMap
-            .values
-            .asSequence()
-            .filterIsInstance<GraphQLObjectType>()
-            .flatMap { containerType ->
-                containerType.fields
-                    .asSequence()
-                    .filter(GraphQLFieldDefinition::isHydration)
-                    .mapNotNull { virtualFieldDef ->
-                        makeVirtualTypeContext(containerType, virtualFieldDef)
-                    }
-            }
-            .toList()
-    }
-
     fun makeVirtualTypeContext(
         engineSchema: GraphQLSchema,
         containerType: GraphQLObjectType,

--- a/lib/src/main/java/graphql/nadel/engine/blueprint/NadelVirtualTypeContext.kt
+++ b/lib/src/main/java/graphql/nadel/engine/blueprint/NadelVirtualTypeContext.kt
@@ -1,0 +1,17 @@
+package graphql.nadel.engine.blueprint
+
+import graphql.schema.GraphQLFieldDefinition
+import graphql.schema.GraphQLFieldsContainer
+
+data class NadelVirtualTypeContext(
+    /**
+     * The container of the virtual field that created this mapping.
+     */
+    val virtualFieldContainer: GraphQLFieldsContainer,
+    /**
+     * The virtual field that created this mapping.
+     */
+    val virtualField: GraphQLFieldDefinition,
+    val virtualTypeToBackingType: Map<String, String>,
+    val backingTypeToVirtualType: Map<String, String>,
+)

--- a/lib/src/main/java/graphql/nadel/engine/blueprint/directives/NadelHydrationDirective.kt
+++ b/lib/src/main/java/graphql/nadel/engine/blueprint/directives/NadelHydrationDirective.kt
@@ -1,0 +1,109 @@
+package graphql.nadel.engine.blueprint.directives
+
+import graphql.language.ArrayValue
+import graphql.language.ObjectField
+import graphql.language.ObjectValue
+import graphql.language.StringValue
+import graphql.nadel.util.AnyAstValue
+import graphql.schema.GraphQLAppliedDirective
+import graphql.schema.GraphQLFieldDefinition
+
+internal fun GraphQLFieldDefinition.isHydration(): Boolean {
+    return hasAppliedDirective(NadelHydrationDirective.SyntaxConstant.hydrated)
+}
+
+internal fun GraphQLFieldDefinition.getHydratedOrNull(): NadelHydrationDirective? {
+    val appliedDirective = getAppliedDirective(NadelHydrationDirective.SyntaxConstant.hydrated)
+        ?: return null
+    return NadelHydrationDirective(appliedDirective)
+}
+
+internal fun GraphQLFieldDefinition.getHydrated(): NadelHydrationDirective {
+    return getHydratedOrNull()!!
+}
+
+/**
+ * ```graphql
+ * "This allows you to hydrate new values into fields"
+ * directive @hydrated(
+ *     "The target service"
+ *     service: String!
+ *     "The target top level field"
+ *     field: String!
+ *     "How to identify matching results"
+ *     identifiedBy: String! = "id"
+ *     "How to identify matching results"
+ *     inputIdentifiedBy: [NadelBatchObjectIdentifiedBy!]! = []
+ *     "Are results indexed"
+ *     indexed: Boolean! = false
+ *     "Is querying batched"
+ *     batched: Boolean! = false
+ *     "The batch size"
+ *     batchSize: Int! = 200
+ *     "The timeout to use when completing hydration"
+ *     timeout: Int! = -1
+ *     "The arguments to the hydrated field"
+ *     arguments: [NadelHydrationArgument!]!
+ *     "Specify a condition for the hydration to activate"
+ *     when: NadelHydrationCondition
+ * ) repeatable on FIELD_DEFINITION
+ * ```
+ */
+internal class NadelHydrationDirective(
+    private val appliedDirective: GraphQLAppliedDirective,
+) {
+    val backingField: List<String>
+        get() = appliedDirective.getArgument(SyntaxConstant.field).getValue<String>().split(".")
+
+    val identifiedBy: String
+        get() = appliedDirective.getArgument(SyntaxConstant.identifiedBy).getValue()
+
+    val isIndexed: Boolean
+        get() = appliedDirective.getArgument(SyntaxConstant.indexed).getValue()
+
+    val isBatched: Boolean
+        get() = appliedDirective.getArgument(SyntaxConstant.batched).getValue()
+
+    val batchSize: Boolean
+        get() = appliedDirective.getArgument(SyntaxConstant.batchSize).getValue()
+
+    val arguments: List<NadelHydrationArgumentDefinition>
+        get() = appliedDirective.getArgument(SyntaxConstant.arguments).getValue<ArrayValue>()
+            .values
+            .map {
+                NadelHydrationArgumentDefinition(it as ObjectValue)
+            }
+
+    object SyntaxConstant {
+        const val hydrated = "hydrated"
+        const val field = "field"
+        const val identifiedBy = "identifiedBy"
+        const val indexed = "indexed"
+        const val batched = "batched"
+        const val batchSize = "batchSize"
+        const val arguments = "arguments"
+    }
+}
+
+/**
+ * Argument belonging to [NadelHydrationDirective.arguments]
+ */
+internal class NadelHydrationArgumentDefinition(
+    private val argumentObject: ObjectValue,
+) {
+    /**
+     * Name of the backing field's argument.
+     */
+    val name: String
+        get() = (argumentObject.getObjectField("name").value as StringValue).value
+
+    /**
+     * Value to support to the backing field's argument at runtime.
+     */
+    val value: AnyAstValue
+        get() = argumentObject.getObjectField("name").value
+}
+
+internal fun ObjectValue.getObjectField(name: String): ObjectField {
+    return objectFields.first { it.name == name }
+}

--- a/lib/src/main/java/graphql/nadel/engine/blueprint/directives/NadelVirtualTypeDirective.kt
+++ b/lib/src/main/java/graphql/nadel/engine/blueprint/directives/NadelVirtualTypeDirective.kt
@@ -1,0 +1,13 @@
+package graphql.nadel.engine.blueprint.directives
+
+import graphql.schema.GraphQLDirectiveContainer
+
+internal fun GraphQLDirectiveContainer.isVirtualType(): Boolean {
+    return hasAppliedDirective(NadelVirtualTypeDirective.SyntaxConstant.virtualType)
+}
+
+internal class NadelVirtualTypeDirective {
+    object SyntaxConstant {
+        const val virtualType = "virtualType"
+    }
+}

--- a/lib/src/main/java/graphql/nadel/engine/transform/NadelDeepRenameTransform.kt
+++ b/lib/src/main/java/graphql/nadel/engine/transform/NadelDeepRenameTransform.kt
@@ -22,7 +22,8 @@ import graphql.nadel.engine.util.toBuilder
 import graphql.normalized.ExecutableNormalizedField
 import graphql.schema.FieldCoordinates
 
-typealias GraphQLObjectTypeName = String
+@Deprecated("Should be changed to a value class")
+internal typealias GraphQLObjectTypeName = String
 
 /**
  * A deep rename is a rename in where the field being "renamed" is not on the same level
@@ -213,7 +214,7 @@ internal class NadelDeepRenameTransform : NadelTransform<NadelDeepRenameTransfor
             .takeIf { it.isNotEmpty() }
             ?: return null
 
-        return NadelTransformUtil.makeTypeNameField(
+        return makeTypeNameField(
             aliasHelper = state.aliasHelper,
             objectTypeNames = objectTypeNames,
             deferredExecutions = field.deferredExecutions,

--- a/lib/src/main/java/graphql/nadel/engine/transform/NadelRenameTransform.kt
+++ b/lib/src/main/java/graphql/nadel/engine/transform/NadelRenameTransform.kt
@@ -117,7 +117,7 @@ internal class NadelRenameTransform : NadelTransform<State> {
             .takeIf { it.isNotEmpty() }
             ?: return null
 
-        return NadelTransformUtil.makeTypeNameField(
+        return makeTypeNameField(
             aliasHelper = state.aliasHelper,
             objectTypeNames = objectTypeNames,
             deferredExecutions = field.deferredExecutions,

--- a/lib/src/main/java/graphql/nadel/engine/transform/NadelServiceTypeFilterTransform.kt
+++ b/lib/src/main/java/graphql/nadel/engine/transform/NadelServiceTypeFilterTransform.kt
@@ -152,6 +152,21 @@ class NadelServiceTypeFilterTransform : NadelTransform<State> {
                 .toList()
 
             if (objectTypeNames.isEmpty()) {
+                // All virtual types
+                if (field.objectTypeNames.all {
+                        executionBlueprint.engineSchema.getObjectType(it).hasAppliedDirective("virtualType")
+                    }) {
+                    return NadelTransformFieldResult(
+                        newField = null,
+                        artificialFields = listOf(
+                            newNormalizedField()
+                                .objectTypeNames(listOf("GraphStoreQueryEdge"))
+                                .alias(state.aliasHelper.typeNameResultKey)
+                                .fieldName(Introspection.TypeNameMetaFieldDef.name)
+                                .build(),
+                        ),
+                    )
+                }
                 error("Service does not own return type. Unable to insert __typename as schema is not configured properly.")
             }
 

--- a/lib/src/main/java/graphql/nadel/engine/transform/NadelServiceTypeFilterTransform.kt
+++ b/lib/src/main/java/graphql/nadel/engine/transform/NadelServiceTypeFilterTransform.kt
@@ -152,7 +152,6 @@ class NadelServiceTypeFilterTransform : NadelTransform<State> {
                 .toList()
 
             if (objectTypeNames.isEmpty()) {
-                // All virtual types
                 error("Service does not own return type. Unable to insert __typename as schema is not configured properly.")
             }
 

--- a/lib/src/main/java/graphql/nadel/engine/transform/NadelServiceTypeFilterTransform.kt
+++ b/lib/src/main/java/graphql/nadel/engine/transform/NadelServiceTypeFilterTransform.kt
@@ -153,20 +153,6 @@ class NadelServiceTypeFilterTransform : NadelTransform<State> {
 
             if (objectTypeNames.isEmpty()) {
                 // All virtual types
-                if (field.objectTypeNames.all {
-                        executionBlueprint.engineSchema.getObjectType(it).hasAppliedDirective("virtualType")
-                    }) {
-                    return NadelTransformFieldResult(
-                        newField = null,
-                        artificialFields = listOf(
-                            newNormalizedField()
-                                .objectTypeNames(listOf("GraphStoreQueryEdge"))
-                                .alias(state.aliasHelper.typeNameResultKey)
-                                .fieldName(Introspection.TypeNameMetaFieldDef.name)
-                                .build(),
-                        ),
-                    )
-                }
                 error("Service does not own return type. Unable to insert __typename as schema is not configured properly.")
             }
 

--- a/lib/src/main/java/graphql/nadel/engine/transform/hydration/NadelHydrationFieldsBuilder.kt
+++ b/lib/src/main/java/graphql/nadel/engine/transform/hydration/NadelHydrationFieldsBuilder.kt
@@ -177,6 +177,10 @@ internal object NadelHydrationFieldsBuilder {
         )
     }
 
+    /**
+     * This converts the [ExecutableNormalizedField.objectTypeNames] from the virtual types
+     * to the backing types.
+     */
     private fun setBackingObjectTypeNames(
         instruction: NadelHydrationFieldInstruction,
         field: ExecutableNormalizedField,

--- a/lib/src/main/java/graphql/nadel/engine/transform/hydration/NadelHydrationFieldsBuilder.kt
+++ b/lib/src/main/java/graphql/nadel/engine/transform/hydration/NadelHydrationFieldsBuilder.kt
@@ -1,6 +1,7 @@
 package graphql.nadel.engine.transform.hydration
 
 import graphql.nadel.Service
+import graphql.nadel.engine.NadelExecutionContext
 import graphql.nadel.engine.blueprint.NadelBatchHydrationFieldInstruction
 import graphql.nadel.engine.blueprint.NadelGenericHydrationInstruction
 import graphql.nadel.engine.blueprint.NadelHydrationFieldInstruction
@@ -22,6 +23,8 @@ import graphql.normalized.NormalizedInputValue
 
 internal object NadelHydrationFieldsBuilder {
     fun makeActorQueries(
+        executionContext: NadelExecutionContext,
+        service: Service,
         instruction: NadelHydrationFieldInstruction,
         aliasHelper: NadelAliasHelper,
         fieldToHydrate: ExecutableNormalizedField,
@@ -45,9 +48,11 @@ internal object NadelHydrationFieldsBuilder {
             }
             // Fix types for virtual fields
             .onEach { field ->
-                setBackingObjectTypeNames(instruction, field)
-                field.traverseSubTree { child ->
-                    setBackingObjectTypeNames(instruction, child)
+                if (executionContext.hints.virtualTypeSupport(service)) {
+                    setBackingObjectTypeNames(instruction, field)
+                    field.traverseSubTree { child ->
+                        setBackingObjectTypeNames(instruction, child)
+                    }
                 }
             }
     }

--- a/lib/src/main/java/graphql/nadel/engine/transform/hydration/NadelHydrationTransform.kt
+++ b/lib/src/main/java/graphql/nadel/engine/transform/hydration/NadelHydrationTransform.kt
@@ -90,6 +90,8 @@ internal class NadelHydrationTransform(
             ?: executionBlueprint.getInstructionInsideVirtualType<NadelHydrationFieldInstruction>(executionBlueprint, hydrationDetails, overallField)
             ?: emptyMap()
 
+        executionContext.hints.isVirtualTypeSupportOn()
+
         return if (instructionsByObjectTypeName.isEmpty()) {
             null
         } else {

--- a/lib/src/main/java/graphql/nadel/engine/transform/hydration/NadelHydrationTransform.kt
+++ b/lib/src/main/java/graphql/nadel/engine/transform/hydration/NadelHydrationTransform.kt
@@ -329,6 +329,8 @@ internal class NadelHydrationTransform(
             }
 
         val actorQueries = NadelHydrationFieldsBuilder.makeActorQueries(
+            executionContext = executionContext,
+            service = state.hydratedFieldService,
             instruction = instruction,
             aliasHelper = state.aliasHelper,
             fieldToHydrate = fieldToHydrate,

--- a/lib/src/main/java/graphql/nadel/engine/transform/hydration/NadelHydrationTransform.kt
+++ b/lib/src/main/java/graphql/nadel/engine/transform/hydration/NadelHydrationTransform.kt
@@ -11,7 +11,6 @@ import graphql.nadel.engine.NadelServiceExecutionContext
 import graphql.nadel.engine.blueprint.NadelGenericHydrationInstruction
 import graphql.nadel.engine.blueprint.NadelHydrationFieldInstruction
 import graphql.nadel.engine.blueprint.NadelOverallExecutionBlueprint
-import graphql.nadel.engine.blueprint.directives.isVirtualType
 import graphql.nadel.engine.blueprint.getTypeNameToInstructionsMap
 import graphql.nadel.engine.blueprint.hydration.NadelHydrationStrategy
 import graphql.nadel.engine.transform.GraphQLObjectTypeName
@@ -29,19 +28,15 @@ import graphql.nadel.engine.transform.result.json.JsonNodeExtractor
 import graphql.nadel.engine.transform.result.json.JsonNodes
 import graphql.nadel.engine.util.JsonMap
 import graphql.nadel.engine.util.emptyOrSingle
-import graphql.nadel.engine.util.fieldPath
-import graphql.nadel.engine.util.getFieldAt
 import graphql.nadel.engine.util.getFieldDefinitionSequence
 import graphql.nadel.engine.util.isList
 import graphql.nadel.engine.util.queryPath
 import graphql.nadel.engine.util.toBuilder
 import graphql.nadel.engine.util.toGraphQLError
-import graphql.nadel.engine.util.unwrapAll
 import graphql.nadel.engine.util.unwrapNonNull
 import graphql.nadel.hooks.NadelExecutionHooks
 import graphql.normalized.ExecutableNormalizedField
 import graphql.schema.FieldCoordinates
-import graphql.schema.GraphQLDirectiveContainer
 import graphql.schema.GraphQLSchema
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
@@ -84,13 +79,14 @@ internal class NadelHydrationTransform(
     ): State? {
         val instructionsByObjectTypeName = executionBlueprint.fieldInstructions
             .getTypeNameToInstructionsMap<NadelHydrationFieldInstruction>(overallField)
-            .takeIf {
-                it.isNotEmpty()
+            .ifEmpty {
+                if (executionContext.hints.virtualTypeSupport(service)) {
+                    executionBlueprint
+                        .getInstructionInsideVirtualType(hydrationDetails, overallField)
+                } else {
+                    emptyMap()
+                }
             }
-            ?: executionBlueprint.getInstructionInsideVirtualType<NadelHydrationFieldInstruction>(executionBlueprint, hydrationDetails, overallField)
-            ?: emptyMap()
-
-        executionContext.hints.isVirtualTypeSupportOn()
 
         return if (instructionsByObjectTypeName.isEmpty()) {
             null

--- a/lib/src/main/java/graphql/nadel/engine/transform/hydration/batch/NadelBatchHydrationByObjectId.kt
+++ b/lib/src/main/java/graphql/nadel/engine/transform/hydration/batch/NadelBatchHydrationByObjectId.kt
@@ -136,14 +136,6 @@ internal object NadelBatchHydrationByObjectId {
     ): NadelResultInstruction {
         val hydratedFieldDef = instruction.hydratedFieldDef
 
-        // val hydratedFieldDef = NadelTransformUtil.getOverallFieldDef(
-        //     overallField = state.hydratedField,
-        //     parentNode = sourceNode,
-        //     service = state.hydratedFieldService,
-        //     executionBlueprint = executionBlueprint,
-        //     aliasHelper = state.aliasHelper,
-        // ) ?: error("Unable to find field definition for ${state.hydratedField.queryPath}")
-
         val newValue: Any? = if (hydratedFieldDef.type.unwrapNonNull().isList) {
             // Set to null if there were no identifier nodes
             if (isAllNull(sourceIds)) {

--- a/lib/src/main/java/graphql/nadel/engine/transform/hydration/batch/NadelBatchHydrationByObjectId.kt
+++ b/lib/src/main/java/graphql/nadel/engine/transform/hydration/batch/NadelBatchHydrationByObjectId.kt
@@ -4,7 +4,6 @@ import graphql.nadel.ServiceExecutionResult
 import graphql.nadel.engine.blueprint.NadelBatchHydrationFieldInstruction
 import graphql.nadel.engine.blueprint.NadelOverallExecutionBlueprint
 import graphql.nadel.engine.blueprint.hydration.NadelBatchHydrationMatchStrategy
-import graphql.nadel.engine.transform.NadelTransformUtil
 import graphql.nadel.engine.transform.hydration.NadelHydrationUtil.getHydrationActorNodes
 import graphql.nadel.engine.transform.result.NadelResultInstruction
 import graphql.nadel.engine.transform.result.NadelResultKey
@@ -17,7 +16,6 @@ import graphql.nadel.engine.util.asNullableJsonMap
 import graphql.nadel.engine.util.emptyOrSingle
 import graphql.nadel.engine.util.flatten
 import graphql.nadel.engine.util.isList
-import graphql.nadel.engine.util.queryPath
 import graphql.nadel.engine.util.unwrapNonNull
 
 internal object NadelBatchHydrationByObjectId {
@@ -120,6 +118,7 @@ internal object NadelBatchHydrationByObjectId {
             getHydrateInstructionsForNodeMatchingObjectId(
                 executionBlueprint = executionBlueprint,
                 state = state,
+                instruction = instruction,
                 sourceNode = sourceNode,
                 sourceIds = sourceIds,
                 resultNodesByObjectId = resultNodesByObjectId
@@ -130,17 +129,20 @@ internal object NadelBatchHydrationByObjectId {
     private fun getHydrateInstructionsForNodeMatchingObjectId(
         executionBlueprint: NadelOverallExecutionBlueprint,
         state: NadelBatchHydrationTransform.State,
+        instruction: NadelBatchHydrationFieldInstruction,
         sourceNode: JsonNode,
         sourceIds: List<List<Any?>>,
         resultNodesByObjectId: Map<List<Any?>, JsonMap>,
     ): NadelResultInstruction {
-        val hydratedFieldDef = NadelTransformUtil.getOverallFieldDef(
-            overallField = state.hydratedField,
-            parentNode = sourceNode,
-            service = state.hydratedFieldService,
-            executionBlueprint = executionBlueprint,
-            aliasHelper = state.aliasHelper,
-        ) ?: error("Unable to find field definition for ${state.hydratedField.queryPath}")
+        val hydratedFieldDef = instruction.hydratedFieldDef
+
+        // val hydratedFieldDef = NadelTransformUtil.getOverallFieldDef(
+        //     overallField = state.hydratedField,
+        //     parentNode = sourceNode,
+        //     service = state.hydratedFieldService,
+        //     executionBlueprint = executionBlueprint,
+        //     aliasHelper = state.aliasHelper,
+        // ) ?: error("Unable to find field definition for ${state.hydratedField.queryPath}")
 
         val newValue: Any? = if (hydratedFieldDef.type.unwrapNonNull().isList) {
             // Set to null if there were no identifier nodes

--- a/lib/src/main/java/graphql/nadel/engine/transform/hydration/batch/NadelBatchHydrationTransform.kt
+++ b/lib/src/main/java/graphql/nadel/engine/transform/hydration/batch/NadelBatchHydrationTransform.kt
@@ -12,10 +12,10 @@ import graphql.nadel.engine.blueprint.getTypeNameToInstructionsMap
 import graphql.nadel.engine.transform.GraphQLObjectTypeName
 import graphql.nadel.engine.transform.NadelTransform
 import graphql.nadel.engine.transform.NadelTransformFieldResult
-import graphql.nadel.engine.transform.NadelTransformUtil.makeTypeNameField
 import graphql.nadel.engine.transform.artificial.NadelAliasHelper
 import graphql.nadel.engine.transform.hydration.NadelHydrationFieldsBuilder
 import graphql.nadel.engine.transform.hydration.batch.NadelBatchHydrationTransform.State
+import graphql.nadel.engine.transform.makeTypeNameField
 import graphql.nadel.engine.transform.query.NadelQueryPath
 import graphql.nadel.engine.transform.query.NadelQueryTransformer
 import graphql.nadel.engine.transform.result.NadelResultInstruction
@@ -50,6 +50,11 @@ internal class NadelBatchHydrationTransform(
     ): State? {
         val instructionsByObjectTypeName = executionBlueprint.fieldInstructions
             .getTypeNameToInstructionsMap<NadelBatchHydrationFieldInstruction>(overallField)
+            .takeIf {
+                it.isNotEmpty()
+            }
+            ?: executionBlueprint.getInstructionInsideVirtualType(executionBlueprint, hydrationDetails, overallField)
+            ?: emptyMap()
 
         return if (instructionsByObjectTypeName.isNotEmpty()) {
             return State(

--- a/lib/src/main/java/graphql/nadel/engine/transform/hydration/batch/NadelBatchHydrationTransform.kt
+++ b/lib/src/main/java/graphql/nadel/engine/transform/hydration/batch/NadelBatchHydrationTransform.kt
@@ -48,17 +48,16 @@ internal class NadelBatchHydrationTransform(
         overallField: ExecutableNormalizedField,
         hydrationDetails: ServiceExecutionHydrationDetails?,
     ): State? {
-        val instructionsByObjectTypeName =
-            executionBlueprint.fieldInstructions
-                .getTypeNameToInstructionsMap<NadelBatchHydrationFieldInstruction>(overallField)
-                .ifEmpty {
-                    if (executionContext.hints.virtualTypeSupport(service)) {
-                        executionBlueprint
-                            .getInstructionInsideVirtualType(hydrationDetails, overallField)
-                    } else {
-                        emptyMap()
-                    }
+        val instructionsByObjectTypeName = executionBlueprint.fieldInstructions
+            .getTypeNameToInstructionsMap<NadelBatchHydrationFieldInstruction>(overallField)
+            .ifEmpty {
+                if (executionContext.hints.virtualTypeSupport(service)) {
+                    executionBlueprint
+                        .getInstructionInsideVirtualType(hydrationDetails, overallField)
+                } else {
+                    emptyMap()
                 }
+            }
 
         return if (instructionsByObjectTypeName.isNotEmpty()) {
             return State(

--- a/lib/src/main/java/graphql/nadel/engine/transform/hydration/batch/NadelBatchHydrationTransform.kt
+++ b/lib/src/main/java/graphql/nadel/engine/transform/hydration/batch/NadelBatchHydrationTransform.kt
@@ -48,13 +48,17 @@ internal class NadelBatchHydrationTransform(
         overallField: ExecutableNormalizedField,
         hydrationDetails: ServiceExecutionHydrationDetails?,
     ): State? {
-        val instructionsByObjectTypeName = executionBlueprint.fieldInstructions
-            .getTypeNameToInstructionsMap<NadelBatchHydrationFieldInstruction>(overallField)
-            .takeIf {
-                it.isNotEmpty()
-            }
-            ?: executionBlueprint.getInstructionInsideVirtualType(executionBlueprint, hydrationDetails, overallField)
-            ?: emptyMap()
+        val instructionsByObjectTypeName =
+            executionBlueprint.fieldInstructions
+                .getTypeNameToInstructionsMap<NadelBatchHydrationFieldInstruction>(overallField)
+                .ifEmpty {
+                    if (executionContext.hints.virtualTypeSupport(service)) {
+                        executionBlueprint
+                            .getInstructionInsideVirtualType(hydrationDetails, overallField)
+                    } else {
+                        emptyMap()
+                    }
+                }
 
         return if (instructionsByObjectTypeName.isNotEmpty()) {
             return State(

--- a/lib/src/main/java/graphql/nadel/engine/transform/hydration/batch/NadelNewBatchHydrator.kt
+++ b/lib/src/main/java/graphql/nadel/engine/transform/hydration/batch/NadelNewBatchHydrator.kt
@@ -445,10 +445,7 @@ internal class NadelNewBatchHydrator(
         sourceObject: JsonNode,
         instructions: List<NadelBatchHydrationFieldInstruction>,
     ): List<SourceInput>? {
-        val coords = makeFieldCoordinates(
-            typeName = sourceField.objectTypeNames.first(),
-            fieldName = sourceField.name,
-        )
+        val coords = instructions.first().location
 
         return if (executionBlueprint.engineSchema.getField(coords)!!.type.unwrapNonNull().isList) {
             val fieldSource = instructions
@@ -462,7 +459,8 @@ internal class NadelNewBatchHydrator(
 
             getSourceInputNodes(sourceObject, fieldSource, aliasHelper, includeNulls = isIndexHydration)
                 ?.map { sourceInput ->
-                    val instruction = getHydrationInstructionForSourceInput(instructions, sourceObject, sourceInput, fieldSource)
+                    val instruction =
+                        getHydrationInstructionForSourceInput(instructions, sourceObject, sourceInput, fieldSource)
                     if (instruction == null) {
                         SourceInput.NotQueryable(sourceInput)
                     } else {
@@ -631,12 +629,9 @@ private class NadelBatchHydratorContext(
     val isSourceFieldListOutput: Boolean by lazy {
         executionBlueprint.engineSchema
             .getField(
-                makeFieldCoordinates(
-                    // In regard to the field output type, the abstract types must all define the same list wrapping
-                    // So here, it does not matter which object type we inspect
-                    typeName = sourceField.objectTypeNames.first(),
-                    fieldName = sourceField.name,
-                )
+                // In regard to the field output type, the abstract types must all define the same list wrapping
+                // So here, it does not matter which object type we inspect
+                instructionsByObjectTypeNames.values.first().first().location,
             )!!.type.unwrapNonNull().isList
     }
 

--- a/lib/src/main/java/graphql/nadel/engine/transform/hydration/batch/NadelNewBatchHydrator.kt
+++ b/lib/src/main/java/graphql/nadel/engine/transform/hydration/batch/NadelNewBatchHydrator.kt
@@ -26,7 +26,6 @@ import graphql.nadel.engine.util.emptyOrSingle
 import graphql.nadel.engine.util.flatten
 import graphql.nadel.engine.util.getField
 import graphql.nadel.engine.util.isList
-import graphql.nadel.engine.util.makeFieldCoordinates
 import graphql.nadel.engine.util.singleOfType
 import graphql.nadel.engine.util.unwrapNonNull
 import graphql.nadel.engine.util.zipOrThrow
@@ -627,12 +626,10 @@ private class NadelBatchHydratorContext(
     val executionBlueprint: NadelOverallExecutionBlueprint,
 ) {
     val isSourceFieldListOutput: Boolean by lazy {
-        executionBlueprint.engineSchema
-            .getField(
-                // In regard to the field output type, the abstract types must all define the same list wrapping
-                // So here, it does not matter which object type we inspect
-                instructionsByObjectTypeNames.values.first().first().location,
-            )!!.type.unwrapNonNull().isList
+        // In regard to the field output type, the abstract types must all define the same list wrapping
+        // So here, it does not matter which object type we inspect
+        val instruction = instructionsByObjectTypeNames.values.first().first()
+        executionBlueprint.engineSchema.getField(instruction.location)!!.type.unwrapNonNull().isList
     }
 
     val isSourceInputFieldListOutput: Boolean by lazy {

--- a/lib/src/main/java/graphql/nadel/hints/NadelVirtualTypeSupportHint.kt
+++ b/lib/src/main/java/graphql/nadel/hints/NadelVirtualTypeSupportHint.kt
@@ -1,0 +1,10 @@
+package graphql.nadel.hints
+
+import graphql.nadel.Service
+
+fun interface NadelVirtualTypeSupportHint {
+    /**
+     * Determines whether virtual type & some of the new hydration work is enabled.
+     */
+    operator fun invoke(service: Service): Boolean
+}

--- a/lib/src/main/java/graphql/nadel/validation/NadelHydrationValidation.kt
+++ b/lib/src/main/java/graphql/nadel/validation/NadelHydrationValidation.kt
@@ -5,6 +5,7 @@ import graphql.nadel.Service
 import graphql.nadel.dsl.NadelHydrationDefinition
 import graphql.nadel.dsl.RemoteArgumentDefinition
 import graphql.nadel.dsl.RemoteArgumentSource
+import graphql.nadel.engine.blueprint.directives.isVirtualType
 import graphql.nadel.engine.util.getFieldAt
 import graphql.nadel.engine.util.getFieldsAlong
 import graphql.nadel.engine.util.isList
@@ -228,7 +229,7 @@ internal class NadelHydrationValidation(
         // Ensures that the underlying type of the actor field matches with the expected overall output type
         val overallType = overallField.type.unwrapAll()
 
-        if ((overallType as? GraphQLDirectiveContainer)?.hasAppliedDirective("virtualType") == true) {
+        if ((overallType as? GraphQLDirectiveContainer)?.isVirtualType() == true) {
             return emptyList() // Bypass validation for now
         }
 

--- a/lib/src/main/java/graphql/nadel/validation/NadelHydrationValidation.kt
+++ b/lib/src/main/java/graphql/nadel/validation/NadelHydrationValidation.kt
@@ -28,6 +28,7 @@ import graphql.nadel.validation.NadelSchemaValidationError.NoSourceArgsInBatchHy
 import graphql.nadel.validation.NadelSchemaValidationError.NonExistentHydrationActorFieldArgument
 import graphql.nadel.validation.util.NadelSchemaUtil.getHydrations
 import graphql.nadel.validation.util.NadelSchemaUtil.hasRename
+import graphql.schema.GraphQLDirectiveContainer
 import graphql.schema.GraphQLFieldDefinition
 import graphql.schema.GraphQLFieldsContainer
 import graphql.schema.GraphQLInterfaceType
@@ -226,6 +227,10 @@ internal class NadelHydrationValidation(
     ): List<NadelSchemaValidationError> {
         // Ensures that the underlying type of the actor field matches with the expected overall output type
         val overallType = overallField.type.unwrapAll()
+
+        if ((overallType as? GraphQLDirectiveContainer)?.hasAppliedDirective("virtualType") == true) {
+            return emptyList() // Bypass validation for now
+        }
 
         // Polymorphic hydration must have union output
         if (hasMoreThanOneHydration && overallType !is GraphQLUnionType) {

--- a/lib/src/main/java/graphql/nadel/validation/NadelTypeValidation.kt
+++ b/lib/src/main/java/graphql/nadel/validation/NadelTypeValidation.kt
@@ -4,6 +4,7 @@ import graphql.Scalars.GraphQLID
 import graphql.Scalars.GraphQLString
 import graphql.language.UnionTypeDefinition
 import graphql.nadel.Service
+import graphql.nadel.engine.blueprint.directives.isVirtualType
 import graphql.nadel.engine.util.AnyNamedNode
 import graphql.nadel.engine.util.all
 import graphql.nadel.engine.util.isExtensionDef
@@ -208,7 +209,7 @@ internal class NadelTypeValidation(
                 val underlyingType = getUnderlyingType(overallType, service)
 
                 if (underlyingType == null) {
-                    if ((overallType as? GraphQLDirectiveContainer)?.hasAppliedDirective("virtualType") == true) {
+                    if ((overallType as? GraphQLDirectiveContainer)?.isVirtualType() == true) {
                         // Do nothing
                     } else {
                         addMissingUnderlyingTypeError(overallType)

--- a/lib/src/main/java/graphql/nadel/validation/NadelTypeValidation.kt
+++ b/lib/src/main/java/graphql/nadel/validation/NadelTypeValidation.kt
@@ -24,6 +24,7 @@ import graphql.nadel.validation.util.NadelBuiltInTypes.allNadelBuiltInTypeNames
 import graphql.nadel.validation.util.NadelSchemaUtil.getUnderlyingName
 import graphql.nadel.validation.util.NadelSchemaUtil.getUnderlyingType
 import graphql.nadel.validation.util.getReachableTypeNames
+import graphql.schema.GraphQLDirectiveContainer
 import graphql.schema.GraphQLFieldDefinition
 import graphql.schema.GraphQLFieldsContainer
 import graphql.schema.GraphQLImplementingType
@@ -207,7 +208,12 @@ internal class NadelTypeValidation(
                 val underlyingType = getUnderlyingType(overallType, service)
 
                 if (underlyingType == null) {
-                    addMissingUnderlyingTypeError(overallType).let { null }
+                    if ((overallType as? GraphQLDirectiveContainer)?.hasAppliedDirective("virtualType") == true) {
+                        // Do nothing
+                    } else {
+                        addMissingUnderlyingTypeError(overallType)
+                    }
+                    null
                 } else {
                     NadelServiceSchemaElement(
                         service = service,

--- a/lib/src/main/java/graphql/nadel/validation/util/NadelGetReachableTypes.kt
+++ b/lib/src/main/java/graphql/nadel/validation/util/NadelGetReachableTypes.kt
@@ -2,6 +2,7 @@ package graphql.nadel.validation.util
 
 import graphql.language.UnionTypeDefinition
 import graphql.nadel.Service
+import graphql.nadel.engine.blueprint.directives.isVirtualType
 import graphql.nadel.engine.util.AnySDLNamedDefinition
 import graphql.nadel.engine.util.unwrapAll
 import graphql.nadel.validation.util.NadelCombinedTypeUtil.getFieldsThatServiceContributed
@@ -67,6 +68,7 @@ internal fun getReachableTypeNames(
             node: GraphQLUnionType,
             context: TraverserContext<GraphQLSchemaElement>,
         ): TraversalControl {
+            visitTypeGuard(node) { return ABORT }
             add(node.name)
             return CONTINUE
         }
@@ -75,6 +77,7 @@ internal fun getReachableTypeNames(
             node: GraphQLInterfaceType,
             context: TraverserContext<GraphQLSchemaElement>,
         ): TraversalControl {
+            visitTypeGuard(node) { return ABORT }
             add(node.name)
             return CONTINUE
         }
@@ -83,6 +86,7 @@ internal fun getReachableTypeNames(
             node: GraphQLEnumType,
             context: TraverserContext<GraphQLSchemaElement>,
         ): TraversalControl {
+            visitTypeGuard(node) { return ABORT }
             add(node.name)
             return CONTINUE
         }
@@ -112,6 +116,7 @@ internal fun getReachableTypeNames(
             node: GraphQLInputObjectType,
             context: TraverserContext<GraphQLSchemaElement>,
         ): TraversalControl {
+            visitTypeGuard(node) { return ABORT }
             add(node.name)
             return CONTINUE
         }
@@ -136,6 +141,8 @@ internal fun getReachableTypeNames(
             node: GraphQLObjectType,
             context: TraverserContext<GraphQLSchemaElement>,
         ): TraversalControl {
+            visitTypeGuard(node) { return ABORT }
+
             // Don't look at union members defined by external services
             val parentNode = context.parentNode
             if (parentNode is GraphQLUnionType && isUnionMemberExempt(service, parentNode, node)) {
@@ -150,6 +157,7 @@ internal fun getReachableTypeNames(
             node: GraphQLScalarType,
             context: TraverserContext<GraphQLSchemaElement>,
         ): TraversalControl {
+            visitTypeGuard(node) { return ABORT }
             add(node.name)
             return CONTINUE
         }
@@ -242,6 +250,20 @@ internal fun getReachableTypeNames(
             // Don't look into applied directives. Could be a shared directive.
             // As long as the schema compiled then we don't care.
             return ABORT
+        }
+
+        /**
+         * Call to ensure the given [type] is not traversed if it shouldn't be.
+         *
+         * The [onExit] lambda is not intended to return, so it is typed to [Nothing]
+         * i.e. use [onExit] to actually exit the outer function to escape the lambda
+         */
+        private inline fun visitTypeGuard(type: GraphQLNamedType, onExit: () -> Nothing) {
+            if (type is GraphQLDirectiveContainer) {
+                if (type.isVirtualType()) {
+                    onExit()
+                }
+            }
         }
     }
 

--- a/lib/src/test/kotlin/graphql/nadel/engine/blueprint/NadelVirtualTypeBlueprintFactoryTest.kt
+++ b/lib/src/test/kotlin/graphql/nadel/engine/blueprint/NadelVirtualTypeBlueprintFactoryTest.kt
@@ -1,0 +1,62 @@
+package graphql.nadel.engine.blueprint
+
+import graphql.schema.idl.SchemaGenerator
+import org.junit.jupiter.api.Test
+import kotlin.test.assertTrue
+
+class NadelVirtualTypeBlueprintFactoryTest {
+    @Test
+    fun `creates a mapping for one scalar`() {
+        val schema = SchemaGenerator.createdMockedSchema(
+            // language=GraphQL
+            """
+                directive @hydrated(field: String!) on FIELD_DEFINITION
+
+                type Query {
+                    virtualEcho: VirtualEcho @hydrated(field: "echo")
+                    echo: BackingEcho
+                }
+                type VirtualEcho {
+                    echo: String
+                    info: VirtualEchoInfo
+                }
+                type VirtualEchoInfo {
+                    cursor: String
+                }
+                type BackingEcho {
+                    echo: String
+                    info: BackingEchoInfo
+                }
+                type BackingEchoInfo {
+                    cursor: String
+                    something: Boolean
+                }
+            """.trimIndent()
+        )
+
+        val virtualTypeContext = NadelVirtualTypeBlueprintFactory()
+            .makeVirtualTypeContext(
+                schema,
+                containerType = schema.queryType,
+                virtualFieldDef = schema.queryType.getField("virtualEcho"),
+            )
+
+        assertTrue(virtualTypeContext != null)
+
+        assertTrue(virtualTypeContext.virtualFieldContainer.name == "Query")
+        assertTrue(virtualTypeContext.virtualField.name == "virtualEcho")
+
+        assertTrue(
+            virtualTypeContext.virtualTypeToBackingType == mapOf(
+                "VirtualEcho" to "BackingEcho",
+                "VirtualEchoInfo" to "BackingEchoInfo",
+            ),
+        )
+        assertTrue(
+            virtualTypeContext.backingTypeToVirtualType == mapOf(
+                "BackingEcho" to "VirtualEcho",
+                "BackingEchoInfo" to "VirtualEchoInfo",
+            ),
+        )
+    }
+}

--- a/test/src/test/kotlin/graphql/nadel/tests/next/NadelIntegrationTest.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/next/NadelIntegrationTest.kt
@@ -453,6 +453,7 @@ abstract class NadelIntegrationTest(
     companion object {
         @JvmStatic
         protected val source = "\$source"
+        @JvmStatic
         protected val argument = "\$argument"
     }
 }

--- a/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/hydration/copy/HydrationCopiesFieldAndHasPolymorphicHydrationTest.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/hydration/copy/HydrationCopiesFieldAndHasPolymorphicHydrationTest.kt
@@ -1,0 +1,285 @@
+package graphql.nadel.tests.next.fixtures.hydration.copy
+
+import graphql.nadel.Nadel
+import graphql.nadel.NadelExecutionHints
+import graphql.nadel.engine.blueprint.NadelGenericHydrationInstruction
+import graphql.nadel.engine.transform.result.json.JsonNode
+import graphql.nadel.engine.util.strictAssociateBy
+import graphql.nadel.hooks.NadelExecutionHooks
+import graphql.nadel.tests.next.NadelIntegrationTest
+
+/**
+ * Uses hydration to "copy" a field. Does not link two pieces of data together i.e. no $source fields used.
+ */
+class HydrationCopiesFieldAndHasPolymorphicHydrationTest : NadelIntegrationTest(
+    query = """
+        query {
+          businessReport_findRecentWorkByTeam(teamId: "hello") {
+            edges {
+              node {
+                ... on JiraIssue {
+                  key
+                }
+                ... on BitbucketPullRequest {
+                  title
+                  patch
+                }
+              }
+              cursor
+            }
+            pageInfo {
+              hasNextPage
+            }
+          }
+        }
+    """.trimIndent(),
+    services = listOf(
+        // Backing service
+        Service(
+            name = "graph_store",
+            overallSchema = """
+                type Query {
+                  graphStore_query(
+                    query: String!
+                    first: Int
+                    after: String
+                  ): GraphStoreQueryConnection
+                }
+                type GraphStoreQueryConnection {
+                  edges: [GraphStoreQueryEdge]
+                  pageInfo: PageInfo
+                }
+                type GraphStoreQueryEdge {
+                  nodeId: ID
+                  cursor: String
+                }
+                type PageInfo {
+                    hasNextPage: Boolean!
+                    hasPreviousPage: Boolean!
+                    startCursor: String
+                    endCursor: String
+                }
+            """.trimIndent(),
+            runtimeWiring = { wiring ->
+                data class GraphStoreQueryEdge(
+                    val nodeId: String,
+                    val cursor: String?,
+                )
+
+                data class PageInfo(
+                    val hasNextPage: Boolean,
+                    val hasPreviousPage: Boolean,
+                    val startCursor: String?,
+                    val endCursor: String?,
+                )
+
+                data class GraphStoreQueryConnection(
+                    val edges: List<GraphStoreQueryEdge>,
+                    val pageInfo: PageInfo,
+                )
+
+                wiring
+                    .type("Query") { type ->
+                        type
+                            .dataFetcher("graphStore_query") { env ->
+                                GraphStoreQueryConnection(
+                                    edges = listOf(
+                                        GraphStoreQueryEdge(
+                                            nodeId = "ari:cloud:jira::issue/1",
+                                            cursor = "1",
+                                        ),
+                                    ),
+                                    pageInfo = PageInfo(
+                                        hasNextPage = true,
+                                        hasPreviousPage = false,
+                                        startCursor = null,
+                                        endCursor = "1",
+                                    ),
+                                )
+                            }
+                    }
+            },
+        ),
+        // Service for hydration
+        Service(
+            name = "jira",
+            overallSchema = """
+                type Query {
+                  issuesByIds(ids: [ID!]!): [JiraIssue]
+                }
+                type JiraIssue {
+                  id: ID!
+                  key: String!
+                  title: String!
+                }
+            """.trimIndent(),
+            runtimeWiring = { runtime ->
+                data class JiraIssue(
+                    val id: String,
+                    val key: String,
+                    val title: String,
+                )
+
+                val issuesByIds = listOf(
+                    JiraIssue(
+                        id = "ari:cloud:jira::issue/1",
+                        key = "GQLGW-1",
+                        title = "Fix the speed of light",
+                    ),
+                    JiraIssue(
+                        id = "ari:cloud:jira::issue/2",
+                        key = "GQLGW-2",
+                        title = "Refactor Nadel",
+                    ),
+                ).strictAssociateBy { it.id }
+
+                runtime
+                    .type("Query") { type ->
+                        type
+                            .dataFetcher("issuesByIds") { env ->
+                                val ids = env.getArgument<List<String>>("ids")
+
+                                ids!!
+                                    .map {
+                                        issuesByIds[it]
+                                    }
+                            }
+                    }
+            },
+        ),
+        Service(
+            name = "bitbucket",
+            overallSchema = """
+                type Query {
+                  pullRequestsByIds(ids: [ID!]!): [BitbucketPullRequest]
+                }
+                type BitbucketPullRequest {
+                  id: ID!
+                  title: String
+                  patch: String
+                }
+            """.trimIndent(),
+            runtimeWiring = { runtime ->
+                data class BitbucketPullRequest(
+                    val id: String,
+                    val title: String,
+                    val patch: String,
+                )
+
+                val issuesByIds = listOf(
+                    BitbucketPullRequest(
+                        id = "ari:cloud:bitbucket::pull-request/1",
+                        title = "Delete everything",
+                        patch = "-",
+                    ),
+                    BitbucketPullRequest(
+                        id = "ari:cloud:bitbucket::pull-request/2",
+                        title = "Initial Commit",
+                        patch = "+",
+                    ),
+                ).strictAssociateBy { it.id }
+
+                runtime
+                    .type("Query") { type ->
+                        type
+                            .dataFetcher("pullRequestsByIds") { env ->
+                                val ids = env.getArgument<List<String>>("ids")
+
+                                ids!!
+                                    .map {
+                                        issuesByIds[it]
+                                    }
+                            }
+                    }
+            },
+        ),
+        // Service that introduces virtual type
+        Service(
+            name = "work",
+            overallSchema = """
+                type Query {
+                  businessReport_findRecentWorkByTeam(
+                    teamId: ID!
+                    first: Int
+                    after: String
+                  ): WorkConnection
+                    @hydrated(
+                      service: "graph_store",
+                      field: "graphStore_query"
+                      arguments: [
+                        {
+                          name: "query"
+                          value: "SELECT * FROM Work WHERE teamId = ?"
+                        }
+                        {
+                          name: "first"
+                          value: "$argument.first"
+                        }
+                        {
+                          name: "after"
+                          value: "$argument.after"
+                        }
+                      ]
+                    )
+                }
+                directive @virtualType on OBJECT
+                type WorkConnection @virtualType {
+                  edges: [WorkEdge]
+                  pageInfo: PageInfo
+                }
+                type WorkEdge @virtualType {
+                  nodeId: ID @hidden
+                  node: WorkNode
+                    @hydrated(
+                      service: "jira"
+                      field: "issuesByIds"
+                      arguments: [{name: "ids", value: "$source.nodeId"}]
+                    )
+                    @hydrated(
+                      service: "jira"
+                      field: "pullRequestsByIds"
+                      arguments: [{name: "ids", value: "$source.nodeId"}]
+                    )
+                  cursor: String
+                }
+                union WorkNode = JiraIssue | BitbucketPullRequest
+            """.trimIndent(),
+            underlyingSchema = """
+                type Query {
+                  business_stub: String
+                }
+            """.trimIndent(),
+            runtimeWiring = { wiring ->
+            },
+        ),
+    ),
+) {
+    override fun makeExecutionHints(): NadelExecutionHints.Builder {
+        return super.makeExecutionHints()
+            .virtualTypeSupport { true }
+            .newBatchHydrationGrouping { true }
+    }
+
+    override fun makeNadel(): Nadel.Builder {
+        return super.makeNadel()
+            .executionHooks(
+                object : NadelExecutionHooks {
+                    override fun <T : NadelGenericHydrationInstruction> getHydrationInstruction(
+                        instructions: List<T>,
+                        sourceInput: JsonNode,
+                        userContext: Any?,
+                    ): T {
+                        val prs = instructions.single { it.actorFieldDef.name == "pullRequestsByIds" }
+                        val issues = instructions.single { it.actorFieldDef.name == "issuesByIds" }
+                        val id = sourceInput.value as String
+
+                        return when {
+                            id.startsWith("ari:cloud:bitbucket::pull-request/") -> prs
+                            id.startsWith("ari:cloud:jira::issues/") -> issues
+                            else -> throw IllegalArgumentException()
+                        }
+                    }
+                }
+            )
+    }
+}

--- a/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/hydration/copy/HydrationCopiesFieldAndHasPolymorphicHydrationTestSnapshot.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/hydration/copy/HydrationCopiesFieldAndHasPolymorphicHydrationTestSnapshot.kt
@@ -21,47 +21,177 @@ private suspend fun main() {
 @Suppress("unused")
 public class HydrationCopiesFieldAndHasPolymorphicHydrationTestSnapshot : TestSnapshot() {
     override val calls: List<ExpectedServiceCall> = listOf(
-            )
+            ExpectedServiceCall(
+                service = "bitbucket",
+                query = """
+                | {
+                |   pullRequestsByIds(ids: ["ari:cloud:bitbucket::pull-request/2"]) {
+                |     title
+                |     patch
+                |     batch_hydration__node__id: id
+                |   }
+                | }
+                """.trimMargin(),
+                variables = " {}",
+                result = """
+                | {
+                |   "data": {
+                |     "pullRequestsByIds": [
+                |       {
+                |         "title": "Initial Commit",
+                |         "patch": "+",
+                |         "batch_hydration__node__id": "ari:cloud:bitbucket::pull-request/2"
+                |       }
+                |     ]
+                |   }
+                | }
+                """.trimMargin(),
+                delayedResults = listOfJsonStrings(
+                ),
+            ),
+            ExpectedServiceCall(
+                service = "graph_store",
+                query = """
+                | {
+                |   graphStore_query(query: "SELECT * FROM Work WHERE teamId = ?") {
+                |     edges {
+                |       batch_hydration__node__nodeId: nodeId
+                |       batch_hydration__node__nodeId: nodeId
+                |       __typename__batch_hydration__node: __typename
+                |       cursor
+                |     }
+                |     pageInfo {
+                |       hasNextPage
+                |     }
+                |   }
+                | }
+                """.trimMargin(),
+                variables = " {}",
+                result = """
+                | {
+                |   "data": {
+                |     "graphStore_query": {
+                |       "edges": [
+                |         {
+                |           "batch_hydration__node__nodeId": "ari:cloud:jira::issue/1",
+                |           "__typename__batch_hydration__node": "GraphStoreQueryEdge",
+                |           "cursor": "1"
+                |         },
+                |         {
+                |           "batch_hydration__node__nodeId": "ari:cloud:bitbucket::pull-request/2",
+                |           "__typename__batch_hydration__node": "GraphStoreQueryEdge",
+                |           "cursor": "2"
+                |         }
+                |       ],
+                |       "pageInfo": {
+                |         "hasNextPage": true
+                |       }
+                |     }
+                |   }
+                | }
+                """.trimMargin(),
+                delayedResults = listOfJsonStrings(
+                ),
+            ),
+            ExpectedServiceCall(
+                service = "jira",
+                query = """
+                | {
+                |   issuesByIds(ids: ["ari:cloud:jira::issue/1"]) {
+                |     key
+                |     batch_hydration__node__id: id
+                |   }
+                | }
+                """.trimMargin(),
+                variables = " {}",
+                result = """
+                | {
+                |   "data": {
+                |     "issuesByIds": [
+                |       {
+                |         "key": "GQLGW-1",
+                |         "batch_hydration__node__id": "ari:cloud:jira::issue/1"
+                |       }
+                |     ]
+                |   }
+                | }
+                """.trimMargin(),
+                delayedResults = listOfJsonStrings(
+                ),
+            ),
+            ExpectedServiceCall(
+                service = "work",
+                query = """
+                | {
+                |   __typename__hydration__businessReport_findRecentWorkByTeam: __typename
+                | }
+                """.trimMargin(),
+                variables = " {}",
+                result = """
+                | {
+                |   "data": {
+                |     "__typename__hydration__businessReport_findRecentWorkByTeam": "Query"
+                |   }
+                | }
+                """.trimMargin(),
+                delayedResults = listOfJsonStrings(
+                ),
+            ),
+        )
 
     /**
      * ```json
      * {
-     *   "errors": [
-     *     {
-     *       "message": "Validation error
-     * (InvalidFragmentType@[businessReport_findRecentWorkByTeam/edges/node]) : Fragment cannot be
-     * spread here as objects of type 'WorkNode' can never be of type 'BitbucketPullRequest'",
-     *       "locations": [
+     *   "data": {
+     *     "businessReport_findRecentWorkByTeam": {
+     *       "edges": [
      *         {
-     *           "line": 8,
-     *           "column": 9
+     *           "cursor": "1",
+     *           "node": {
+     *             "key": "GQLGW-1"
+     *           }
+     *         },
+     *         {
+     *           "cursor": "2",
+     *           "node": {
+     *             "title": "Initial Commit",
+     *             "patch": "+"
+     *           }
      *         }
      *       ],
-     *       "extensions": {
-     *         "classification": "ValidationError"
+     *       "pageInfo": {
+     *         "hasNextPage": true
      *       }
      *     }
-     *   ]
+     *   }
      * }
      * ```
      */
     override val result: ExpectedNadelResult = ExpectedNadelResult(
             result = """
             | {
-            |   "errors": [
-            |     {
-            |       "message": "Validation error (InvalidFragmentType@[businessReport_findRecentWorkByTeam/edges/node]) : Fragment cannot be spread here as objects of type 'WorkNode' can never be of type 'BitbucketPullRequest'",
-            |       "locations": [
+            |   "data": {
+            |     "businessReport_findRecentWorkByTeam": {
+            |       "edges": [
             |         {
-            |           "line": 8,
-            |           "column": 9
+            |           "cursor": "1",
+            |           "node": {
+            |             "key": "GQLGW-1"
+            |           }
+            |         },
+            |         {
+            |           "cursor": "2",
+            |           "node": {
+            |             "title": "Initial Commit",
+            |             "patch": "+"
+            |           }
             |         }
             |       ],
-            |       "extensions": {
-            |         "classification": "ValidationError"
+            |       "pageInfo": {
+            |         "hasNextPage": true
             |       }
             |     }
-            |   ]
+            |   }
             | }
             """.trimMargin(),
             delayedResults = listOfJsonStrings(

--- a/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/hydration/copy/HydrationCopiesFieldAndHasPolymorphicHydrationTestSnapshot.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/hydration/copy/HydrationCopiesFieldAndHasPolymorphicHydrationTestSnapshot.kt
@@ -1,0 +1,70 @@
+// @formatter:off
+package graphql.nadel.tests.next.fixtures.hydration.copy
+
+import graphql.nadel.tests.next.ExpectedNadelResult
+import graphql.nadel.tests.next.ExpectedServiceCall
+import graphql.nadel.tests.next.TestSnapshot
+import graphql.nadel.tests.next.listOfJsonStrings
+import kotlin.Suppress
+import kotlin.collections.List
+import kotlin.collections.listOf
+
+private suspend fun main() {
+    graphql.nadel.tests.next.update<HydrationCopiesFieldAndHasPolymorphicHydrationTest>()
+}
+
+/**
+ * This class is generated. Do NOT modify.
+ *
+ * Refer to [graphql.nadel.tests.next.UpdateTestSnapshots
+ */
+@Suppress("unused")
+public class HydrationCopiesFieldAndHasPolymorphicHydrationTestSnapshot : TestSnapshot() {
+    override val calls: List<ExpectedServiceCall> = listOf(
+            )
+
+    /**
+     * ```json
+     * {
+     *   "errors": [
+     *     {
+     *       "message": "Validation error
+     * (InvalidFragmentType@[businessReport_findRecentWorkByTeam/edges/node]) : Fragment cannot be
+     * spread here as objects of type 'WorkNode' can never be of type 'BitbucketPullRequest'",
+     *       "locations": [
+     *         {
+     *           "line": 8,
+     *           "column": 9
+     *         }
+     *       ],
+     *       "extensions": {
+     *         "classification": "ValidationError"
+     *       }
+     *     }
+     *   ]
+     * }
+     * ```
+     */
+    override val result: ExpectedNadelResult = ExpectedNadelResult(
+            result = """
+            | {
+            |   "errors": [
+            |     {
+            |       "message": "Validation error (InvalidFragmentType@[businessReport_findRecentWorkByTeam/edges/node]) : Fragment cannot be spread here as objects of type 'WorkNode' can never be of type 'BitbucketPullRequest'",
+            |       "locations": [
+            |         {
+            |           "line": 8,
+            |           "column": 9
+            |         }
+            |       ],
+            |       "extensions": {
+            |         "classification": "ValidationError"
+            |       }
+            |     }
+            |   ]
+            | }
+            """.trimMargin(),
+            delayedResults = listOfJsonStrings(
+            ),
+        )
+}

--- a/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/hydration/copy/HydrationCopiesFieldHintOffTest.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/hydration/copy/HydrationCopiesFieldHintOffTest.kt
@@ -1,0 +1,202 @@
+package graphql.nadel.tests.next.fixtures.hydration.copy
+
+import graphql.nadel.NadelExecutionHints
+import graphql.nadel.engine.util.strictAssociateBy
+import graphql.nadel.tests.next.NadelIntegrationTest
+
+/**
+ * Tests what happens if the virtual types hint is off.
+ */
+class HydrationCopiesFieldHintOffTest : NadelIntegrationTest(
+    query = """
+        query {
+          businessReport_findRecentWorkByTeam(teamId: "hello") {
+            edges {
+              node {
+                ... on JiraIssue {
+                  key
+                }
+              }
+              cursor
+            }
+            pageInfo {
+              hasNextPage
+            }
+          }
+        }
+    """.trimIndent(),
+    services = listOf(
+        // Backing service
+        Service(
+            name = "graph_store",
+            overallSchema = """
+                type Query {
+                  graphStore_query(
+                    query: String!
+                    first: Int
+                    after: String
+                  ): GraphStoreQueryConnection
+                }
+                type GraphStoreQueryConnection {
+                  edges: [GraphStoreQueryEdge]
+                  pageInfo: PageInfo
+                }
+                type GraphStoreQueryEdge {
+                  nodeId: ID
+                  cursor: String
+                }
+                type PageInfo {
+                    hasNextPage: Boolean!
+                    hasPreviousPage: Boolean!
+                    startCursor: String
+                    endCursor: String
+                }
+            """.trimIndent(),
+            runtimeWiring = { wiring ->
+                data class GraphStoreQueryEdge(
+                    val nodeId: String,
+                    val cursor: String?,
+                )
+
+                data class PageInfo(
+                    val hasNextPage: Boolean,
+                    val hasPreviousPage: Boolean,
+                    val startCursor: String?,
+                    val endCursor: String?,
+                )
+
+                data class GraphStoreQueryConnection(
+                    val edges: List<GraphStoreQueryEdge>,
+                    val pageInfo: PageInfo,
+                )
+
+                wiring
+                    .type("Query") { type ->
+                        type
+                            .dataFetcher("graphStore_query") { env ->
+                                GraphStoreQueryConnection(
+                                    edges = listOf(
+                                        GraphStoreQueryEdge(
+                                            nodeId = "ari:cloud:jira::issue/1",
+                                            cursor = "1",
+                                        ),
+                                    ),
+                                    pageInfo = PageInfo(
+                                        hasNextPage = true,
+                                        hasPreviousPage = false,
+                                        startCursor = null,
+                                        endCursor = "1",
+                                    ),
+                                )
+                            }
+                    }
+            },
+        ),
+        // Service for hydration
+        Service(
+            name = "jira",
+            overallSchema = """
+                type Query {
+                  issuesByIds(ids: [ID!]!): [JiraIssue]
+                }
+                type JiraIssue {
+                  id: ID!
+                  key: String!
+                  title: String!
+                }
+            """.trimIndent(),
+            runtimeWiring = { runtime ->
+                data class JiraIssue(
+                    val id: String,
+                    val key: String,
+                    val title: String,
+                )
+
+                val issuesByIds = listOf(
+                    JiraIssue(
+                        id = "ari:cloud:jira::issue/1",
+                        key = "GQLGW-1",
+                        title = "Fix the speed of light",
+                    ),
+                    JiraIssue(
+                        id = "ari:cloud:jira::issue/2",
+                        key = "GQLGW-2",
+                        title = "Refactor Nadel",
+                    ),
+                ).strictAssociateBy { it.id }
+
+                runtime
+                    .type("Query") { type ->
+                        type
+                            .dataFetcher("issuesByIds") { env ->
+                                val ids = env.getArgument<List<String>>("ids")
+
+                                ids!!
+                                    .map {
+                                        issuesByIds[it]
+                                    }
+                            }
+                    }
+            },
+        ),
+        // Service that introduces virtual type
+        Service(
+            name = "work",
+            overallSchema = """
+                type Query {
+                  businessReport_findRecentWorkByTeam(
+                    teamId: ID!
+                    first: Int
+                    after: String
+                  ): WorkConnection
+                    @hydrated(
+                      service: "graph_store",
+                      field: "graphStore_query"
+                      arguments: [
+                        {
+                          name: "query"
+                          value: "SELECT * FROM Work WHERE teamId = ?"
+                        }
+                        {
+                          name: "first"
+                          value: "$argument.first"
+                        }
+                        {
+                          name: "after"
+                          value: "$argument.after"
+                        }
+                      ]
+                    )
+                }
+                directive @virtualType on OBJECT
+                type WorkConnection @virtualType {
+                  edges: [WorkEdge]
+                  pageInfo: PageInfo
+                }
+                type WorkEdge @virtualType {
+                  nodeId: ID @hidden
+                  node: WorkNode
+                    @hydrated(
+                      service: "jira"
+                      field: "issuesByIds"
+                      arguments: [{name: "ids", value: "$source.nodeId"}]
+                    )
+                  cursor: String
+                }
+                union WorkNode = JiraIssue
+            """.trimIndent(),
+            underlyingSchema = """
+                type Query {
+                  business_stub: String
+                }
+            """.trimIndent(),
+            runtimeWiring = { wiring ->
+            },
+        ),
+    ),
+) {
+    override fun makeExecutionHints(): NadelExecutionHints.Builder {
+        return super.makeExecutionHints()
+            .virtualTypeSupport { false }
+    }
+}

--- a/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/hydration/copy/HydrationCopiesFieldHintOffTestSnapshot.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/hydration/copy/HydrationCopiesFieldHintOffTestSnapshot.kt
@@ -1,0 +1,88 @@
+// @formatter:off
+package graphql.nadel.tests.next.fixtures.hydration.copy
+
+import graphql.nadel.tests.next.ExpectedNadelResult
+import graphql.nadel.tests.next.ExpectedServiceCall
+import graphql.nadel.tests.next.TestSnapshot
+import graphql.nadel.tests.next.listOfJsonStrings
+import kotlin.Suppress
+import kotlin.collections.List
+import kotlin.collections.listOf
+
+private suspend fun main() {
+    graphql.nadel.tests.next.update<HydrationCopiesFieldHintOffTest>()
+}
+
+/**
+ * This class is generated. Do NOT modify.
+ *
+ * Refer to [graphql.nadel.tests.next.UpdateTestSnapshots
+ */
+@Suppress("unused")
+public class HydrationCopiesFieldHintOffTestSnapshot : TestSnapshot() {
+    override val calls: List<ExpectedServiceCall> = listOf(
+            ExpectedServiceCall(
+                service = "graph_store",
+                query = """
+                | {
+                |   graphStore_query(query: "SELECT * FROM Work WHERE teamId = ?") {
+                |     __typename__type_filter__edges: __typename
+                |     __typename__type_filter__pageInfo: __typename
+                |   }
+                | }
+                """.trimMargin(),
+                variables = " {}",
+                result = """
+                | {
+                |   "data": {
+                |     "graphStore_query": {
+                |       "__typename__type_filter__edges": "GraphStoreQueryConnection",
+                |       "__typename__type_filter__pageInfo": "GraphStoreQueryConnection"
+                |     }
+                |   }
+                | }
+                """.trimMargin(),
+                delayedResults = listOfJsonStrings(
+                ),
+            ),
+            ExpectedServiceCall(
+                service = "work",
+                query = """
+                | {
+                |   __typename__hydration__businessReport_findRecentWorkByTeam: __typename
+                | }
+                """.trimMargin(),
+                variables = " {}",
+                result = """
+                | {
+                |   "data": {
+                |     "__typename__hydration__businessReport_findRecentWorkByTeam": "Query"
+                |   }
+                | }
+                """.trimMargin(),
+                delayedResults = listOfJsonStrings(
+                ),
+            ),
+        )
+
+    /**
+     * ```json
+     * {
+     *   "data": {
+     *     "businessReport_findRecentWorkByTeam": {}
+     *   }
+     * }
+     * ```
+     */
+    override val result: ExpectedNadelResult = ExpectedNadelResult(
+            result = """
+            | {
+            |   "data": {
+            |     "businessReport_findRecentWorkByTeam": {}
+            |   }
+            | }
+            """.trimMargin(),
+            delayedResults = listOfJsonStrings(
+            ),
+        )
+}

--- a/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/hydration/copy/HydrationCopiesFieldTest.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/hydration/copy/HydrationCopiesFieldTest.kt
@@ -1,5 +1,6 @@
 package graphql.nadel.tests.next.fixtures.hydration.copy
 
+import graphql.nadel.NadelExecutionHints
 import graphql.nadel.engine.util.strictAssociateBy
 import graphql.nadel.tests.next.NadelIntegrationTest
 
@@ -193,4 +194,9 @@ class HydrationCopiesFieldTest : NadelIntegrationTest(
             },
         ),
     ),
-)
+) {
+    override fun makeExecutionHints(): NadelExecutionHints.Builder {
+        return super.makeExecutionHints()
+            .virtualTypeSupport { true }
+    }
+}

--- a/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/hydration/copy/HydrationCopiesFieldTest.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/hydration/copy/HydrationCopiesFieldTest.kt
@@ -1,9 +1,12 @@
-package graphql.nadel.tests.next.fixtures.hydration.virtual
+package graphql.nadel.tests.next.fixtures.hydration.copy
 
 import graphql.nadel.engine.util.strictAssociateBy
 import graphql.nadel.tests.next.NadelIntegrationTest
 
-class HydrationMakesVirtualFieldTest : NadelIntegrationTest(
+/**
+ * Uses hydration to "copy" a field. Does not link two pieces of data together i.e. no $source fields used.
+ */
+class HydrationCopiesFieldTest : NadelIntegrationTest(
     query = """
         query {
           businessReport_findRecentWorkByTeam(teamId: "hello") {

--- a/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/hydration/copy/HydrationCopiesFieldTestSnapshot.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/hydration/copy/HydrationCopiesFieldTestSnapshot.kt
@@ -1,5 +1,5 @@
 // @formatter:off
-package graphql.nadel.tests.next.fixtures.hydration.virtual
+package graphql.nadel.tests.next.fixtures.hydration.copy
 
 import graphql.nadel.tests.next.ExpectedNadelResult
 import graphql.nadel.tests.next.ExpectedServiceCall
@@ -10,7 +10,7 @@ import kotlin.collections.List
 import kotlin.collections.listOf
 
 private suspend fun main() {
-    graphql.nadel.tests.next.update<HydrationMakesVirtualFieldTest>()
+    graphql.nadel.tests.next.update<HydrationCopiesFieldTest>()
 }
 
 /**
@@ -19,7 +19,7 @@ private suspend fun main() {
  * Refer to [graphql.nadel.tests.next.UpdateTestSnapshots
  */
 @Suppress("unused")
-public class HydrationMakesVirtualFieldTestSnapshot : TestSnapshot() {
+public class HydrationCopiesFieldTestSnapshot : TestSnapshot() {
     override val calls: List<ExpectedServiceCall> = listOf(
             ExpectedServiceCall(
                 service = "graph_store",

--- a/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/hydration/copy/HydrationCopiesScalarFieldTest.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/hydration/copy/HydrationCopiesScalarFieldTest.kt
@@ -1,5 +1,6 @@
 package graphql.nadel.tests.next.fixtures.hydration.copy
 
+import graphql.nadel.NadelExecutionHints
 import graphql.nadel.tests.next.NadelIntegrationTest
 
 class HydrationCopiesScalarFieldTest : NadelIntegrationTest(
@@ -63,4 +64,9 @@ class HydrationCopiesScalarFieldTest : NadelIntegrationTest(
             },
         ),
     ),
-)
+) {
+    override fun makeExecutionHints(): NadelExecutionHints.Builder {
+        return super.makeExecutionHints()
+            .virtualTypeSupport { true }
+    }
+}

--- a/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/hydration/copy/HydrationCopiesScalarFieldTest.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/hydration/copy/HydrationCopiesScalarFieldTest.kt
@@ -1,0 +1,66 @@
+package graphql.nadel.tests.next.fixtures.hydration.copy
+
+import graphql.nadel.tests.next.NadelIntegrationTest
+
+class HydrationCopiesScalarFieldTest : NadelIntegrationTest(
+    query = """
+        query {
+          copyField(id: "wow")
+        }
+    """.trimIndent(),
+    services = listOf(
+        // Backing service
+        Service(
+            name = "graph_store",
+            overallSchema = """
+                type Query {
+                  backingField(
+                    id: String
+                    secret: String
+                  ): String @hidden
+                }
+            """.trimIndent(),
+            runtimeWiring = { wiring ->
+                wiring
+                    .type("Query") { type ->
+                        type
+                            .dataFetcher("backingField") { env ->
+                                env.getArgument<String>("id")
+                            }
+                    }
+            },
+        ),
+        // Service that introduces virtual type
+        Service(
+            name = "work",
+            overallSchema = """
+                type Query {
+                  copyField(
+                    id: ID!
+                  ): String
+                    @hydrated(
+                      service: "graph_store",
+                      field: "backingField"
+                      arguments: [
+                        {
+                          name: "id"
+                          value: "$argument.id"
+                        }
+                        {
+                          name: "secret"
+                          value: "cowabunga"
+                        }
+                      ]
+                    )
+                }
+            """.trimIndent(),
+            underlyingSchema = """
+                type Query {
+                  business_stub: String
+                }
+            """.trimIndent(),
+            runtimeWiring = { wiring ->
+            },
+        ),
+    ),
+)

--- a/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/hydration/copy/HydrationCopiesScalarFieldTestSnapshot.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/hydration/copy/HydrationCopiesScalarFieldTestSnapshot.kt
@@ -1,0 +1,82 @@
+// @formatter:off
+package graphql.nadel.tests.next.fixtures.hydration.copy
+
+import graphql.nadel.tests.next.ExpectedNadelResult
+import graphql.nadel.tests.next.ExpectedServiceCall
+import graphql.nadel.tests.next.TestSnapshot
+import graphql.nadel.tests.next.listOfJsonStrings
+import kotlin.Suppress
+import kotlin.collections.List
+import kotlin.collections.listOf
+
+private suspend fun main() {
+    graphql.nadel.tests.next.update<HydrationCopiesScalarFieldTest>()
+}
+
+/**
+ * This class is generated. Do NOT modify.
+ *
+ * Refer to [graphql.nadel.tests.next.UpdateTestSnapshots
+ */
+@Suppress("unused")
+public class HydrationCopiesScalarFieldTestSnapshot : TestSnapshot() {
+    override val calls: List<ExpectedServiceCall> = listOf(
+            ExpectedServiceCall(
+                service = "graph_store",
+                query = """
+                | {
+                |   backingField(id: "wow", secret: "cowabunga")
+                | }
+                """.trimMargin(),
+                variables = " {}",
+                result = """
+                | {
+                |   "data": {
+                |     "backingField": "wow"
+                |   }
+                | }
+                """.trimMargin(),
+                delayedResults = listOfJsonStrings(
+                ),
+            ),
+            ExpectedServiceCall(
+                service = "work",
+                query = """
+                | {
+                |   __typename__hydration__copyField: __typename
+                | }
+                """.trimMargin(),
+                variables = " {}",
+                result = """
+                | {
+                |   "data": {
+                |     "__typename__hydration__copyField": "Query"
+                |   }
+                | }
+                """.trimMargin(),
+                delayedResults = listOfJsonStrings(
+                ),
+            ),
+        )
+
+    /**
+     * ```json
+     * {
+     *   "data": {
+     *     "copyField": "wow"
+     *   }
+     * }
+     * ```
+     */
+    override val result: ExpectedNadelResult = ExpectedNadelResult(
+            result = """
+            | {
+            |   "data": {
+            |     "copyField": "wow"
+            |   }
+            | }
+            """.trimMargin(),
+            delayedResults = listOfJsonStrings(
+            ),
+        )
+}

--- a/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/hydration/virtual/HydrationMakesVirtualFieldTest.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/hydration/virtual/HydrationMakesVirtualFieldTest.kt
@@ -1,0 +1,164 @@
+package graphql.nadel.tests.next.fixtures.hydration.virtual
+
+import graphql.nadel.engine.util.strictAssociateBy
+import graphql.nadel.tests.next.NadelIntegrationTest
+
+class HydrationMakesVirtualFieldTest : NadelIntegrationTest(
+    query = """
+        query {
+          businessReport_findRecentWorkByTeam(teamId: "hello") {
+            edges {
+              node {
+                ... on JiraIssue {
+                  key
+                }
+              }
+            }
+          }
+        }
+    """.trimIndent(),
+    services = listOf(
+        // Backing service
+        Service(
+            name = "graph_store",
+            overallSchema = """
+                type Query {
+                  graphStore_query(
+                    query: String!
+                    first: Int
+                    after: String
+                  ): GraphStoreQueryConnection
+                }
+                type GraphStoreQueryConnection {
+                  edges: [GraphStoreQueryEdge]
+                }
+                type GraphStoreQueryEdge {
+                  nodeId: ID
+                }
+            """.trimIndent(),
+            runtimeWiring = { wiring ->
+                data class GraphStoreQueryEdge(
+                    val nodeId: String,
+                )
+
+                data class GraphStoreQueryConnection(
+                    val edges: List<GraphStoreQueryEdge>,
+                )
+
+                wiring
+                    .type("Query") { type ->
+                        type
+                            .dataFetcher("graphStore_query") { env ->
+                                GraphStoreQueryConnection(
+                                    edges = listOf(
+                                        GraphStoreQueryEdge(
+                                            nodeId = "ari:cloud:jira::issue/1",
+                                        ),
+                                    ),
+                                )
+                            }
+                    }
+            },
+        ),
+        // Service for hydration
+        Service(
+            name = "jira",
+            overallSchema = """
+                type Query {
+                  issuesByIds(ids: [ID!]!): [JiraIssue]
+                }
+                type JiraIssue {
+                  id: ID!
+                  key: String!
+                  title: String!
+                }
+            """.trimIndent(),
+            runtimeWiring = { runtime ->
+                data class JiraIssue(
+                    val id: String,
+                    val key: String,
+                    val title: String,
+                )
+
+                val issuesByIds = listOf(
+                    JiraIssue(
+                        id = "ari:cloud:jira::issue/1",
+                        key = "GQLGW-1",
+                        title = "Fix the speed of light",
+                    ),
+                    JiraIssue(
+                        id = "ari:cloud:jira::issue/2",
+                        key = "GQLGW-2",
+                        title = "Refactor Nadel",
+                    ),
+                ).strictAssociateBy { it.id }
+
+                runtime
+                    .type("Query") { type ->
+                        type
+                            .dataFetcher("issuesByIds") { env ->
+                                val ids = env.getArgument<List<String>>("ids")
+
+                                ids!!
+                                    .map {
+                                        issuesByIds[it]
+                                    }
+                            }
+                    }
+            },
+        ),
+        // Service that introduces virtual type
+        Service(
+            name = "work",
+            overallSchema = """
+                type Query {
+                  business_stub: String @hidden
+                  businessReport_findRecentWorkByTeam(
+                    teamId: ID!
+                    first: Int
+                    after: String
+                  ): WorkConnection
+                    @hydrated(
+                      service: "graph_store",
+                      field: "graphStore_query"
+                      arguments: [
+                        {
+                          name: "query"
+                          value: "SELECT * FROM Work WHERE teamId = ?"
+                        }
+                        {
+                          name: "first"
+                          value: "$argument.first"
+                        }
+                        {
+                          name: "after"
+                          value: "$argument.after"
+                        }
+                      ]
+                    )
+                }
+                directive @virtualType on OBJECT
+                type WorkConnection @virtualType {
+                  edges: [WorkEdge]
+                }
+                type WorkEdge @virtualType {
+                  nodeId: ID @hidden
+                  node: WorkNode
+                    @hydrated(
+                      service: "jira"
+                      field: "issuesByIds"
+                      arguments: [{name: "ids", value: "$source.nodeId"}]
+                    )
+                }
+                union WorkNode = JiraIssue
+            """.trimIndent(),
+            underlyingSchema = """
+                type Query {
+                  business_stub: String
+                }
+            """.trimIndent(),
+            runtimeWiring = { wiring ->
+            },
+        ),
+    ),
+)

--- a/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/hydration/virtual/HydrationMakesVirtualFieldTestSnapshot.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/hydration/virtual/HydrationMakesVirtualFieldTestSnapshot.kt
@@ -1,0 +1,136 @@
+// @formatter:off
+package graphql.nadel.tests.next.fixtures.hydration.virtual
+
+import graphql.nadel.tests.next.ExpectedNadelResult
+import graphql.nadel.tests.next.ExpectedServiceCall
+import graphql.nadel.tests.next.TestSnapshot
+import graphql.nadel.tests.next.listOfJsonStrings
+import kotlin.Suppress
+import kotlin.collections.List
+import kotlin.collections.listOf
+
+private suspend fun main() {
+    graphql.nadel.tests.next.update<HydrationMakesVirtualFieldTest>()
+}
+
+/**
+ * This class is generated. Do NOT modify.
+ *
+ * Refer to [graphql.nadel.tests.next.UpdateTestSnapshots
+ */
+@Suppress("unused")
+public class HydrationMakesVirtualFieldTestSnapshot : TestSnapshot() {
+    override val calls: List<ExpectedServiceCall> = listOf(
+            ExpectedServiceCall(
+                service = "graph_store",
+                query = """
+                | {
+                |   graphStore_query(query: "SELECT * FROM Work WHERE teamId = ?") {
+                |     edges {
+                |       batch_hydration__node__nodeId: nodeId
+                |       __typename__batch_hydration__node: __typename
+                |     }
+                |   }
+                | }
+                """.trimMargin(),
+                variables = " {}",
+                result = """
+                | {
+                |   "data": {
+                |     "graphStore_query": {
+                |       "edges": [
+                |         {
+                |           "batch_hydration__node__nodeId": "ari:cloud:jira::issue/1",
+                |           "__typename__batch_hydration__node": "GraphStoreQueryEdge"
+                |         }
+                |       ]
+                |     }
+                |   }
+                | }
+                """.trimMargin(),
+                delayedResults = listOfJsonStrings(
+                ),
+            ),
+            ExpectedServiceCall(
+                service = "jira",
+                query = """
+                | {
+                |   issuesByIds(ids: ["ari:cloud:jira::issue/1"]) {
+                |     key
+                |     batch_hydration__node__id: id
+                |   }
+                | }
+                """.trimMargin(),
+                variables = " {}",
+                result = """
+                | {
+                |   "data": {
+                |     "issuesByIds": [
+                |       {
+                |         "key": "GQLGW-1",
+                |         "batch_hydration__node__id": "ari:cloud:jira::issue/1"
+                |       }
+                |     ]
+                |   }
+                | }
+                """.trimMargin(),
+                delayedResults = listOfJsonStrings(
+                ),
+            ),
+            ExpectedServiceCall(
+                service = "work",
+                query = """
+                | {
+                |   __typename__hydration__businessReport_findRecentWorkByTeam: __typename
+                | }
+                """.trimMargin(),
+                variables = " {}",
+                result = """
+                | {
+                |   "data": {
+                |     "__typename__hydration__businessReport_findRecentWorkByTeam": "Query"
+                |   }
+                | }
+                """.trimMargin(),
+                delayedResults = listOfJsonStrings(
+                ),
+            ),
+        )
+
+    /**
+     * ```json
+     * {
+     *   "data": {
+     *     "businessReport_findRecentWorkByTeam": {
+     *       "edges": [
+     *         {
+     *           "node": {
+     *             "key": "GQLGW-1"
+     *           }
+     *         }
+     *       ]
+     *     }
+     *   }
+     * }
+     * ```
+     */
+    override val result: ExpectedNadelResult = ExpectedNadelResult(
+            result = """
+            | {
+            |   "data": {
+            |     "businessReport_findRecentWorkByTeam": {
+            |       "edges": [
+            |         {
+            |           "node": {
+            |             "key": "GQLGW-1"
+            |           }
+            |         }
+            |       ]
+            |     }
+            |   }
+            | }
+            """.trimMargin(),
+            delayedResults = listOfJsonStrings(
+            ),
+        )
+}

--- a/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/hydration/virtual/HydrationMakesVirtualFieldTestSnapshot.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/hydration/virtual/HydrationMakesVirtualFieldTestSnapshot.kt
@@ -29,6 +29,10 @@ public class HydrationMakesVirtualFieldTestSnapshot : TestSnapshot() {
                 |     edges {
                 |       batch_hydration__node__nodeId: nodeId
                 |       __typename__batch_hydration__node: __typename
+                |       cursor
+                |     }
+                |     pageInfo {
+                |       hasNextPage
                 |     }
                 |   }
                 | }
@@ -41,9 +45,13 @@ public class HydrationMakesVirtualFieldTestSnapshot : TestSnapshot() {
                 |       "edges": [
                 |         {
                 |           "batch_hydration__node__nodeId": "ari:cloud:jira::issue/1",
-                |           "__typename__batch_hydration__node": "GraphStoreQueryEdge"
+                |           "__typename__batch_hydration__node": "GraphStoreQueryEdge",
+                |           "cursor": "1"
                 |         }
-                |       ]
+                |       ],
+                |       "pageInfo": {
+                |         "hasNextPage": true
+                |       }
                 |     }
                 |   }
                 | }
@@ -104,11 +112,15 @@ public class HydrationMakesVirtualFieldTestSnapshot : TestSnapshot() {
      *     "businessReport_findRecentWorkByTeam": {
      *       "edges": [
      *         {
+     *           "cursor": "1",
      *           "node": {
      *             "key": "GQLGW-1"
      *           }
      *         }
-     *       ]
+     *       ],
+     *       "pageInfo": {
+     *         "hasNextPage": true
+     *       }
      *     }
      *   }
      * }
@@ -121,11 +133,15 @@ public class HydrationMakesVirtualFieldTestSnapshot : TestSnapshot() {
             |     "businessReport_findRecentWorkByTeam": {
             |       "edges": [
             |         {
+            |           "cursor": "1",
             |           "node": {
             |             "key": "GQLGW-1"
             |           }
             |         }
-            |       ]
+            |       ],
+            |       "pageInfo": {
+            |         "hasNextPage": true
+            |       }
             |     }
             |   }
             | }


### PR DESCRIPTION
So the phrase virtual fields here refers to a `@hydrated` field at the top level that doesn't use any `$source` arguments.

Though in a new branch I've repurposed it and renamed `hydratedField` etc. to virtual field and actor field to backing field.