### PR TITLE
Handle deleted types by SchemaTransformer

### DIFF
--- a/lib/src/main/java/graphql/nadel/engine/blueprint/NadelFastSchemaTraverser.kt
+++ b/lib/src/main/java/graphql/nadel/engine/blueprint/NadelFastSchemaTraverser.kt
@@ -45,8 +45,15 @@ internal class NadelFastSchemaTraverser {
         visitor: Visitor,
     ) {
         val queue = roots
-            .mapTo(mutableListOf()) {
-                (null as GraphQLNamedSchemaElement?) to (schema.typeMap[it] ?: schema.getDirective(it))!!
+            .mapNotNullTo(mutableListOf()) { typeName ->
+                val type = schema.typeMap[typeName] ?: schema.getDirective(typeName)
+                // Types can be deleted by transformer, so they may not exist in end schema
+                if (type == null) {
+                    null
+                } else {
+                    // Null parent to type
+                    (null as GraphQLNamedSchemaElement?) to type
+                }
             }
         val visited = roots.toMutableSet()
 


### PR DESCRIPTION
I actually had this fixed in another dev branch.

Cherry picked this to fix master.

The PRs didn't fail because it required both #616 and #619 to be merged for a caused semantic merge conflict.