### PR TITLE
Manual exemption to get hydration instruction

### DIFF
--- a/lib/src/main/java/graphql/nadel/validation/hydration/NadelHydrationArgumentTypeValidation.kt
+++ b/lib/src/main/java/graphql/nadel/validation/hydration/NadelHydrationArgumentTypeValidation.kt
@@ -195,6 +195,11 @@ internal class NadelHydrationArgumentTypeValidation {
             return true
         }
 
+        // I hate to bake this into here… but ugh. They're not assignable. Will remove at some point
+        if (suppliedType.name == "DevOpsProviderType" && requiredType.name == "ToolchainProviderType") {
+            return true
+        }
+
         // All values from supplied enum can be used as values in the required type
         return requiredType.values.map { it.name }
             .containsAll(suppliedType.values.map { it.name })


### PR DESCRIPTION
Don't want to add an API for exemptions. So hardcoding the values in.

This incompatibility is an issue because it errors out and prevents the hydration instruction from being generated.

There's just one extra enum value in `DevOpsProviderType` that doesn't exist in `ToolchainProviderType`

Let's exempt this for now and fix it up in schema later.