### PR TITLE
fix empty query short circuit

### DIFF
--- a/lib/src/main/java/graphql/nadel/NextgenEngine.kt
+++ b/lib/src/main/java/graphql/nadel/NextgenEngine.kt
@@ -53,6 +53,7 @@ import graphql.nadel.util.OperationNameUtil
 import graphql.normalized.ExecutableNormalizedField
 import graphql.normalized.ExecutableNormalizedOperationFactory.createExecutableNormalizedOperationWithRawVariables
 import graphql.normalized.VariablePredicate
+import graphql.schema.GraphQLFieldDefinition
 import graphql.schema.GraphQLObjectType
 import graphql.schema.GraphQLSchema
 import kotlinx.coroutines.CoroutineScope
@@ -469,9 +470,9 @@ internal class NextgenEngine(
         }
 
         val operationType = engineSchema.getTypeAs<GraphQLObjectType>(topLevelField.singleObjectTypeName)
-        val topLevelFieldDefinition = operationType.getField(topLevelField.name)
+        val topLevelFieldDefinition: GraphQLFieldDefinition? = operationType.getField(topLevelField.name)
 
-        return if (topLevelFieldDefinition.hasAppliedDirective(namespacedDirectiveDefinition.name)) {
+        return if (topLevelFieldDefinition?.hasAppliedDirective(namespacedDirectiveDefinition.name) == true) {
             topLevelField.hasChildren()
                 && topLevelField.children.all { it.name == TypeNameMetaFieldDef.name }
         } else {

--- a/test/src/test/kotlin/graphql/nadel/tests/hooks/remove-fields.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/hooks/remove-fields.kt
@@ -137,6 +137,12 @@ class `namespaced-field-is-removed-with-renames` : EngineTestHook {
     override fun makeExecutionHints(builder: NadelExecutionHints.Builder) = builder.shortCircuitEmptyQuery { true }
 }
 
+@UseHook
+class `renamed-top-level-field-is-not-removed-short-circuit-hint-is-on` : EngineTestHook {
+    override val customTransforms = listOf(RemoveFieldTestTransform())
+    override fun makeExecutionHints(builder: NadelExecutionHints.Builder) = builder.shortCircuitEmptyQuery { true }
+}
+
 // @UseHook
 class `top-level-field-in-batched-query-is-removed` : EngineTestHook {
     override fun makeNadel(builder: Nadel.Builder): Nadel.Builder {

--- a/test/src/test/resources/fixtures/field removed/renamed-top-level-field-is-not-removed-short-circuit-hint-is-on.yml
+++ b/test/src/test/resources/fixtures/field removed/renamed-top-level-field-is-not-removed-short-circuit-hint-is-on.yml
@@ -1,0 +1,60 @@
+name: "renamed top level field is not removed short circuit hint is on"
+enabled: true
+# language=GraphQL
+overallSchema:
+  CommentService: |
+    directive @toBeDeleted on FIELD_DEFINITION
+    type Query {
+      commentById(id: ID): Comment @renamed(from: "commentByIdUnderlying")
+    }
+    type Comment {
+      id: ID
+    }
+# language=GraphQL
+underlyingSchema:
+  CommentService: |
+    type Query {
+      commentByIdUnderlying(id: ID): Comment
+    }
+    type Comment {
+      id: ID
+    }
+# language=GraphQL
+query: |
+  query {
+    commentById(id: "C1") {
+      id
+    }
+  }
+variables: { }
+serviceCalls:
+  - serviceName: "CommentService"
+    request:
+      # language=GraphQL
+      query: |
+        {
+          rename__commentById__commentByIdUnderlying: commentByIdUnderlying(id: "C1") {
+            id
+          }
+        }
+      variables: { }
+    # language=JSON
+    response: |-
+      {
+        "data": {
+          "rename__commentById__commentByIdUnderlying": {
+            "id": "C1"
+          }
+        },
+        "extensions": {}
+      }
+# language=JSON
+response: |-
+  {
+    "data": {
+      "commentById": {
+        "id": "C1"
+      }
+    },
+    "extensions": {}
+  }


### PR DESCRIPTION
Please make sure you consider the following:

- [ ] Add tests that use __typename in queries
- [ ] Does this change work with all nadel transformations (rename, type rename, hydration, etc)? Add tests for this.
- [ ] Is it worth using hints for this change in order to be able to enable a percentage rollout?
- [ ] Do we need to add integration tests for this change in the graphql gateway?
- [ ] Do we need a pollinator check for this?
