### PR TITLE
Add support for collating remaining hydration arguments

### DIFF
--- a/lib/src/main/java/graphql/nadel/engine/blueprint/hydration/NadelHydrationArgument.kt
+++ b/lib/src/main/java/graphql/nadel/engine/blueprint/hydration/NadelHydrationArgument.kt
@@ -61,6 +61,10 @@ data class NadelHydrationArgument(
         data class StaticValue(
             val value: Value<*>,
         ) : ValueSource()
+
+        data class RemainingArguments(
+            val remainingArgumentNames: List<String>
+        ) : ValueSource()
     }
 }
 

--- a/lib/src/main/java/graphql/nadel/engine/transform/hydration/NadelHydrationInputBuilder.kt
+++ b/lib/src/main/java/graphql/nadel/engine/transform/hydration/NadelHydrationInputBuilder.kt
@@ -16,6 +16,7 @@ import graphql.nadel.engine.util.makeNormalizedInputValue
 import graphql.nadel.engine.util.toMapStrictly
 import graphql.normalized.ExecutableNormalizedField
 import graphql.normalized.NormalizedInputValue
+import graphql.schema.GraphQLTypeUtil
 
 internal class NadelHydrationInputBuilder private constructor(
     private val instruction: NadelHydrationFieldInstruction,
@@ -129,6 +130,14 @@ internal class NadelHydrationInputBuilder private constructor(
                 value = getResultValue(valueSource),
             )
             is ValueSource.StaticValue -> makeInputValue(inputDef, valueSource.value)
+            is ValueSource.RemainingArguments -> NormalizedInputValue(
+                /* typeName = */ GraphQLTypeUtil.simplePrint(inputDef.backingArgumentDef.type),
+                /* value = */
+                valueSource.remainingArgumentNames
+                    .associateWith {
+                        virtualField.normalizedArguments[it]?.value
+                    },
+            )
         }
     }
 

--- a/lib/src/main/java/graphql/nadel/engine/transform/hydration/batch/NadelBatchHydrationInputBuilder.kt
+++ b/lib/src/main/java/graphql/nadel/engine/transform/hydration/batch/NadelBatchHydrationInputBuilder.kt
@@ -8,6 +8,7 @@ import graphql.nadel.engine.util.makeNormalizedInputValue
 import graphql.nadel.engine.util.mapFrom
 import graphql.normalized.ExecutableNormalizedField
 import graphql.normalized.NormalizedInputValue
+import graphql.schema.GraphQLTypeUtil
 
 /**
  * README
@@ -41,6 +42,16 @@ internal object NadelBatchHydrationInputBuilder {
                             value = valueSource.value,
                         )
                         argument to staticValue
+                    }
+                    is NadelHydrationArgument.ValueSource.RemainingArguments -> {
+                        argument to NormalizedInputValue(
+                            /* typeName = */ GraphQLTypeUtil.simplePrint(argument.backingArgumentDef.type),
+                            /* value = */
+                            valueSource.remainingArgumentNames
+                                .associateWith {
+                                    virtualField.normalizedArguments[it]?.value
+                                },
+                        )
                     }
                 }
             },

--- a/lib/src/main/java/graphql/nadel/schema/NadelDirectives.kt
+++ b/lib/src/main/java/graphql/nadel/schema/NadelDirectives.kt
@@ -38,6 +38,13 @@ object NadelDirectives {
 
     val hydratedDirectiveDefinition = NadelHydrationDefinition.directiveDefinition
 
+    val nadelHydrationRemainingArguments = parseDefinition<DirectiveDefinition>(
+        // language=GraphQL
+        """
+          directive @hydrationRemainingArguments on ARGUMENT_DEFINITION
+        """.trimIndent()
+    )
+
     val dynamicServiceDirectiveDefinition = parseDefinition<DirectiveDefinition>(
         // language=GraphQL
         """

--- a/lib/src/main/java/graphql/nadel/schema/OverallSchemaGenerator.kt
+++ b/lib/src/main/java/graphql/nadel/schema/OverallSchemaGenerator.kt
@@ -69,6 +69,7 @@ internal class OverallSchemaGenerator {
         addIfNotPresent(overallRegistry, allDefinitions, NadelDirectives.nadelHydrationResultFieldPredicateDefinition)
         addIfNotPresent(overallRegistry, allDefinitions, NadelDirectives.nadelHydrationResultConditionDefinition)
         addIfNotPresent(overallRegistry, allDefinitions, NadelDirectives.nadelHydrationConditionDefinition)
+        addIfNotPresent(overallRegistry, allDefinitions, NadelDirectives.nadelHydrationRemainingArguments)
         addIfNotPresent(overallRegistry, allDefinitions, NadelDirectives.deferDirectiveDefinition)
         addIfNotPresent(overallRegistry, allDefinitions, NadelDirectives.namespacedDirectiveDefinition)
         addIfNotPresent(overallRegistry, allDefinitions, NadelDirectives.partitionDirectiveDefinition)

--- a/lib/src/main/java/graphql/nadel/validation/util/NadelBuiltInTypes.kt
+++ b/lib/src/main/java/graphql/nadel/validation/util/NadelBuiltInTypes.kt
@@ -10,6 +10,7 @@ import graphql.nadel.schema.NadelDirectives.deferDirectiveDefinition
 import graphql.nadel.schema.NadelDirectives.dynamicServiceDirectiveDefinition
 import graphql.nadel.schema.NadelDirectives.hiddenDirectiveDefinition
 import graphql.nadel.schema.NadelDirectives.hydratedDirectiveDefinition
+import graphql.nadel.schema.NadelDirectives.nadelHydrationRemainingArguments
 import graphql.nadel.schema.NadelDirectives.nadelBatchObjectIdentifiedByDefinition
 import graphql.nadel.schema.NadelDirectives.nadelHydrationArgumentDefinition
 import graphql.nadel.schema.NadelDirectives.nadelHydrationConditionDefinition
@@ -48,6 +49,7 @@ object NadelBuiltInTypes {
         nadelHydrationResultFieldPredicateDefinition,
         nadelHydrationResultConditionDefinition,
         nadelHydrationConditionDefinition,
+        nadelHydrationRemainingArguments,
     ).mapTo(LinkedHashSet()) {
         it.name
     }

--- a/test/src/test/kotlin/graphql/nadel/tests/next/UnderlyingSchemaGenerator.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/next/UnderlyingSchemaGenerator.kt
@@ -317,6 +317,7 @@ private fun transformInputValueDefinitions(inputValueDefinitions: List<InputValu
             inputValue.transform { inputValueBuilder ->
                 inputValueBuilder
                     .type(inputValue.type.getUnderlyingType())
+                    .directives(inputValue.directives.filterNotNadelDirectives())
             }
         }
 }

--- a/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/hydration/copy/HydrationRemainingArgumentsTest.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/hydration/copy/HydrationRemainingArgumentsTest.kt
@@ -1,0 +1,175 @@
+package graphql.nadel.tests.next.fixtures.hydration.copy
+
+import graphql.nadel.NadelExecutionHints
+import graphql.nadel.engine.util.strictAssociateBy
+import graphql.nadel.tests.next.NadelIntegrationTest
+import graphql.scalars.ExtendedScalars
+
+class HydrationRemainingArgumentsTest : NadelIntegrationTest(
+    query = """
+        query {
+          businessReport_findRecentWorkByTeam(orgId: "turtles", teamId: "hello") {
+            edges {
+              node {
+                ... on JiraIssue {
+                  key
+                }
+              }
+            }
+          }
+        }
+    """.trimIndent(),
+    services = listOf(
+        // Backing service
+        Service(
+            name = "graph_store",
+            overallSchema = """
+                scalar JSON
+                type Query {
+                  graphStore_query(
+                    query: String!
+                    first: Int
+                    after: String
+                    remainingArgs: JSON @hydrationRemainingArguments
+                  ): GraphStoreQueryConnection
+                }
+                type GraphStoreQueryConnection {
+                  edges: [GraphStoreQueryEdge]
+                }
+                type GraphStoreQueryEdge {
+                  nodeId: ID
+                }
+            """.trimIndent(),
+            runtimeWiring = { wiring ->
+                data class GraphStoreQueryEdge(
+                    val nodeId: String,
+                )
+
+                data class GraphStoreQueryConnection(
+                    val edges: List<GraphStoreQueryEdge>,
+                )
+
+                wiring
+                    .scalar(ExtendedScalars.Json)
+                    .type("Query") { type ->
+                        type
+                            .dataFetcher("graphStore_query") { env ->
+                                GraphStoreQueryConnection(
+                                    edges = listOf(
+                                        GraphStoreQueryEdge(
+                                            nodeId = "ari:cloud:jira::issue/1",
+                                        ),
+                                    ),
+                                )
+                            }
+                    }
+            },
+        ),
+        // Service for hydration
+        Service(
+            name = "jira",
+            overallSchema = """
+                type Query {
+                  issuesByIds(ids: [ID!]!): [JiraIssue]
+                }
+                type JiraIssue {
+                  id: ID!
+                  key: String!
+                  title: String!
+                }
+            """.trimIndent(),
+            runtimeWiring = { runtime ->
+                data class JiraIssue(
+                    val id: String,
+                    val key: String,
+                    val title: String,
+                )
+
+                val issuesByIds = listOf(
+                    JiraIssue(
+                        id = "ari:cloud:jira::issue/1",
+                        key = "GQLGW-1",
+                        title = "Fix the speed of light",
+                    ),
+                    JiraIssue(
+                        id = "ari:cloud:jira::issue/2",
+                        key = "GQLGW-2",
+                        title = "Refactor Nadel",
+                    ),
+                ).strictAssociateBy { it.id }
+
+                runtime
+                    .type("Query") { type ->
+                        type
+                            .dataFetcher("issuesByIds") { env ->
+                                val ids = env.getArgument<List<String>>("ids")
+
+                                ids!!
+                                    .map {
+                                        issuesByIds[it]
+                                    }
+                            }
+                    }
+            },
+        ),
+        // Service that introduces virtual type
+        Service(
+            name = "work",
+            overallSchema = """
+                type Query {
+                  business_stub: String @hidden
+                  businessReport_findRecentWorkByTeam(
+                    orgId: ID!
+                    teamId: ID!
+                    first: Int
+                    after: String
+                  ): WorkConnection
+                    @hydrated(
+                      service: "graph_store",
+                      field: "graphStore_query"
+                      arguments: [
+                        {
+                          name: "query"
+                          value: "SELECT * FROM Work WHERE teamId = ?"
+                        }
+                        {
+                          name: "first"
+                          value: "$argument.first"
+                        }
+                        {
+                          name: "after"
+                          value: "$argument.after"
+                        }
+                      ]
+                    )
+                }
+                directive @virtualType on OBJECT
+                type WorkConnection @virtualType {
+                  edges: [WorkEdge]
+                }
+                type WorkEdge @virtualType {
+                  nodeId: ID @hidden
+                  node: WorkNode
+                    @hydrated(
+                      service: "jira"
+                      field: "issuesByIds"
+                      arguments: [{name: "ids", value: "$source.nodeId"}]
+                    )
+                }
+                union WorkNode = JiraIssue
+            """.trimIndent(),
+            underlyingSchema = """
+                type Query {
+                  business_stub: String
+                }
+            """.trimIndent(),
+            runtimeWiring = { wiring ->
+            },
+        ),
+    ),
+) {
+    override fun makeExecutionHints(): NadelExecutionHints.Builder {
+        return super.makeExecutionHints()
+            .virtualTypeSupport { true }
+    }
+}

--- a/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/hydration/copy/HydrationRemainingArgumentsTestSnapshot.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/hydration/copy/HydrationRemainingArgumentsTestSnapshot.kt
@@ -1,0 +1,143 @@
+// @formatter:off
+package graphql.nadel.tests.next.fixtures.hydration.copy
+
+import graphql.nadel.tests.next.ExpectedNadelResult
+import graphql.nadel.tests.next.ExpectedServiceCall
+import graphql.nadel.tests.next.TestSnapshot
+import graphql.nadel.tests.next.listOfJsonStrings
+import kotlin.Suppress
+import kotlin.collections.List
+import kotlin.collections.listOf
+
+private suspend fun main() {
+    graphql.nadel.tests.next.update<HydrationRemainingArgumentsTest>()
+}
+
+/**
+ * This class is generated. Do NOT modify.
+ *
+ * Refer to [graphql.nadel.tests.next.UpdateTestSnapshots
+ */
+@Suppress("unused")
+public class HydrationRemainingArgumentsTestSnapshot : TestSnapshot() {
+    override val calls: List<ExpectedServiceCall> = listOf(
+            ExpectedServiceCall(
+                service = "graph_store",
+                query = """
+                | query (${'$'}v0: JSON) {
+                |   graphStore_query(query: "SELECT * FROM Work WHERE teamId = ?", remainingArgs: ${'$'}v0) {
+                |     edges {
+                |       batch_hydration__node__nodeId: nodeId
+                |       __typename__batch_hydration__node: __typename
+                |     }
+                |   }
+                | }
+                """.trimMargin(),
+                variables = """
+                | {
+                |   "v0": {
+                |     "orgId": "turtles",
+                |     "teamId": "hello"
+                |   }
+                | }
+                """.trimMargin(),
+                result = """
+                | {
+                |   "data": {
+                |     "graphStore_query": {
+                |       "edges": [
+                |         {
+                |           "batch_hydration__node__nodeId": "ari:cloud:jira::issue/1",
+                |           "__typename__batch_hydration__node": "GraphStoreQueryEdge"
+                |         }
+                |       ]
+                |     }
+                |   }
+                | }
+                """.trimMargin(),
+                delayedResults = listOfJsonStrings(
+                ),
+            ),
+            ExpectedServiceCall(
+                service = "jira",
+                query = """
+                | {
+                |   issuesByIds(ids: ["ari:cloud:jira::issue/1"]) {
+                |     key
+                |     batch_hydration__node__id: id
+                |   }
+                | }
+                """.trimMargin(),
+                variables = " {}",
+                result = """
+                | {
+                |   "data": {
+                |     "issuesByIds": [
+                |       {
+                |         "key": "GQLGW-1",
+                |         "batch_hydration__node__id": "ari:cloud:jira::issue/1"
+                |       }
+                |     ]
+                |   }
+                | }
+                """.trimMargin(),
+                delayedResults = listOfJsonStrings(
+                ),
+            ),
+            ExpectedServiceCall(
+                service = "work",
+                query = """
+                | {
+                |   __typename__hydration__businessReport_findRecentWorkByTeam: __typename
+                | }
+                """.trimMargin(),
+                variables = " {}",
+                result = """
+                | {
+                |   "data": {
+                |     "__typename__hydration__businessReport_findRecentWorkByTeam": "Query"
+                |   }
+                | }
+                """.trimMargin(),
+                delayedResults = listOfJsonStrings(
+                ),
+            ),
+        )
+
+    /**
+     * ```json
+     * {
+     *   "data": {
+     *     "businessReport_findRecentWorkByTeam": {
+     *       "edges": [
+     *         {
+     *           "node": {
+     *             "key": "GQLGW-1"
+     *           }
+     *         }
+     *       ]
+     *     }
+     *   }
+     * }
+     * ```
+     */
+    override val result: ExpectedNadelResult = ExpectedNadelResult(
+            result = """
+            | {
+            |   "data": {
+            |     "businessReport_findRecentWorkByTeam": {
+            |       "edges": [
+            |         {
+            |           "node": {
+            |             "key": "GQLGW-1"
+            |           }
+            |         }
+            |       ]
+            |     }
+            |   }
+            | }
+            """.trimMargin(),
+            delayedResults = listOfJsonStrings(
+            ),
+        )
+}


### PR DESCRIPTION
Adds the ability to pass in unused virtual field arguments into a JSON object argument annotated with `@remainingHydrationArguments`