### PR TITLE
Add test to never use GraphQLSchema.getAllTypesAsList etc

### DIFF
--- a/lib/src/test/kotlin/graphql/nadel/ForbiddenGraphQLJavaUsageTest.kt
+++ b/lib/src/test/kotlin/graphql/nadel/ForbiddenGraphQLJavaUsageTest.kt
@@ -1,0 +1,31 @@
+package graphql.nadel
+
+import com.tngtech.archunit.base.DescribedPredicate
+import com.tngtech.archunit.core.domain.JavaAccess
+import com.tngtech.archunit.core.importer.ClassFileImporter
+import com.tngtech.archunit.core.importer.ImportOption
+import com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses
+import org.junit.jupiter.api.Test
+
+class ForbiddenGraphQLJavaUsageTest {
+    @Test
+    fun `do not access slow GraphQL Java methods`() {
+        val importedClasses = ClassFileImporter()
+            .withImportOption(ImportOption.DoNotIncludeTests())
+            .importPackages("graphql.nadel")
+
+        val rule = noClasses()
+            .should()
+            .accessTargetWhere(
+                object : DescribedPredicate<JavaAccess<*>>("access slow GraphQL Java methods") {
+                    override fun test(t: JavaAccess<*>): Boolean {
+                        // These methods sort the entire List alphabetically before returning it, not useful
+                        return t.target.fullName.startsWith("graphql.schema.GraphQLSchema.getAllTypesAsList")
+                            || t.target.fullName.startsWith("graphql.schema.GraphQLSchema.getAllElementsAsList")
+                    }
+                }
+            )
+
+        rule.check(importedClasses)
+    }
+}


### PR DESCRIPTION
Saw this being used in Central Schema validation and decided to ban it here.

In Nadel we always use `.typeMap.values` because `getAllTypesAsList` sorts the result for whatever reason.