### PR TITLE
return empty response when subscription are running on the internal introspection service

### DIFF
--- a/lib/src/main/java/graphql/nadel/engine/blueprint/IntrospectionService.kt
+++ b/lib/src/main/java/graphql/nadel/engine/blueprint/IntrospectionService.kt
@@ -4,12 +4,13 @@ import graphql.ExecutionInput
 import graphql.GraphQL
 import graphql.GraphqlErrorHelper.toSpecification
 import graphql.language.AstPrinter
+import graphql.language.OperationDefinition
 import graphql.nadel.NadelDefinitionRegistry
+import graphql.nadel.NadelServiceExecutionResultImpl
 import graphql.nadel.Service
 import graphql.nadel.ServiceExecution
 import graphql.nadel.ServiceExecutionParameters
 import graphql.nadel.ServiceExecutionResult
-import graphql.nadel.NadelServiceExecutionResultImpl
 import graphql.nadel.engine.util.makeFieldCoordinates
 import graphql.nadel.engine.util.toBuilder
 import graphql.nadel.engine.util.toBuilderWithoutTypes
@@ -40,6 +41,9 @@ open class NadelDefaultIntrospectionRunner(schema: GraphQLSchema) : ServiceExecu
         .build()
 
     override fun execute(serviceExecutionParameters: ServiceExecutionParameters): CompletableFuture<ServiceExecutionResult> {
+        if (serviceExecutionParameters.operationDefinition.operation == OperationDefinition.Operation.SUBSCRIPTION) {
+            return CompletableFuture.completedFuture(NadelServiceExecutionResultImpl())
+        }
         return graphQL
             .executeAsync(
                 ExecutionInput.newExecutionInput()

--- a/test/src/test/kotlin/graphql/nadel/tests/hooks/remove-fields.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/hooks/remove-fields.kt
@@ -102,6 +102,18 @@ class `top-level-field-is-removed` : EngineTestHook {
 }
 
 @UseHook
+class `top-level-field-is-removed-for-a-subscription` : EngineTestHook {
+    override val customTransforms = listOf(RemoveFieldTestTransform())
+    override fun makeExecutionHints(builder: NadelExecutionHints.Builder) = builder.shortCircuitEmptyQuery { true }
+}
+
+@UseHook
+class `top-level-field-is-removed-for-a-subscription-with-namespaced-field` : EngineTestHook {
+    override val customTransforms = listOf(RemoveFieldTestTransform())
+    override fun makeExecutionHints(builder: NadelExecutionHints.Builder) = builder.shortCircuitEmptyQuery { true }
+}
+
+@UseHook
 class `top-level-field-is-removed-hint-is-off` : EngineTestHook {
     override val customTransforms = listOf(RemoveFieldTestTransform())
     override fun makeExecutionHints(builder: NadelExecutionHints.Builder) = builder.shortCircuitEmptyQuery { false }

--- a/test/src/test/kotlin/graphql/nadel/tests/transforms/RemoveFieldTestTransform.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/transforms/RemoveFieldTestTransform.kt
@@ -1,5 +1,6 @@
 package graphql.nadel.tests.transforms
 
+import graphql.ErrorType
 import graphql.GraphQLError
 import graphql.introspection.Introspection
 import graphql.nadel.Service
@@ -15,11 +16,10 @@ import graphql.nadel.engine.transform.query.NadelQueryTransformer
 import graphql.nadel.engine.transform.result.NadelResultInstruction
 import graphql.nadel.engine.transform.result.NadelResultKey
 import graphql.nadel.engine.transform.result.json.JsonNodes
+import graphql.nadel.engine.util.newGraphQLError
 import graphql.nadel.engine.util.queryPath
 import graphql.normalized.ExecutableNormalizedField
 import graphql.schema.GraphQLObjectType
-import graphql.validation.ValidationError.newValidationError
-import graphql.validation.ValidationErrorType
 
 class RemoveFieldTestTransform : NadelTransform<GraphQLError> {
     override suspend fun isApplicable(
@@ -40,7 +40,10 @@ class RemoveFieldTestTransform : NadelTransform<GraphQLError> {
             ?: return null
 
         if (objectType.getField(overallField.name)?.getDirective("toBeDeleted") != null) {
-            return newValidationError().validationErrorType(ValidationErrorType.WrongType).build()
+            return newGraphQLError(
+                "field `${objectType.name}.${overallField.name}` has been removed by RemoveFieldTestTransform",
+                ErrorType.DataFetchingException,
+            )
         }
 
         return null

--- a/test/src/test/resources/fixtures/chained transforms/two-transforms-on-a-field.yml
+++ b/test/src/test/resources/fixtures/chained transforms/two-transforms-on-a-field.yml
@@ -77,12 +77,11 @@ response: |-
     },
     "errors": [
       {
-        "message": "null",
+        "message": "field `Foo.epicEntity` has been removed by RemoveFieldTestTransform",
         "locations": [],
         "extensions": {
-          "classification": "ValidationError"
+          "classification": "DataFetchingException"
         }
       }
-    ],
-    "extensions": {}
+    ]
   }

--- a/test/src/test/resources/fixtures/field removed/hidden-namespaced-hydration-top-level-field-is-removed.yml
+++ b/test/src/test/resources/fixtures/field removed/hidden-namespaced-hydration-top-level-field-is-removed.yml
@@ -91,19 +91,19 @@ serviceCalls:
 # language=JSON
 response: |-
   {
-    "errors": [
-      {
-        "locations": [],
-        "message": "An error has occurred",
-        "extensions": {
-          "classification": "ValidationError"
-        }
-      }
-    ],
     "data": {
       "issueById": {
         "id": "C1",
         "comment": null
       }
-    }
+    },
+    "errors": [
+      {
+        "message": "field `CommentApi.commentById` has been removed by RemoveFieldTestTransform",
+        "locations": [],
+        "extensions": {
+          "classification": "DataFetchingException"
+        }
+      }
+    ]
   }

--- a/test/src/test/resources/fixtures/field removed/hydration-top-level-field-is-removed.yml
+++ b/test/src/test/resources/fixtures/field removed/hydration-top-level-field-is-removed.yml
@@ -80,19 +80,19 @@ serviceCalls:
 # language=JSON
 response: |-
   {
-    "errors": [
-      {
-        "locations": [],
-        "message": "An error has occurred",
-        "extensions": {
-          "classification": "ValidationError"
-        }
-      }
-    ],
     "data": {
       "issueById": {
         "id": "C1",
         "comment": null
       }
-    }
+    },
+    "errors": [
+      {
+        "message": "field `Query.commentById` has been removed by RemoveFieldTestTransform",
+        "locations": [],
+        "extensions": {
+          "classification": "DataFetchingException"
+        }
+      }
+    ]
   }

--- a/test/src/test/resources/fixtures/field removed/namespaced-field-is-removed-with-renames.yml
+++ b/test/src/test/resources/fixtures/field removed/namespaced-field-is-removed-with-renames.yml
@@ -40,18 +40,18 @@ serviceCalls: [ ]
 # language=JSON
 response: |-
   {
-    "errors": [
-      {
-        "locations": [],
-        "message": "null",
-        "extensions": {
-          "classification": "ValidationError"
-        }
-      }
-    ],
     "data": {
       "commentApi": {
         "commentById": null
       }
-    }
+    },
+    "errors": [
+      {
+        "message": "field `CommentApi.commentById` has been removed by RemoveFieldTestTransform",
+        "locations": [],
+        "extensions": {
+          "classification": "DataFetchingException"
+        }
+      }
+    ]
   }

--- a/test/src/test/resources/fixtures/field removed/namespaced-field-is-removed.yml
+++ b/test/src/test/resources/fixtures/field removed/namespaced-field-is-removed.yml
@@ -40,18 +40,18 @@ serviceCalls: [ ]
 # language=JSON
 response: |-
   {
-    "errors": [
-      {
-        "locations": [],
-        "message": "null",
-        "extensions": {
-          "classification": "ValidationError"
-        }
-      }
-    ],
     "data": {
       "commentApi": {
         "commentById": null
       }
-    }
+    },
+    "errors": [
+      {
+        "message": "field `CommentApi.commentById` has been removed by RemoveFieldTestTransform",
+        "locations": [],
+        "extensions": {
+          "classification": "DataFetchingException"
+        }
+      }
+    ]
   }

--- a/test/src/test/resources/fixtures/field removed/namespaced-hydration-top-level-field-is-removed.yml
+++ b/test/src/test/resources/fixtures/field removed/namespaced-hydration-top-level-field-is-removed.yml
@@ -87,19 +87,19 @@ serviceCalls:
 # language=JSON
 response: |-
   {
-    "errors": [
-      {
-        "locations": [],
-        "message": "An error has occurred",
-        "extensions": {
-          "classification": "ValidationError"
-        }
-      }
-    ],
     "data": {
       "issueById": {
         "id": "C1",
         "comment": null
       }
-    }
+    },
+    "errors": [
+      {
+        "message": "field `CommentApi.commentById` has been removed by RemoveFieldTestTransform",
+        "locations": [],
+        "extensions": {
+          "classification": "DataFetchingException"
+        }
+      }
+    ]
   }

--- a/test/src/test/resources/fixtures/field removed/top-level-field-is-removed-for-a-subscription-with-namespaced-field.yml
+++ b/test/src/test/resources/fixtures/field removed/top-level-field-is-removed-for-a-subscription-with-namespaced-field.yml
@@ -1,0 +1,60 @@
+name: "top level field is removed for a subscription with namespaced field"
+enabled: true
+# language=GraphQL
+overallSchema:
+  CommentService: |
+    directive @toBeDeleted on FIELD_DEFINITION
+    type Query {
+      commentById(id: ID): Comment @toBeDeleted
+    }
+    type Subscription {
+      commentsApi: CommentsApi @namespaced
+    }
+    type CommentsApi {
+      onCommentUpdated(id: ID): Comment @toBeDeleted
+    }
+    type Comment {
+      id: ID
+    }
+# language=GraphQL
+underlyingSchema:
+  CommentService: |
+    type Query {
+      commentById(id: ID): Comment
+    }
+    type Subscription {
+      commentsApi: CommentsApi
+    }
+    type CommentsApi {
+      onCommentUpdated(id: ID): Comment
+    }
+    type Comment {
+      id: ID
+    }
+# language=GraphQL
+query: |
+  subscription {
+    commentsApi {
+      onCommentUpdated(id: "C1") {
+        id
+      }
+    }
+  }
+variables: { }
+serviceCalls: [ ]
+# language=JSON
+response: |-
+  {
+    "errors": [
+      {
+        "locations": [],
+        "message": "null",
+        "extensions": {
+          "classification": "ValidationError"
+        }
+      }
+    ],
+    "data": {
+      "commentsApi": null
+    }
+  }

--- a/test/src/test/resources/fixtures/field removed/top-level-field-is-removed-for-a-subscription-with-namespaced-field.yml
+++ b/test/src/test/resources/fixtures/field removed/top-level-field-is-removed-for-a-subscription-with-namespaced-field.yml
@@ -45,16 +45,16 @@ serviceCalls: [ ]
 # language=JSON
 response: |-
   {
-    "errors": [
-      {
-        "locations": [],
-        "message": "null",
-        "extensions": {
-          "classification": "ValidationError"
-        }
-      }
-    ],
     "data": {
       "commentsApi": null
-    }
+    },
+    "errors": [
+      {
+        "message": "field `CommentsApi.onCommentUpdated` has been removed by RemoveFieldTestTransform",
+        "locations": [],
+        "extensions": {
+          "classification": "DataFetchingException"
+        }
+      }
+    ]
   }

--- a/test/src/test/resources/fixtures/field removed/top-level-field-is-removed-for-a-subscription.yml
+++ b/test/src/test/resources/fixtures/field removed/top-level-field-is-removed-for-a-subscription.yml
@@ -1,0 +1,52 @@
+name: "top level field is removed for a subscription"
+enabled: true
+# language=GraphQL
+overallSchema:
+  CommentService: |
+    directive @toBeDeleted on FIELD_DEFINITION
+    type Query {
+      commentById(id: ID): Comment
+    }
+    type Subscription {
+      onCommentUpdated(id: ID): Comment @toBeDeleted
+    }
+    type Comment {
+      id: ID
+    }
+# language=GraphQL
+underlyingSchema:
+  CommentService: |
+    type Query {
+      commentById(id: ID): Comment
+    }
+    type Subscription {
+      onCommentUpdated(id: ID): Comment
+    }
+    type Comment {
+      id: ID
+    }
+# language=GraphQL
+query: |
+  subscription {
+    onCommentUpdated(id: "C1") {
+      id
+    }
+  }
+variables: { }
+serviceCalls: [ ]
+# language=JSON
+response: |-
+  {
+    "errors": [
+      {
+        "locations": [],
+        "message": "null",
+        "extensions": {
+          "classification": "ValidationError"
+        }
+      }
+    ],
+    "data": {
+      "onCommentUpdated": null
+    }
+  }

--- a/test/src/test/resources/fixtures/field removed/top-level-field-is-removed-for-a-subscription.yml
+++ b/test/src/test/resources/fixtures/field removed/top-level-field-is-removed-for-a-subscription.yml
@@ -37,16 +37,16 @@ serviceCalls: [ ]
 # language=JSON
 response: |-
   {
-    "errors": [
-      {
-        "locations": [],
-        "message": "null",
-        "extensions": {
-          "classification": "ValidationError"
-        }
-      }
-    ],
     "data": {
       "onCommentUpdated": null
-    }
+    },
+    "errors": [
+      {
+        "message": "field `Subscription.onCommentUpdated` has been removed by RemoveFieldTestTransform",
+        "locations": [],
+        "extensions": {
+          "classification": "DataFetchingException"
+        }
+      }
+    ]
   }

--- a/test/src/test/resources/fixtures/field removed/top-level-field-is-removed-hint-is-off.yml
+++ b/test/src/test/resources/fixtures/field removed/top-level-field-is-removed-hint-is-off.yml
@@ -47,16 +47,16 @@ serviceCalls:
 # language=JSON
 response: |-
   {
-    "errors": [
-      {
-        "locations": [],
-        "message": "null",
-        "extensions": {
-          "classification": "ValidationError"
-        }
-      }
-    ],
     "data": {
       "commentById": null
-    }
+    },
+    "errors": [
+      {
+        "message": "field `Query.commentById` has been removed by RemoveFieldTestTransform",
+        "locations": [],
+        "extensions": {
+          "classification": "DataFetchingException"
+        }
+      }
+    ]
   }

--- a/test/src/test/resources/fixtures/field removed/top-level-field-is-removed.yml
+++ b/test/src/test/resources/fixtures/field removed/top-level-field-is-removed.yml
@@ -31,16 +31,16 @@ serviceCalls: [ ]
 # language=JSON
 response: |-
   {
-    "errors": [
-      {
-        "locations": [],
-        "message": "null",
-        "extensions": {
-          "classification": "ValidationError"
-        }
-      }
-    ],
     "data": {
       "commentById": null
-    }
+    },
+    "errors": [
+      {
+        "message": "field `Query.commentById` has been removed by RemoveFieldTestTransform",
+        "locations": [],
+        "extensions": {
+          "classification": "DataFetchingException"
+        }
+      }
+    ]
   }

--- a/test/src/test/resources/fixtures/introspection/no-introspections-on-subscriptions.yml
+++ b/test/src/test/resources/fixtures/introspection/no-introspections-on-subscriptions.yml
@@ -1,0 +1,52 @@
+name: "no introspections on subscriptions"
+enabled: true
+# language=GraphQL
+overallSchema:
+  MyService: |
+    type Query {
+      comment: Comment
+    }
+    type Subscription {
+      onComment: Comment @namespaced
+    }
+    type Comment {
+      id: ID
+    }
+# language=GraphQL
+underlyingSchema:
+  MyService: |
+    type Query {
+      comment: Comment
+    }
+    type Subscription {
+      onComment: Comment
+    }
+    type Comment {
+      id: ID
+    }
+# language=GraphQL
+query: |
+  subscription {
+    __typename
+  }
+variables: { }
+serviceCalls: [ ]
+# language=JSON
+response: |-
+  {
+    "data": null,
+    "errors": [
+      {
+        "message": "Validation error (SubscriptionIntrospectionRootField) : Subscription operation 'null' root field '__typename' cannot be an introspection field",
+        "locations": [
+          {
+            "line": 2,
+            "column": 3
+          }
+        ],
+        "extensions": {
+          "classification": "ValidationError"
+        }
+      }
+    ]
+  }


### PR DESCRIPTION
Please make sure you consider the following:

- [x] Add tests that use __typename in queries
- [x] Does this change work with all nadel transformations (rename, type rename, hydration, etc)? Add tests for this.
- [x] Is it worth using hints for this change in order to be able to enable a percentage rollout?
- [x] Do we need to add integration tests for this change in the graphql gateway?
- [x] Do we need a pollinator check for this?
