### PR TITLE
Faster validation

### DIFF
--- a/lib/src/main/java/graphql/nadel/NadelDefinitionRegistry.kt
+++ b/lib/src/main/java/graphql/nadel/NadelDefinitionRegistry.kt
@@ -78,6 +78,10 @@ class NadelDefinitionRegistry {
         return sdlDefinitions.filterIsInstance<T>()
     }
 
+    fun getDefinitions(name: String): List<AnySDLDefinition> {
+        return definitionsByName[name] ?: return emptyList()
+    }
+
     inline fun <reified T : AnySDLDefinition> getDefinitionsOfType(): List<T> {
         return getDefinitionsOfType(T::class.java)
     }

--- a/lib/src/main/java/graphql/nadel/engine/blueprint/NadelFastSchemaTraverser.kt
+++ b/lib/src/main/java/graphql/nadel/engine/blueprint/NadelFastSchemaTraverser.kt
@@ -1,0 +1,272 @@
+package graphql.nadel.engine.blueprint
+
+import graphql.nadel.engine.util.unwrapAll
+import graphql.schema.GraphQLAppliedDirective
+import graphql.schema.GraphQLAppliedDirectiveArgument
+import graphql.schema.GraphQLArgument
+import graphql.schema.GraphQLCompositeType
+import graphql.schema.GraphQLDirective
+import graphql.schema.GraphQLDirectiveContainer
+import graphql.schema.GraphQLEnumType
+import graphql.schema.GraphQLEnumValueDefinition
+import graphql.schema.GraphQLFieldDefinition
+import graphql.schema.GraphQLFieldsContainer
+import graphql.schema.GraphQLInputFieldsContainer
+import graphql.schema.GraphQLInputObjectField
+import graphql.schema.GraphQLInputObjectType
+import graphql.schema.GraphQLInterfaceType
+import graphql.schema.GraphQLList
+import graphql.schema.GraphQLModifiedType
+import graphql.schema.GraphQLNamedSchemaElement
+import graphql.schema.GraphQLNamedType
+import graphql.schema.GraphQLNonNull
+import graphql.schema.GraphQLNullableType
+import graphql.schema.GraphQLObjectType
+import graphql.schema.GraphQLOutputType
+import graphql.schema.GraphQLScalarType
+import graphql.schema.GraphQLSchema
+import graphql.schema.GraphQLSchemaElement
+import graphql.schema.GraphQLType
+import graphql.schema.GraphQLTypeReference
+import graphql.schema.GraphQLUnionType
+import graphql.schema.GraphQLUnmodifiedType
+
+/**
+ * Significantly faster than normal [graphql.schema.SchemaTraverser] as it's simpler.
+ *
+ * Validating central schema with old [graphql.schema.SchemaTraverser] takes 306ms and this impl takes 74ms.
+ *
+ * That's 4x faster.
+ */
+internal class NadelFastSchemaTraverser {
+    fun traverse(
+        schema: GraphQLSchema,
+        roots: List<String>,
+        visitor: Visitor,
+    ) {
+        val queue = roots
+            .mapTo(mutableListOf()) {
+                (null as GraphQLNamedSchemaElement?) to (schema.typeMap[it] ?: schema.getDirective(it))!!
+            }
+        val visited = roots.toMutableSet()
+
+        fun queueType(parent: GraphQLNamedSchemaElement, type: GraphQLNamedType) {
+            if (!visited.contains(type.name)) {
+                visited.add(type.name)
+                queue.add(parent to type)
+            }
+        }
+
+        fun queueElement(parent: GraphQLNamedSchemaElement, element: GraphQLNamedSchemaElement) {
+            queue.add(parent to element)
+        }
+
+        while (queue.isNotEmpty()) {
+            val (parent, element) = queue.removeLast()
+            val result = when (element) {
+                is GraphQLObjectType -> visitor.visitGraphQLObjectType(parent, element)
+                is GraphQLFieldDefinition -> visitor.visitGraphQLFieldDefinition(parent, element)
+                is GraphQLScalarType -> visitor.visitGraphQLScalarType(parent, element)
+                is GraphQLInputObjectType -> visitor.visitGraphQLInputObjectType(parent, element)
+                is GraphQLInputObjectField -> visitor.visitGraphQLInputObjectField(parent, element)
+                is GraphQLAppliedDirective -> visitor.visitGraphQLAppliedDirective(parent, element)
+                is GraphQLDirective -> visitor.visitGraphQLDirective(parent, element)
+                is GraphQLArgument -> visitor.visitGraphQLArgument(parent, element)
+                is GraphQLEnumType -> visitor.visitGraphQLEnumType(parent, element)
+                is GraphQLEnumValueDefinition -> visitor.visitGraphQLEnumValueDefinition(parent, element)
+                is GraphQLInterfaceType -> visitor.visitGraphQLInterfaceType(parent, element)
+                is GraphQLUnionType -> visitor.visitGraphQLUnionType(parent, element)
+                else -> false
+            }
+
+            if (!result) {
+                continue
+            }
+
+            // Handle next
+            element.forEachChild { child ->
+                when (child) {
+                    is GraphQLType -> {
+                        queueType(parent = element, child.unwrapAll())
+                    }
+                    is GraphQLNamedSchemaElement -> {
+                        queueElement(parent = element, child)
+                    }
+                }
+            }
+        }
+    }
+
+    interface Visitor {
+        fun visitGraphQLArgument(
+            parent: GraphQLNamedSchemaElement?,
+            node: GraphQLArgument,
+        ): Boolean
+
+        fun visitGraphQLUnionType(
+            parent: GraphQLNamedSchemaElement?,
+            node: GraphQLUnionType,
+        ): Boolean
+
+        fun visitGraphQLInterfaceType(
+            parent: GraphQLNamedSchemaElement?,
+            node: GraphQLInterfaceType,
+        ): Boolean
+
+        fun visitGraphQLEnumType(
+            parent: GraphQLNamedSchemaElement?,
+            node: GraphQLEnumType,
+        ): Boolean
+
+        fun visitGraphQLEnumValueDefinition(
+            parent: GraphQLNamedSchemaElement?,
+            node: GraphQLEnumValueDefinition,
+        ): Boolean
+
+        fun visitGraphQLFieldDefinition(
+            parent: GraphQLNamedSchemaElement?,
+            node: GraphQLFieldDefinition,
+        ): Boolean
+
+        fun visitGraphQLInputObjectField(
+            parent: GraphQLNamedSchemaElement?,
+            node: GraphQLInputObjectField,
+        ): Boolean
+
+        fun visitGraphQLInputObjectType(
+            parent: GraphQLNamedSchemaElement?,
+            node: GraphQLInputObjectType,
+        ): Boolean
+
+        fun visitGraphQLList(
+            parent: GraphQLNamedSchemaElement?,
+            node: GraphQLList,
+        ): Boolean
+
+        fun visitGraphQLNonNull(
+            parent: GraphQLNamedSchemaElement?,
+            node: GraphQLNonNull,
+        ): Boolean
+
+        fun visitGraphQLObjectType(
+            parent: GraphQLNamedSchemaElement?,
+            node: GraphQLObjectType,
+        ): Boolean
+
+        fun visitGraphQLScalarType(
+            parent: GraphQLNamedSchemaElement?,
+            node: GraphQLScalarType,
+        ): Boolean
+
+        fun visitGraphQLTypeReference(
+            parent: GraphQLNamedSchemaElement?,
+            node: GraphQLTypeReference,
+        ): Boolean
+
+        fun visitGraphQLModifiedType(
+            parent: GraphQLNamedSchemaElement?,
+            node: GraphQLModifiedType,
+        ): Boolean
+
+        fun visitGraphQLCompositeType(
+            parent: GraphQLNamedSchemaElement?,
+            node: GraphQLCompositeType,
+        ): Boolean
+
+        fun visitGraphQLDirective(
+            parent: GraphQLNamedSchemaElement?,
+            node: GraphQLDirective,
+        ): Boolean
+
+        fun visitGraphQLDirectiveContainer(
+            parent: GraphQLNamedSchemaElement?,
+            node: GraphQLDirectiveContainer,
+        ): Boolean
+
+        fun visitGraphQLFieldsContainer(
+            parent: GraphQLNamedSchemaElement?,
+            node: GraphQLFieldsContainer,
+        ): Boolean
+
+        fun visitGraphQLInputFieldsContainer(
+            parent: GraphQLNamedSchemaElement?,
+            node: GraphQLInputFieldsContainer,
+        ): Boolean
+
+        fun visitGraphQLNullableType(
+            parent: GraphQLNamedSchemaElement?,
+            node: GraphQLNullableType,
+        ): Boolean
+
+        fun visitGraphQLOutputType(
+            parent: GraphQLNamedSchemaElement?,
+            node: GraphQLOutputType,
+        ): Boolean
+
+        fun visitGraphQLUnmodifiedType(
+            parent: GraphQLNamedSchemaElement?,
+            node: GraphQLUnmodifiedType,
+        ): Boolean
+
+        fun visitGraphQLAppliedDirective(
+            parent: GraphQLNamedSchemaElement?,
+            node: GraphQLAppliedDirective,
+        ): Boolean
+    }
+}
+
+private inline fun GraphQLSchemaElement.forEachChild(
+    onElement: (GraphQLSchemaElement) -> Unit,
+) {
+    when (this) {
+        is GraphQLAppliedDirective -> {
+            arguments.forEach(onElement)
+        }
+        is GraphQLAppliedDirectiveArgument -> {
+            onElement(type)
+        }
+        is GraphQLArgument -> {
+            onElement(type)
+        }
+        is GraphQLDirective -> {
+            arguments.forEach(onElement)
+        }
+        is GraphQLEnumType -> {
+            values.forEach(onElement)
+        }
+        is GraphQLEnumValueDefinition -> {
+        }
+        is GraphQLFieldDefinition -> {
+            onElement(type)
+            arguments.forEach(onElement)
+        }
+        is GraphQLInputObjectField -> {
+            onElement(type)
+        }
+        is GraphQLInputObjectType -> {
+            fields.forEach(onElement)
+        }
+        is GraphQLInterfaceType -> {
+            fields.forEach(onElement)
+            interfaces.forEach(onElement)
+        }
+        is GraphQLList -> {
+            onElement(unwrapAll())
+        }
+        is GraphQLNonNull -> {
+            onElement(unwrapAll())
+        }
+        is GraphQLObjectType -> {
+            fields.forEach(onElement)
+            interfaces.forEach(onElement)
+        }
+        is GraphQLScalarType -> {
+        }
+        is GraphQLUnionType -> {
+            types.forEach(onElement)
+        }
+        else -> {
+            throw UnsupportedOperationException()
+        }
+    }
+}

--- a/lib/src/main/java/graphql/nadel/validation/NadelFieldValidation.kt
+++ b/lib/src/main/java/graphql/nadel/validation/NadelFieldValidation.kt
@@ -10,7 +10,6 @@ import graphql.nadel.validation.NadelSchemaValidationError.MissingUnderlyingFiel
 import graphql.nadel.validation.NadelTypeWrappingValidation.Rule.LHS_MUST_BE_LOOSER_OR_SAME
 import graphql.nadel.validation.hydration.NadelHydrationValidation
 import graphql.nadel.validation.util.NadelCombinedTypeUtil.getFieldsThatServiceContributed
-import graphql.nadel.validation.util.NadelCombinedTypeUtil.isCombinedType
 import graphql.nadel.validation.util.NadelSchemaUtil.getUnderlyingName
 import graphql.schema.GraphQLFieldDefinition
 import graphql.schema.GraphQLFieldsContainer
@@ -181,6 +180,6 @@ internal class NadelFieldValidation(
 
     context(NadelValidationContext)
     private fun isCombinedType(type: GraphQLNamedSchemaElement): Boolean {
-        return isCombinedType(engineSchema, type)
+        return type.name in combinedTypeNames
     }
 }

--- a/lib/src/main/java/graphql/nadel/validation/NadelNamespaceValidation.kt
+++ b/lib/src/main/java/graphql/nadel/validation/NadelNamespaceValidation.kt
@@ -1,18 +1,14 @@
 package graphql.nadel.validation
 
-import graphql.nadel.engine.util.operationTypes
-import graphql.nadel.engine.util.unwrapAll
-import graphql.nadel.util.NamespacedUtil.isNamespacedField
 import graphql.nadel.validation.NadelSchemaValidationError.NamespacedTypeMustBeObject
 import graphql.schema.GraphQLObjectType
 
-class NadelNamespaceValidation(
-) {
+class NadelNamespaceValidation {
     context(NadelValidationContext)
     fun validate(
         schemaElement: NadelServiceSchemaElement,
     ): NadelSchemaValidationResult {
-        if (!isNamespacedOperationType(typeName = schemaElement.overall.name)) {
+        if (schemaElement.overall.name !in namespaceTypeNames) {
             return ok()
         }
 
@@ -21,16 +17,5 @@ class NadelNamespaceValidation(
         }
 
         return ok()
-    }
-
-    context(NadelValidationContext)
-    fun isNamespacedOperationType(typeName: String): Boolean {
-        return engineSchema.operationTypes
-            .any { operationType ->
-                operationType.fields
-                    .any { field ->
-                        isNamespacedField(field) && field.type.unwrapAll().name == typeName
-                    }
-            }
     }
 }

--- a/lib/src/main/java/graphql/nadel/validation/NadelSchemaValidation.kt
+++ b/lib/src/main/java/graphql/nadel/validation/NadelSchemaValidation.kt
@@ -4,14 +4,22 @@ import graphql.language.EnumTypeDefinition
 import graphql.language.ImplementingTypeDefinition
 import graphql.nadel.NadelSchemas
 import graphql.nadel.Service
+import graphql.nadel.definition.hydration.isHydrated
 import graphql.nadel.engine.blueprint.NadelOverallExecutionBlueprint
 import graphql.nadel.engine.blueprint.NadelTypeRenameInstructions
 import graphql.nadel.engine.blueprint.NadelUnderlyingExecutionBlueprint
 import graphql.nadel.engine.util.makeFieldCoordinates
 import graphql.nadel.engine.util.strictAssociateBy
 import graphql.nadel.engine.util.toMapStrictly
+import graphql.nadel.engine.util.unwrapAll
+import graphql.nadel.schema.NadelDirectives
 import graphql.schema.FieldCoordinates
+import graphql.schema.GraphQLFieldDefinition
+import graphql.schema.GraphQLFieldsContainer
 import graphql.schema.GraphQLNamedSchemaElement
+import graphql.schema.GraphQLObjectType
+import graphql.schema.GraphQLSchema
+import graphql.schema.GraphQLUnionType
 
 class NadelSchemaValidation(
     // Why is this a constructor argument…
@@ -29,10 +37,17 @@ class NadelSchemaValidation(
         val (engineSchema, services) = schemas
 
         val servicesByName = services.strictAssociateBy(Service::name)
+
+        val operationTypes = getOperationTypeNames(engineSchema)
+        val namespaceTypes = getNamespaceOperationTypes(engineSchema)
+
         val context = NadelValidationContext(
-            engineSchema,
-            servicesByName,
-            fieldContributorMap,
+            engineSchema = engineSchema,
+            servicesByName = servicesByName,
+            fieldContributor = fieldContributorMap,
+            hydrationUnions = getHydrationUnions(engineSchema),
+            namespaceTypeNames = namespaceTypes,
+            combinedTypeNames = namespaceTypes + operationTypes.map { it.name },
         )
         val typeValidation = NadelTypeValidation()
 
@@ -43,6 +58,33 @@ class NadelSchemaValidation(
                 }
                 .toResult()
         }
+    }
+
+    private fun getHydrationUnions(engineSchema: GraphQLSchema): Set<String> {
+        // For each union type, find all fields that use it as an output type
+        val fieldsByUnionOutputTypes = engineSchema.typeMap.values
+            .asSequence()
+            .filterIsInstance<GraphQLFieldsContainer>()
+            .flatMap {
+                it.fieldDefinitions
+            }
+            .filter {
+                it.type.unwrapAll() is GraphQLUnionType
+            }
+            .groupBy {
+                it.type.unwrapAll().name
+            }
+
+        return engineSchema.typeMap.values
+            .asSequence()
+            .filterIsInstance<GraphQLUnionType>()
+            .filter { union ->
+                fieldsByUnionOutputTypes[union.name]?.all(GraphQLFieldDefinition::isHydrated) == true
+            }
+            .map {
+                it.name
+            }
+            .toSet()
     }
 
     fun validateAndGenerateBlueprint(): NadelOverallExecutionBlueprint {
@@ -157,4 +199,29 @@ private fun makeFieldContributorMap(services: List<Service>): Map<FieldCoordinat
                 }
         }
         .toMapStrictly()
+}
+
+private fun getOperationTypeNames(engineSchema: GraphQLSchema): List<GraphQLObjectType> {
+    return listOfNotNull(
+        engineSchema.queryType,
+        engineSchema.mutationType,
+        engineSchema.subscriptionType,
+    )
+}
+
+private fun getNamespaceOperationTypes(overallSchema: GraphQLSchema): Set<String> {
+    val operationTypes = getOperationTypeNames(overallSchema)
+
+    return operationTypes
+        .asSequence()
+        .flatMap { type ->
+            type.fields
+        }
+        .filter { field ->
+            field.hasAppliedDirective(NadelDirectives.namespacedDirectiveDefinition.name)
+        }
+        .map { field ->
+            field.type.unwrapAll().name
+        }
+        .toSet()
 }

--- a/lib/src/main/java/graphql/nadel/validation/NadelTypeValidation.kt
+++ b/lib/src/main/java/graphql/nadel/validation/NadelTypeValidation.kt
@@ -7,11 +7,8 @@ import graphql.nadel.Service
 import graphql.nadel.definition.virtualType.isVirtualType
 import graphql.nadel.engine.blueprint.NadelTypeRenameInstruction
 import graphql.nadel.engine.util.AnyNamedNode
-import graphql.nadel.engine.util.all
 import graphql.nadel.engine.util.isExtensionDef
 import graphql.nadel.engine.util.operationTypes
-import graphql.nadel.engine.util.unwrapAll
-import graphql.nadel.schema.NadelDirectives.hydratedDirectiveDefinition
 import graphql.nadel.validation.NadelSchemaValidationError.DuplicatedUnderlyingType
 import graphql.nadel.validation.NadelSchemaValidationError.IncompatibleType
 import graphql.nadel.validation.NadelSchemaValidationError.MissingUnderlyingType
@@ -19,7 +16,6 @@ import graphql.nadel.validation.util.NadelBuiltInTypes.allNadelBuiltInTypeNames
 import graphql.nadel.validation.util.NadelSchemaUtil.getUnderlyingType
 import graphql.nadel.validation.util.getReachableTypeNames
 import graphql.schema.GraphQLDirectiveContainer
-import graphql.schema.GraphQLFieldsContainer
 import graphql.schema.GraphQLImplementingType
 import graphql.schema.GraphQLInterfaceType
 import graphql.schema.GraphQLNamedOutputType
@@ -63,7 +59,6 @@ internal class NadelTypeValidation {
     ): NadelReachableServiceTypesResult {
         val reachableOverallTypeNames = serviceTypes
             .mapTo(mutableSetOf()) { it.overall.name }
-
         val reachableUnderlyingTypeNames = serviceTypes
             .map { it.underlying.name }
 
@@ -159,16 +154,14 @@ internal class NadelTypeValidation {
             errors.add(MissingUnderlyingType(service, overallType))
         }
 
-        return engineSchema
-            .typeMap
-            .asSequence()
-            .filter { (key) ->
-                key in namesUsed
+        return namesUsed
+            .map {
+                engineSchema.typeMap[it]!!
             }
-            .filterNot { (key) ->
-                key in allNadelBuiltInTypeNames
+            .filterNot {
+                it.name in allNadelBuiltInTypeNames
             }
-            .mapNotNull { (_, overallType) ->
+            .mapNotNull { overallType ->
                 val underlyingType = getUnderlyingType(overallType, service)
 
                 if (underlyingType == null) {
@@ -202,35 +195,21 @@ internal class NadelTypeValidation {
     }
 
     context(NadelValidationContext)
-    private fun getHydrationUnions(service: Service): Set<GraphQLUnionType> {
-        return service.definitionRegistry
-            .definitions
+    private fun getHydrationUnions(service: Service): List<GraphQLUnionType> {
+        return service.definitionRegistry.definitions
             .asSequence()
             .filterIsInstance<UnionTypeDefinition>()
-            .filter { union ->
-                // Check that ALL fields that output the union are annotated with @hydrated
-                engineSchema.typeMap
-                    .values
-                    .asSequence()
-                    .filterIsInstance<GraphQLFieldsContainer>()
-                    .flatMap {
-                        it.fieldDefinitions
-                    }
-                    .filter {
-                        it.type.unwrapAll().name == union.name
-                    }
-                    .all(min = 1) {
-                        it.hasAppliedDirective(hydratedDirectiveDefinition.name)
-                    }
+            .filter {
+                it.name in hydrationUnions
             }
             .map {
                 engineSchema.typeMap[it.name] as GraphQLUnionType
             }
-            .toSet()
+            .toList()
     }
 
     context(NadelValidationContext)
-    private fun getTypeNamesUsed(service: Service, externalTypes: Set<GraphQLNamedType>): Set<String> {
+    private fun getTypeNamesUsed(service: Service, externalTypes: List<GraphQLNamedType>): Set<String> {
         // There is no shared service to validate.
         // These shared types are USED in other services. When they are used, the validation
         // will validate that the service has a compatible underlying type.
@@ -238,11 +217,14 @@ internal class NadelTypeValidation {
             return emptySet()
         }
 
-        val namesToIgnore = externalTypes.map { it.name }.toSet()
+        val namesToIgnore = externalTypes.mapTo(HashSet()) { it.name }
 
         val definitionNames = service.definitionRegistry.definitions
             .asSequence()
             .filterIsInstance<AnyNamedNode>()
+            .filterNot {
+                it.name in namesToIgnore
+            }
             .filter { def ->
                 if (def.isExtensionDef) {
                     isNamespacedOperationType(typeName = def.name) || isOperationType(typeName = def.name)
@@ -253,14 +235,13 @@ internal class NadelTypeValidation {
             .map {
                 it.name
             }
-            .toSet() - namesToIgnore
+            .toList()
 
-        val matchingImplementsNames = service.underlyingSchema.typeMap
-            .values
+        val matchingImplementsNames = service.underlyingSchema.typeMap.values
             .asSequence()
-            .filterIsInstance<GraphQLInterfaceType>()
-            .flatMap {
-                service.underlyingSchema.getImplementations(it)
+            .filterIsInstance<GraphQLObjectType>()
+            .filter {
+                it.interfaces.isNotEmpty()
             }
             .map {
                 it.name
@@ -270,19 +251,17 @@ internal class NadelTypeValidation {
             }
 
         // If it can be reached by using your service, you must own it to return it!
-        val referencedTypes = getReachableTypeNames(engineSchema, service, definitionNames + matchingImplementsNames)
-
-        return (definitionNames + referencedTypes).toSet()
+        return getReachableTypeNames(service, definitionNames + matchingImplementsNames)
     }
 
     context(NadelValidationContext)
     private fun isNamespacedOperationType(typeName: String): Boolean {
-        return namespaceValidation.isNamespacedOperationType(typeName)
+        return typeName in namespaceTypeNames
     }
 
     context(NadelValidationContext)
     private fun isOperationType(typeName: String): Boolean {
-        return engineSchema.operationTypes.map { it.name }.contains(typeName)
+        return engineSchema.operationTypes.any { it.name == typeName }
     }
 
     context(NadelValidationContext)

--- a/lib/src/main/java/graphql/nadel/validation/NadelValidationContext.kt
+++ b/lib/src/main/java/graphql/nadel/validation/NadelValidationContext.kt
@@ -8,6 +8,9 @@ internal data class NadelValidationContext(
     val engineSchema: GraphQLSchema,
     val servicesByName: Map<String, Service>,
     val fieldContributor: Map<FieldCoordinates, Service>,
+    val hydrationUnions: Set<String>,
+    val namespaceTypeNames: Set<String>,
+    val combinedTypeNames: Set<String>,
 ) {
     val visitedTypes: MutableSet<NadelServiceSchemaElementRef> = hashSetOf()
 }

--- a/lib/src/main/java/graphql/nadel/validation/util/NadelGetReachableTypes.kt
+++ b/lib/src/main/java/graphql/nadel/validation/util/NadelGetReachableTypes.kt
@@ -4,10 +4,10 @@ import graphql.language.UnionTypeDefinition
 import graphql.nadel.Service
 import graphql.nadel.definition.hydration.isHydrated
 import graphql.nadel.definition.virtualType.isVirtualType
-import graphql.nadel.engine.util.AnySDLNamedDefinition
+import graphql.nadel.engine.blueprint.NadelFastSchemaTraverser
+import graphql.nadel.engine.util.makeFieldCoordinates
 import graphql.nadel.engine.util.unwrapAll
-import graphql.nadel.validation.util.NadelCombinedTypeUtil.getFieldsThatServiceContributed
-import graphql.nadel.validation.util.NadelCombinedTypeUtil.isCombinedType
+import graphql.nadel.validation.NadelValidationContext
 import graphql.nadel.validation.util.NadelSchemaUtil.getUnderlyingType
 import graphql.schema.GraphQLAppliedDirective
 import graphql.schema.GraphQLArgument
@@ -15,6 +15,7 @@ import graphql.schema.GraphQLCompositeType
 import graphql.schema.GraphQLDirective
 import graphql.schema.GraphQLDirectiveContainer
 import graphql.schema.GraphQLEnumType
+import graphql.schema.GraphQLEnumValueDefinition
 import graphql.schema.GraphQLFieldDefinition
 import graphql.schema.GraphQLFieldsContainer
 import graphql.schema.GraphQLInputFieldsContainer
@@ -30,22 +31,14 @@ import graphql.schema.GraphQLNullableType
 import graphql.schema.GraphQLObjectType
 import graphql.schema.GraphQLOutputType
 import graphql.schema.GraphQLScalarType
-import graphql.schema.GraphQLSchema
-import graphql.schema.GraphQLSchemaElement
 import graphql.schema.GraphQLTypeReference
-import graphql.schema.GraphQLTypeVisitorStub
 import graphql.schema.GraphQLUnionType
 import graphql.schema.GraphQLUnmodifiedType
-import graphql.schema.SchemaTraverser
-import graphql.util.TraversalControl
-import graphql.util.TraversalControl.ABORT
-import graphql.util.TraversalControl.CONTINUE
-import graphql.util.TraverserContext
 
+context(NadelValidationContext)
 internal fun getReachableTypeNames(
-    overallSchema: GraphQLSchema,
     service: Service,
-    definitionNames: Set<String>,
+    definitionNames: List<String>,
 ): Set<String> {
     // We need a mutable Set so we can keep track of what types we've visited to avoid StackOverflows
     val reachableTypeNames = mutableSetOf<String>()
@@ -54,202 +47,210 @@ internal fun getReachableTypeNames(
     fun add(name: String) = reachableTypeNames.add(name)
     fun addAll(elements: Collection<String>) = reachableTypeNames.addAll(elements)
 
-    val serviceDefinitions = overallSchema.typeMap.values.filter { it.name in definitionNames }
-    val traverser = object : GraphQLTypeVisitorStub() {
+    val traverser = object : NadelFastSchemaTraverser.Visitor {
         override fun visitGraphQLArgument(
+            parent: GraphQLNamedSchemaElement?,
             node: GraphQLArgument,
-            context: TraverserContext<GraphQLSchemaElement>,
-        ): TraversalControl {
+        ): Boolean {
             add(node.type.unwrapAll().name)
-            return CONTINUE
+            return true
         }
 
         override fun visitGraphQLUnionType(
+            parent: GraphQLNamedSchemaElement?,
             node: GraphQLUnionType,
-            context: TraverserContext<GraphQLSchemaElement>,
-        ): TraversalControl {
-            visitTypeGuard(node) { return ABORT }
+        ): Boolean {
+            visitTypeGuard(node) { return false }
             add(node.name)
-            return CONTINUE
+            return true
         }
 
         override fun visitGraphQLInterfaceType(
+            parent: GraphQLNamedSchemaElement?,
             node: GraphQLInterfaceType,
-            context: TraverserContext<GraphQLSchemaElement>,
-        ): TraversalControl {
-            visitTypeGuard(node) { return ABORT }
+        ): Boolean {
+            visitTypeGuard(node) { return false }
             add(node.name)
-            return CONTINUE
+            return true
         }
 
         override fun visitGraphQLEnumType(
+            parent: GraphQLNamedSchemaElement?,
             node: GraphQLEnumType,
-            context: TraverserContext<GraphQLSchemaElement>,
-        ): TraversalControl {
-            visitTypeGuard(node) { return ABORT }
+        ): Boolean {
+            visitTypeGuard(node) { return false }
             add(node.name)
-            return CONTINUE
+            return true
+        }
+
+        override fun visitGraphQLEnumValueDefinition(
+            parent: GraphQLNamedSchemaElement?,
+            node: GraphQLEnumValueDefinition,
+        ): Boolean {
+            return true
         }
 
         override fun visitGraphQLFieldDefinition(
+            parent: GraphQLNamedSchemaElement?,
             node: GraphQLFieldDefinition,
-            context: TraverserContext<GraphQLSchemaElement>,
-        ): TraversalControl {
-            return if (node.isHydrated()) {
-                // Do not collect output type, hydrations do not require the type to be defined in the service
-                ABORT
-            } else {
-                // Will visit the output type
-                CONTINUE
+        ): Boolean {
+            val parentNode = parent as GraphQLFieldsContainer
+
+            // Don't look at fields contributed by other services
+            if (parentNode.name in combinedTypeNames) {
+                if (service.name != fieldContributor[makeFieldCoordinates(parentNode.name, node.name)]!!.name) {
+                    return false
+                }
             }
+
+            return !node.isHydrated()
         }
 
         override fun visitGraphQLInputObjectField(
+            parent: GraphQLNamedSchemaElement?,
             node: GraphQLInputObjectField,
-            context: TraverserContext<GraphQLSchemaElement>,
-        ): TraversalControl {
+        ): Boolean {
             add(node.type.unwrapAll().name)
-            return CONTINUE
+            return true
         }
 
         override fun visitGraphQLInputObjectType(
+            parent: GraphQLNamedSchemaElement?,
             node: GraphQLInputObjectType,
-            context: TraverserContext<GraphQLSchemaElement>,
-        ): TraversalControl {
-            visitTypeGuard(node) { return ABORT }
+        ): Boolean {
+            visitTypeGuard(node) { return false }
             add(node.name)
-            return CONTINUE
+            return true
         }
 
         override fun visitGraphQLList(
+            parent: GraphQLNamedSchemaElement?,
             node: GraphQLList,
-            context: TraverserContext<GraphQLSchemaElement>,
-        ): TraversalControl {
+        ): Boolean {
             add(node.unwrapAll().name)
-            return CONTINUE
+            return true
         }
 
         override fun visitGraphQLNonNull(
+            parent: GraphQLNamedSchemaElement?,
             node: GraphQLNonNull,
-            context: TraverserContext<GraphQLSchemaElement>,
-        ): TraversalControl {
+        ): Boolean {
             add(node.unwrapAll().name)
-            return CONTINUE
+            return true
         }
 
         override fun visitGraphQLObjectType(
+            parent: GraphQLNamedSchemaElement?,
             node: GraphQLObjectType,
-            context: TraverserContext<GraphQLSchemaElement>,
-        ): TraversalControl {
-            visitTypeGuard(node) { return ABORT }
+        ): Boolean {
+            visitTypeGuard(node) { return false }
 
             // Don't look at union members defined by external services
-            val parentNode = context.parentNode
-            if (parentNode is GraphQLUnionType && isUnionMemberExempt(service, parentNode, node)) {
-                return ABORT
+            if (parent is GraphQLUnionType && isUnionMemberExempt(service, parent, node)) {
+                return false
             }
 
             add(node.name)
-            return CONTINUE
+            return true
         }
 
         override fun visitGraphQLScalarType(
+            parent: GraphQLNamedSchemaElement?,
             node: GraphQLScalarType,
-            context: TraverserContext<GraphQLSchemaElement>,
-        ): TraversalControl {
-            visitTypeGuard(node) { return ABORT }
+        ): Boolean {
+            visitTypeGuard(node) { return false }
             add(node.name)
-            return CONTINUE
+            return true
         }
 
         override fun visitGraphQLTypeReference(
+            parent: GraphQLNamedSchemaElement?,
             node: GraphQLTypeReference,
-            context: TraverserContext<GraphQLSchemaElement>,
-        ): TraversalControl {
+        ): Boolean {
             add(node.name)
-            return CONTINUE
+            return true
         }
 
         override fun visitGraphQLModifiedType(
+            parent: GraphQLNamedSchemaElement?,
             node: GraphQLModifiedType,
-            context: TraverserContext<GraphQLSchemaElement>,
-        ): TraversalControl {
+        ): Boolean {
             add(node.unwrapAll().name)
-            return CONTINUE
+            return true
         }
 
         override fun visitGraphQLCompositeType(
+            parent: GraphQLNamedSchemaElement?,
             node: GraphQLCompositeType,
-            context: TraverserContext<GraphQLSchemaElement>,
-        ): TraversalControl {
+        ): Boolean {
             add(node.name)
-            return CONTINUE
+            return true
         }
 
         override fun visitGraphQLDirective(
+            parent: GraphQLNamedSchemaElement?,
             node: GraphQLDirective,
-            context: TraverserContext<GraphQLSchemaElement>,
-        ): TraversalControl {
+        ): Boolean {
             // We don't care about directives, not a Nadel runtime concern
             // GraphQL Java will do validation on them for us
-            return ABORT
+            return false
         }
 
         override fun visitGraphQLDirectiveContainer(
+            parent: GraphQLNamedSchemaElement?,
             node: GraphQLDirectiveContainer,
-            context: TraverserContext<GraphQLSchemaElement>,
-        ): TraversalControl {
+        ): Boolean {
             add(node.name)
-            return CONTINUE
+            return true
         }
 
         override fun visitGraphQLFieldsContainer(
+            parent: GraphQLNamedSchemaElement?,
             node: GraphQLFieldsContainer,
-            context: TraverserContext<GraphQLSchemaElement>,
-        ): TraversalControl {
+        ): Boolean {
             add(node.name)
-            return CONTINUE
+            return true
         }
 
         override fun visitGraphQLInputFieldsContainer(
+            parent: GraphQLNamedSchemaElement?,
             node: GraphQLInputFieldsContainer,
-            context: TraverserContext<GraphQLSchemaElement>,
-        ): TraversalControl {
+        ): Boolean {
             add(node.name)
-            return CONTINUE
+            return true
         }
 
         override fun visitGraphQLNullableType(
+            parent: GraphQLNamedSchemaElement?,
             node: GraphQLNullableType,
-            context: TraverserContext<GraphQLSchemaElement>,
-        ): TraversalControl {
+        ): Boolean {
             add(node.unwrapAll().name)
-            return CONTINUE
+            return true
         }
 
         override fun visitGraphQLOutputType(
+            parent: GraphQLNamedSchemaElement?,
             node: GraphQLOutputType,
-            context: TraverserContext<GraphQLSchemaElement>,
-        ): TraversalControl {
+        ): Boolean {
             add(node.unwrapAll().name)
-            return CONTINUE
+            return true
         }
 
         override fun visitGraphQLUnmodifiedType(
+            parent: GraphQLNamedSchemaElement?,
             node: GraphQLUnmodifiedType,
-            context: TraverserContext<GraphQLSchemaElement>,
-        ): TraversalControl {
+        ): Boolean {
             add(node.name)
-            return CONTINUE
+            return true
         }
 
         override fun visitGraphQLAppliedDirective(
+            parent: GraphQLNamedSchemaElement?,
             node: GraphQLAppliedDirective,
-            context: TraverserContext<GraphQLSchemaElement>,
-        ): TraversalControl {
+        ): Boolean {
             // Don't look into applied directives. Could be a shared directive.
             // As long as the schema compiled then we don't care.
-            return ABORT
+            return false
         }
 
         /**
@@ -267,21 +268,11 @@ internal fun getReachableTypeNames(
         }
     }
 
-    SchemaTraverser { element ->
-        // Handle combined types
-        if (element is GraphQLNamedSchemaElement && isCombinedType(overallSchema, element)) {
-            val fieldsThatServiceContributed = getFieldsThatServiceContributed(service, element)
-            // Don't visit fields that service did not contribute i.e. unreachable
-            element.children.filter { children ->
-                when (children) {
-                    is GraphQLFieldDefinition -> children.name in fieldsThatServiceContributed
-                    else -> false
-                }
-            }
-        } else {
-            element.children
-        }
-    }.depthFirst(traverser, serviceDefinitions)
+    NadelFastSchemaTraverser().traverse(
+        schema = engineSchema,
+        roots = definitionNames,
+        visitor = traverser,
+    )
 
     return reachableTypeNames
 }
@@ -291,8 +282,8 @@ internal fun isUnionMemberExempt(
     unionType: GraphQLUnionType,
     memberInQuestion: GraphQLObjectType,
 ): Boolean {
-    return isUnionMemberExternal(service, unionType, memberInQuestion) &&
-        isMemberMissingFromUnderlyingSchema(service, memberInQuestion)
+    return isMemberMissingFromUnderlyingSchema(service, memberInQuestion)
+        && isUnionMemberExternal(service, unionType, memberInQuestion)
 }
 
 /**
@@ -305,11 +296,9 @@ internal fun isUnionMemberExternal(
     unionType: GraphQLUnionType,
     memberInQuestion: GraphQLObjectType,
 ): Boolean {
-
-    return service.definitionRegistry.definitions
+    return service.definitionRegistry
+        .getDefinitions(unionType.name)
         .asSequence()
-        .filterIsInstance<AnySDLNamedDefinition>()
-        .filter { it.name == unionType.name }
         .flatMap {
             (it as UnionTypeDefinition).memberTypes
         }


### PR DESCRIPTION
So I ran this against Central Schema using dcd34ebc3ebb5baf87acd4ec885a1214a0165c57

The current validation takes 2 _seconds_. With the improvements on this branch it brings it down to 80ms.

The big majority of time saves are in precomputing info instead of computing it for each service validated etc.

For reference, the current blueprint creation method takes 30ms.