### PR TITLE
Handle NPE on null errors for whatever reason

### DIFF
--- a/lib/src/main/java/graphql/nadel/ServiceExecutionResult.kt
+++ b/lib/src/main/java/graphql/nadel/ServiceExecutionResult.kt
@@ -6,13 +6,13 @@ import org.reactivestreams.Publisher
 
 sealed class ServiceExecutionResult {
     abstract val data: MutableMap<String, Any?>
-    abstract val errors: MutableList<MutableMap<String, Any?>>
+    abstract val errors: MutableList<MutableMap<String, Any?>?>
     abstract val extensions: MutableMap<String, Any?>
 }
 
 data class NadelIncrementalServiceExecutionResult(
     override val data: MutableMap<String, Any?> = LinkedHashMap(),
-    override val errors: MutableList<MutableMap<String, Any?>> = ArrayList(),
+    override val errors: MutableList<MutableMap<String, Any?>?> = ArrayList(),
     override val extensions: MutableMap<String, Any?> = LinkedHashMap(),
     val incremental: List<IncrementalPayload>?,
     val incrementalItemPublisher: Publisher<DelayedIncrementalPartialResult>,
@@ -21,6 +21,6 @@ data class NadelIncrementalServiceExecutionResult(
 
 data class NadelServiceExecutionResultImpl @JvmOverloads constructor(
     override val data: MutableMap<String, Any?> = LinkedHashMap(),
-    override val errors: MutableList<MutableMap<String, Any?>> = ArrayList(),
+    override val errors: MutableList<MutableMap<String, Any?>?> = ArrayList(),
     override val extensions: MutableMap<String, Any?> = LinkedHashMap(),
 ) : ServiceExecutionResult()

--- a/lib/src/main/java/graphql/nadel/engine/transform/hydration/NadelHydrationTransform.kt
+++ b/lib/src/main/java/graphql/nadel/engine/transform/hydration/NadelHydrationTransform.kt
@@ -217,6 +217,7 @@ internal class NadelHydrationTransform(
                     )
                     val addErrors = hydration.errors
                         .asSequence()
+                        .filterNotNull()
                         .map { error ->
                             toGraphQLError(error)
                         }
@@ -288,12 +289,15 @@ internal class NadelHydrationTransform(
                                 .path(parentPath.toRawPath())
                                 .errors(
                                     hydration.errors
+                                        .asSequence()
+                                        .filterNotNull()
                                         .map {
                                             toGraphQLError(
                                                 raw = it,
                                                 path = path.toRawPath(),
                                             )
-                                        },
+                                        }
+                                        .toList(),
                                 )
                                 .build()
                         }
@@ -499,5 +503,5 @@ private fun interface NadelPreparedHydration {
 private data class NadelHydrationResult(
     val parentNode: JsonNode,
     val newValue: JsonNode?,
-    val errors: List<JsonMap>,
+    val errors: List<JsonMap?>,
 )

--- a/lib/src/main/java/graphql/nadel/engine/transform/hydration/NadelHydrationUtil.kt
+++ b/lib/src/main/java/graphql/nadel/engine/transform/hydration/NadelHydrationUtil.kt
@@ -40,6 +40,7 @@ internal object NadelHydrationUtil {
     ): Sequence<NadelResultInstruction.AddError> {
         return result.errors
             .asSequence()
+            .filterNotNull()
             .map(::toGraphQLError)
             .map(NadelResultInstruction::AddError)
     }

--- a/lib/src/main/java/graphql/nadel/engine/transform/partition/NadelPartitionTransform.kt
+++ b/lib/src/main/java/graphql/nadel/engine/transform/partition/NadelPartitionTransform.kt
@@ -225,7 +225,9 @@ internal class NadelPartitionTransform(
         }
 
         val errorInstructions = resultFromPartitionCalls
+            .asSequence()
             .flatMap { it.errors }
+            .filterNotNull()
             .map { error ->
                 NadelResultInstruction.AddError(
                     toGraphQLError(
@@ -237,6 +239,7 @@ internal class NadelPartitionTransform(
                     )
                 )
             }
+            .toList()
 
         return mergedData + errorInstructions
     }

--- a/lib/src/main/java/graphql/nadel/engine/transform/result/NadelResultTransformer.kt
+++ b/lib/src/main/java/graphql/nadel/engine/transform/result/NadelResultTransformer.kt
@@ -159,7 +159,7 @@ internal class NadelResultTransformer(private val executionBlueprint: NadelOvera
 
     private fun process(
         instruction: NadelResultInstruction.AddError,
-        errors: List<JsonMap>,
+        errors: List<JsonMap?>,
     ) {
         val newError = instruction.error.toSpecification()
 

--- a/lib/src/main/java/graphql/nadel/engine/util/GraphQLUtil.kt
+++ b/lib/src/main/java/graphql/nadel/engine/util/GraphQLUtil.kt
@@ -389,7 +389,7 @@ fun ExecutionIdProvider.provide(executionInput: ExecutionInput): ExecutionId {
 
 fun newServiceExecutionResult(
     data: MutableJsonMap = mutableMapOf(),
-    errors: MutableList<MutableJsonMap> = mutableListOf(),
+    errors: MutableList<MutableJsonMap?> = mutableListOf(),
     extensions: MutableJsonMap = mutableMapOf(),
 ): ServiceExecutionResult {
     return NadelServiceExecutionResultImpl(data, errors, extensions)

--- a/lib/src/main/java/graphql/nadel/util/ErrorUtil.kt
+++ b/lib/src/main/java/graphql/nadel/util/ErrorUtil.kt
@@ -11,10 +11,11 @@ typealias GraphQLErrorBuilder = GraphqlErrorBuilder<*>
  * A helper class that can to deal with graphql errors
  */
 internal object ErrorUtil {
-    fun createGraphQLErrorsFromRawErrors(errors: List<Map<String, Any?>>): List<GraphQLError> {
-        return errors.map {
-            createGraphQLErrorFromRawError(it)
-        }
+    fun createGraphQLErrorsFromRawErrors(errors: List<Map<String, Any?>?>): List<GraphQLError> {
+        return errors
+            .mapNotNull {
+                it?.let(::createGraphQLErrorFromRawError)
+            }
     }
 
     fun createGraphQLErrorFromRawError(rawError: Map<String, Any?>): GraphQLError {

--- a/test/src/test/kotlin/graphql/nadel/tests/EngineTests.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/EngineTests.kt
@@ -235,7 +235,7 @@ private suspend fun execute(
                     return CompletableFuture.completedFuture(
                         NadelIncrementalServiceExecutionResult(
                             data = initialResponse["data"] as MutableJsonMap? ?: LinkedHashMap(),
-                            errors = initialResponse["errors"] as MutableList<MutableJsonMap>? ?: ArrayList(),
+                            errors = initialResponse["errors"] as MutableList<MutableJsonMap?>? ?: ArrayList(),
                             extensions = initialResponse["extensions"] as MutableJsonMap? ?: LinkedHashMap(),
                             incremental = emptyList(), // todo: support this if we need it
                             incrementalItemPublisher = incrementalItemPublisher,
@@ -248,7 +248,7 @@ private suspend fun execute(
                     return CompletableFuture.completedFuture(
                         NadelServiceExecutionResultImpl(
                             serviceCallResponse["data"] as MutableJsonMap? ?: LinkedHashMap(),
-                            serviceCallResponse["errors"] as MutableList<MutableJsonMap>? ?: ArrayList(),
+                            serviceCallResponse["errors"] as MutableList<MutableJsonMap?>? ?: ArrayList(),
                             serviceCallResponse["extensions"] as MutableJsonMap? ?: LinkedHashMap(),
                         ),
                     )

--- a/test/src/test/kotlin/graphql/nadel/tests/next/GraphQLServiceExecution.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/next/GraphQLServiceExecution.kt
@@ -42,7 +42,7 @@ class GraphQLServiceExecution(
                     @Suppress("UNCHECKED_CAST")
                     NadelIncrementalServiceExecutionResult(
                         data = spec["data"] as MutableMap<String, Any?>? ?: mutableMapOf(),
-                        errors = spec["errors"] as MutableList<MutableMap<String, Any?>>? ?: mutableListOf(),
+                        errors = spec["errors"] as MutableList<MutableMap<String, Any?>?>? ?: mutableListOf(),
                         extensions = spec["extensions"] as MutableMap<String, Any?>? ?: mutableMapOf(),
                         incremental = it.incremental,
                         incrementalItemPublisher = it.incrementalItemPublisher
@@ -63,7 +63,7 @@ class GraphQLServiceExecution(
                     @Suppress("UNCHECKED_CAST")
                     NadelServiceExecutionResultImpl(
                         data = spec["data"] as MutableMap<String, Any?>? ?: mutableMapOf(),
-                        errors = spec["errors"] as MutableList<MutableMap<String, Any?>>? ?: mutableListOf(),
+                        errors = spec["errors"] as MutableList<MutableMap<String, Any?>?>? ?: mutableListOf(),
                         extensions = spec["extensions"] as MutableMap<String, Any?>? ?: mutableMapOf(),
                     )
                 }


### PR DESCRIPTION
Not sure why but we got an NPE for a null error.

Probably not normal according to GraphQL spec to have null values in top level errors field.

But let's fix this so we don't see issues.