### PR TITLE
Delete unused flag. It's set inside Nadel.Builder instead

### DIFF
--- a/lib/src/main/java/graphql/nadel/NadelExecutionHints.kt
+++ b/lib/src/main/java/graphql/nadel/NadelExecutionHints.kt
@@ -17,7 +17,6 @@ data class NadelExecutionHints(
     val sharedTypeRenames: NadelSharedTypeRenamesHint,
     val shortCircuitEmptyQuery: NadelShortCircuitEmptyQueryHint,
     val virtualTypeSupport: NadelVirtualTypeSupportHint,
-    val validationBlueprint: NadelValidationBlueprintHint,
 ) {
     /**
      * Returns a builder with the same field values as this object.
@@ -37,7 +36,6 @@ data class NadelExecutionHints(
         private var shortCircuitEmptyQuery = NadelShortCircuitEmptyQueryHint { false }
         private var sharedTypeRenames = NadelSharedTypeRenamesHint { false }
         private var virtualTypeSupport = NadelVirtualTypeSupportHint { false }
-        private var validationBlueprint = NadelValidationBlueprintHint { false }
 
         constructor()
 
@@ -83,11 +81,6 @@ data class NadelExecutionHints(
             return this
         }
 
-        fun validationBlueprint(flag: NadelValidationBlueprintHint): Builder {
-            validationBlueprint = flag
-            return this
-        }
-
         fun build(): NadelExecutionHints {
             return NadelExecutionHints(
                 legacyOperationNames,
@@ -97,7 +90,6 @@ data class NadelExecutionHints(
                 sharedTypeRenames,
                 shortCircuitEmptyQuery,
                 virtualTypeSupport,
-                validationBlueprint,
             )
         }
     }


### PR DESCRIPTION
I was reading over the PR again and noticed this is unused.

This flag is actually set globally for the entire Nadel engine at `graphql.nadel.Nadel.Builder#blueprintHint`