### PR TITLE
Default hydration validation

### DIFF
--- a/lib/src/main/java/graphql/nadel/definition/hydration/NadelDefaultHydrationDefinition.kt
+++ b/lib/src/main/java/graphql/nadel/definition/hydration/NadelDefaultHydrationDefinition.kt
@@ -1,6 +1,7 @@
 package graphql.nadel.definition.hydration
 
 import graphql.language.DirectiveDefinition
+import graphql.nadel.definition.NadelInstructionDefinition
 import graphql.nadel.definition.hydration.NadelDefaultHydrationDefinition.Keyword
 import graphql.nadel.engine.util.parseDefinition
 import graphql.schema.GraphQLAppliedDirective
@@ -11,14 +12,14 @@ fun GraphQLNamedType.hasDefaultHydration(): Boolean {
     return (this as? GraphQLDirectiveContainer)?.hasAppliedDirective(Keyword.defaultHydration) == true
 }
 
-fun GraphQLNamedType.getDefaultHydrationOrNull(): NadelDefaultHydrationDefinition? {
+fun GraphQLNamedType.parseDefaultHydrationOrNull(): NadelDefaultHydrationDefinition? {
     return (this as? GraphQLDirectiveContainer)?.getAppliedDirective(Keyword.defaultHydration)
         ?.let(::NadelDefaultHydrationDefinition)
 }
 
 class NadelDefaultHydrationDefinition(
     private val appliedDirective: GraphQLAppliedDirective,
-) {
+) : NadelInstructionDefinition {
     companion object {
         val directiveDefinition = parseDefinition<DirectiveDefinition>(
             // language=GraphQL

--- a/lib/src/main/java/graphql/nadel/validation/NadelIdHydrationDefinitionParser.kt
+++ b/lib/src/main/java/graphql/nadel/validation/NadelIdHydrationDefinitionParser.kt
@@ -6,7 +6,7 @@ import graphql.nadel.definition.hydration.NadelHydrationArgumentDefinition
 import graphql.nadel.definition.hydration.NadelHydrationConditionDefinition
 import graphql.nadel.definition.hydration.NadelHydrationDefinition
 import graphql.nadel.definition.hydration.NadelIdHydrationDefinition
-import graphql.nadel.definition.hydration.getDefaultHydrationOrNull
+import graphql.nadel.definition.hydration.parseDefaultHydrationOrNull
 import graphql.nadel.definition.hydration.parseIdHydrationOrNull
 import graphql.nadel.engine.util.unwrapAll
 import graphql.schema.GraphQLFieldDefinition
@@ -61,7 +61,7 @@ internal class NadelIdHydrationDefinitionParser {
         return NadelValidationInterimResult.Success.of(
             virtualFieldType.types
                 .mapNotNull { unionMemberType ->
-                    if ((unionMemberType as? GraphQLNamedType)?.getDefaultHydrationOrNull() == null) {
+                    if ((unionMemberType as? GraphQLNamedType)?.parseDefaultHydrationOrNull() == null) {
                         null
                     } else {
                         getHydrationDefinitionForType(
@@ -81,7 +81,7 @@ internal class NadelIdHydrationDefinitionParser {
         idHydration: NadelIdHydrationDefinition,
         type: GraphQLNamedType,
     ): NadelValidationInterimResult<NadelHydrationDefinition> {
-        val defaultHydration = (type as? GraphQLNamedType)?.getDefaultHydrationOrNull()
+        val defaultHydration = (type as? GraphQLNamedType)?.parseDefaultHydrationOrNull()
             ?: return NadelValidationInterimResult.Error.of(NadelMissingDefaultHydrationError(parent, virtualField))
 
         return NadelValidationInterimResult.Success.of(

--- a/lib/src/main/java/graphql/nadel/validation/NadelInstructionDefinitionParser.kt
+++ b/lib/src/main/java/graphql/nadel/validation/NadelInstructionDefinitionParser.kt
@@ -3,6 +3,7 @@ package graphql.nadel.validation
 import graphql.nadel.definition.NadelInstructionDefinition
 import graphql.nadel.definition.NadelSchemaMemberCoordinates
 import graphql.nadel.definition.coordinates
+import graphql.nadel.definition.hydration.parseDefaultHydrationOrNull
 import graphql.nadel.definition.hydration.parseHydrationDefinitions
 import graphql.nadel.definition.partition.parsePartitionOrNull
 import graphql.nadel.definition.renamed.parseRenamedOrNull
@@ -165,12 +166,16 @@ internal class NadelInstructionDefinitionParser(
                         val coordinates = element.coordinates()
                         val type = element.node
 
-                        type.parseRenamedOrNull()?.also { renamed ->
-                            definitionMap.computeIfAbsent(coordinates) { mutableListOf() }.add(renamed)
+                        val definitions by lazy {
+                            definitionMap.computeIfAbsent(coordinates) {
+                                mutableListOf()
+                            }
                         }
+
+                        type.parseRenamedOrNull()?.also(definitions::add)
+                        type.parseDefaultHydrationOrNull()?.also(definitions::add)
                         if (type.hasVirtualTypeDefinition()) {
-                            definitionMap.computeIfAbsent(coordinates) { mutableListOf() }
-                                .add(NadelVirtualTypeDefinition())
+                            definitions.add(NadelVirtualTypeDefinition())
                         }
                     }
                 }

--- a/lib/src/main/java/graphql/nadel/validation/NadelSchemaHydrationValidationError.kt
+++ b/lib/src/main/java/graphql/nadel/validation/NadelSchemaHydrationValidationError.kt
@@ -586,6 +586,48 @@ data class NadelMissingDefaultHydrationError(
     override val subject = virtualField
 }
 
+data class NadelDefaultHydrationFieldNotFoundError(
+    val type: NadelServiceSchemaElement.Type,
+    val defaultHydration: NadelDefaultHydrationDefinition,
+) : NadelSchemaValidationError {
+    override val message = run {
+        val typeName = type.overall.name
+        val field = defaultHydration.backingField.joinToString(".")
+        "Type $typeName declares @defaultHydration which references field $field that does not exist"
+    }
+
+    override val subject = type.overall
+}
+
+data class NadelDefaultHydrationIncompatibleBackingFieldTypeError(
+    val type: NadelServiceSchemaElement.Type,
+    val defaultHydration: NadelDefaultHydrationDefinition,
+    val backingField: GraphQLFieldDefinition,
+) : NadelSchemaValidationError {
+    override val message = run {
+        val typeName = type.overall.name
+        val field = defaultHydration.backingField.joinToString(".")
+        "Type $typeName declares @defaultHydration backed by $field but that field does not return $typeName"
+    }
+
+    override val subject = type.overall
+}
+
+data class NadelDefaultHydrationIdArgumentNotFoundError(
+    val type: NadelServiceSchemaElement.Type,
+    val defaultHydration: NadelDefaultHydrationDefinition,
+    val backingField: GraphQLFieldDefinition,
+) : NadelSchemaValidationError {
+    override val message = run {
+        val typeName = type.overall.name
+        val field = defaultHydration.backingField.joinToString(".")
+        val idArgument = defaultHydration.idArgument
+        "Type $typeName declares @defaultHydration backed by field $field but it is missing specified $idArgument argument"
+    }
+
+    override val subject = type.overall
+}
+
 data class NadelPolymorphicHydrationIncompatibleSourceFieldsError(
     val parentType: NadelServiceSchemaElement,
     val virtualField: GraphQLFieldDefinition,

--- a/lib/src/main/java/graphql/nadel/validation/NadelSchemaValidation.kt
+++ b/lib/src/main/java/graphql/nadel/validation/NadelSchemaValidation.kt
@@ -22,13 +22,7 @@ import graphql.schema.GraphQLSchema
 import graphql.schema.GraphQLUnionType
 
 class NadelSchemaValidation internal constructor(
-    private val fieldValidation: NadelFieldValidation,
-    private val inputValidation: NadelInputObjectValidation,
-    private val unionValidation: NadelUnionValidation,
-    private val enumValidation: NadelEnumValidation,
-    private val interfaceValidation: NadelInterfaceValidation,
-    private val namespaceValidation: NadelNamespaceValidation,
-    private val virtualTypeValidation: NadelVirtualTypeValidation,
+    private val typeValidation: NadelTypeValidation,
     private val instructionDefinitionParser: NadelInstructionDefinitionParser,
     private val hook: NadelSchemaValidationHook,
 ) {
@@ -65,16 +59,6 @@ class NadelSchemaValidation internal constructor(
             hiddenTypeNames = hiddenTypeNames,
             instructionDefinitions = instructionDefinitions,
             hook = hook,
-        )
-
-        val typeValidation = NadelTypeValidation(
-            fieldValidation = fieldValidation,
-            inputValidation = inputValidation,
-            unionValidation = unionValidation,
-            enumValidation = enumValidation,
-            interfaceValidation = interfaceValidation,
-            namespaceValidation = namespaceValidation,
-            virtualTypeValidation = virtualTypeValidation,
         )
 
         return with(context) {

--- a/lib/src/main/java/graphql/nadel/validation/NadelSchemaValidationFactory.kt
+++ b/lib/src/main/java/graphql/nadel/validation/NadelSchemaValidationFactory.kt
@@ -1,5 +1,6 @@
 package graphql.nadel.validation
 
+import graphql.nadel.validation.hydration.NadelDefaultHydrationDefinitionValidation
 import graphql.nadel.validation.hydration.NadelHydrationArgumentTypeValidation
 import graphql.nadel.validation.hydration.NadelHydrationArgumentValidation
 import graphql.nadel.validation.hydration.NadelHydrationConditionValidation
@@ -15,13 +16,16 @@ abstract class NadelSchemaValidationFactory {
         )
 
         return NadelSchemaValidation(
-            fieldValidation = fieldValidation,
-            inputValidation = inputObjectValidation,
-            unionValidation = unionValidation,
-            enumValidation = enumValidation,
-            interfaceValidation = interfaceValidation,
-            namespaceValidation = namespaceValidation,
-            virtualTypeValidation = virtualTypeValidation,
+            typeValidation = NadelTypeValidation(
+                fieldValidation = fieldValidation,
+                inputObjectValidation = inputObjectValidation,
+                unionValidation = unionValidation,
+                enumValidation = enumValidation,
+                interfaceValidation = interfaceValidation,
+                namespaceValidation = namespaceValidation,
+                virtualTypeValidation = virtualTypeValidation,
+                defaultHydrationDefinitionValidation = defaultHydrationDefinitionValidation,
+            ),
             instructionDefinitionParser = definitionParser,
             hook = hook,
         )
@@ -42,6 +46,8 @@ abstract class NadelSchemaValidationFactory {
     private val hydrationConditionValidation = NadelHydrationConditionValidation()
     private val hydrationSourceFieldValidation = NadelHydrationSourceFieldValidation()
     private val hydrationVirtualTypeValidation = NadelHydrationVirtualTypeValidation()
+
+    private val defaultHydrationDefinitionValidation = NadelDefaultHydrationDefinitionValidation()
 
     private val hydrationValidation = NadelHydrationValidation(
         argumentValidation = hydrationArgumentValidation,

--- a/lib/src/main/java/graphql/nadel/validation/hydration/NadelDefaultHydrationDefinitionValidation.kt
+++ b/lib/src/main/java/graphql/nadel/validation/hydration/NadelDefaultHydrationDefinitionValidation.kt
@@ -1,0 +1,65 @@
+package graphql.nadel.validation.hydration
+
+import graphql.nadel.definition.hydration.NadelDefaultHydrationDefinition
+import graphql.nadel.engine.util.getFieldAt
+import graphql.nadel.engine.util.unwrapAll
+import graphql.nadel.engine.util.whenType
+import graphql.nadel.validation.NadelDefaultHydrationFieldNotFoundError
+import graphql.nadel.validation.NadelDefaultHydrationIdArgumentNotFoundError
+import graphql.nadel.validation.NadelDefaultHydrationIncompatibleBackingFieldTypeError
+import graphql.nadel.validation.NadelSchemaValidationResult
+import graphql.nadel.validation.NadelServiceSchemaElement
+import graphql.nadel.validation.NadelValidationContext
+import graphql.nadel.validation.ok
+
+/**
+ * Validates a `@defaultHydration` before it's actually put to use.
+ */
+class NadelDefaultHydrationDefinitionValidation {
+    context(NadelValidationContext)
+    fun validate(type: NadelServiceSchemaElement.Type): NadelSchemaValidationResult {
+        val defaultHydration = instructionDefinitions.getDefaultHydrationOrNull(type)
+            ?: return ok()
+
+        return validate(type, defaultHydration)
+    }
+
+    context(NadelValidationContext)
+    private fun validate(
+        type: NadelServiceSchemaElement.Type,
+        defaultHydration: NadelDefaultHydrationDefinition,
+    ): NadelSchemaValidationResult {
+        val backingField = engineSchema.queryType.getFieldAt(defaultHydration.backingField)
+            ?: return NadelDefaultHydrationFieldNotFoundError(type, defaultHydration)
+
+        val backingFieldType = backingField.type.unwrapAll()
+
+        // Backing field should return the type declaring the @defaultHydration
+        // It's ok if the backing field returns an abstract type and there are other possible options
+        // We have validation elsewhere that dictates that the hydrated field type must be valid
+        val backingFieldOutputTypeValid = backingFieldType.whenType(
+            enumType = { enumType -> enumType.name == type.overall.name },
+            inputObjectType = { inputObjectType -> inputObjectType.name == type.overall.name },
+            interfaceType = { interfaceType ->
+                interfaceType.name == type.overall.name
+                    || engineSchema.getImplementations(interfaceType).contains(type.overall)
+            },
+            objectType = { objectType -> objectType.name == type.overall.name },
+            scalarType = { scalarType -> scalarType.name == type.overall.name },
+            unionType = { unionType ->
+                unionType.name == type.overall.name
+                    || unionType.types.contains(type.overall)
+            },
+        )
+
+        if (!backingFieldOutputTypeValid) {
+            return NadelDefaultHydrationIncompatibleBackingFieldTypeError(type, defaultHydration, backingField)
+        }
+
+        if (backingField.getArgument(defaultHydration.idArgument) == null) {
+            return NadelDefaultHydrationIdArgumentNotFoundError(type, defaultHydration, backingField)
+        }
+
+        return ok()
+    }
+}

--- a/lib/src/test/kotlin/graphql/nadel/validation/hydration/NadelDefaultHydrationDefinitionValidationTest.kt
+++ b/lib/src/test/kotlin/graphql/nadel/validation/hydration/NadelDefaultHydrationDefinitionValidationTest.kt
@@ -1,0 +1,220 @@
+package graphql.nadel.validation.hydration
+
+import graphql.nadel.validation.NadelDefaultHydrationIdArgumentNotFoundError
+import graphql.nadel.validation.NadelDefaultHydrationIncompatibleBackingFieldTypeError
+import graphql.nadel.validation.NadelValidationTestFixture
+import graphql.nadel.validation.util.assertSingleOfType
+import graphql.nadel.validation.validate
+import org.junit.jupiter.api.Test
+import kotlin.test.assertTrue
+
+class NadelDefaultHydrationDefinitionValidationTest {
+    @Test
+    fun `passes valid default hydration`() {
+        val fixture = NadelValidationTestFixture(
+            overallSchema = mapOf(
+                "issues" to /* language=GraphQL*/ """
+                    type Query {
+                        comments(ids: [ID!]!): [Comment]
+                    }
+                    type Comment @defaultHydration(field: "comments", idArgument: "ids", identifiedBy: "id") {
+                        id: ID!
+                    }
+                """.trimIndent(),
+            ),
+            underlyingSchema = mapOf(
+                "issues" to /* language=GraphQL*/ """
+                    type Query {
+                        comments(ids: [ID!]!): [Comment]
+                    }
+                    type Comment {
+                        id: ID!
+                    }
+                """.trimIndent(),
+            ),
+        )
+
+        // When
+        val errors = validate(fixture)
+
+        // Then
+        assertTrue(errors.map { it.message }.isEmpty())
+    }
+
+    @Test
+    fun `fails if default hydration references non existent id argument`() {
+        val fixture = NadelValidationTestFixture(
+            overallSchema = mapOf(
+                "issues" to /* language=GraphQL*/ """
+                    type Query {
+                        comments(ids: [ID!]!): [Comment]
+                    }
+                    type Comment @defaultHydration(field: "comments", idArgument: "identity", identifiedBy: "id") {
+                        id: ID!
+                    }
+                """.trimIndent(),
+            ),
+            underlyingSchema = mapOf(
+                "issues" to /* language=GraphQL*/ """
+                    type Query {
+                        comments(ids: [ID!]!): [Comment]
+                    }
+                    type Comment {
+                        id: ID!
+                    }
+                """.trimIndent(),
+            ),
+        )
+
+        // When
+        val errors = validate(fixture)
+
+        // Then
+        assertTrue(errors.map { it.message }.isNotEmpty())
+
+        val error = errors.assertSingleOfType<NadelDefaultHydrationIdArgumentNotFoundError>()
+        assertTrue(error.backingField.name == "comments")
+        assertTrue(error.defaultHydration.idArgument == "identity")
+    }
+
+    @Test
+    fun `fails if backing field does not return compatible type`() {
+        val fixture = NadelValidationTestFixture(
+            overallSchema = mapOf(
+                "issues" to /* language=GraphQL*/ """
+                    type Query {
+                        comments(ids: [ID!]!): [Comment]
+                        issues(ids: [ID!]!): [Issue]
+                    }
+                    type Comment @defaultHydration(field: "issues", idArgument: "ids", identifiedBy: "id") {
+                        id: ID!
+                    }
+                    type Issue {
+                        id: ID!
+                    }
+                """.trimIndent(),
+            ),
+            underlyingSchema = mapOf(
+                "issues" to /* language=GraphQL*/ """
+                    type Query {
+                        comments(ids: [ID!]!): [Comment]
+                        issues(ids: [ID!]!): [Issue]
+                    }
+                    type Comment {
+                        id: ID!
+                    }
+                    type Issue {
+                        id: ID!
+                    }
+                """.trimIndent(),
+            ),
+        )
+
+        // When
+        val errors = validate(fixture)
+
+        // Then
+        assertTrue(errors.map { it.message }.isNotEmpty())
+
+        val error = errors.assertSingleOfType<NadelDefaultHydrationIncompatibleBackingFieldTypeError>()
+        assertTrue(error.type.overall.name == "Comment")
+        assertTrue(error.backingField.name == "issues")
+    }
+
+    /**
+     * This is a weird one. Technically it's a valid hydration. We allow it.
+     *
+     * There is validation elsewhere that says the `@idHydrated` field must return all implementations of the interface
+     */
+    @Test
+    fun `passes if backing field returns interface that declaring type implements`() {
+        val fixture = NadelValidationTestFixture(
+            overallSchema = mapOf(
+                "issues" to /* language=GraphQL*/ """
+                    type Query {
+                        comments(ids: [ID!]!): [Comment]
+                        things(ids: [ID!]!): [Thing]
+                    }
+                    interface Thing {
+                        id: ID!
+                    }
+                    type Comment implements Thing @defaultHydration(field: "things", idArgument: "ids", identifiedBy: "id") {
+                        id: ID!
+                    }
+                    type Issue implements Thing {
+                        id: ID!
+                    }
+                """.trimIndent(),
+            ),
+            underlyingSchema = mapOf(
+                "issues" to /* language=GraphQL*/ """
+                    type Query {
+                        comments(ids: [ID!]!): [Comment]
+                        things(ids: [ID!]!): [Thing]
+                    }
+                    interface Thing {
+                        id: ID!
+                    }
+                    type Comment implements Thing {
+                        id: ID!
+                    }
+                    type Issue implements Thing {
+                        id: ID!
+                    }
+                """.trimIndent(),
+            ),
+        )
+
+        // When
+        val errors = validate(fixture)
+
+        // Then
+        assertTrue(errors.map { it.message }.isEmpty())
+    }
+    /**
+     * This is a weird one. Technically it's a valid hydration. We allow it.
+     *
+     * There is validation elsewhere that says the `@idHydrated` field must return all members of the union
+     */
+    @Test
+    fun `passes if backing field returns union that the declaring type is part of`() {
+        val fixture = NadelValidationTestFixture(
+            overallSchema = mapOf(
+                "issues" to /* language=GraphQL*/ """
+                    type Query {
+                        comments(ids: [ID!]!): [Comment]
+                        things(ids: [ID!]!): [Thing]
+                    }
+                    union Thing = Comment | Issue
+                    type Comment @defaultHydration(field: "things", idArgument: "ids", identifiedBy: "id") {
+                        id: ID!
+                    }
+                    type Issue {
+                        id: ID!
+                    }
+                """.trimIndent(),
+            ),
+            underlyingSchema = mapOf(
+                "issues" to /* language=GraphQL*/ """
+                    type Query {
+                        comments(ids: [ID!]!): [Comment]
+                        things(ids: [ID!]!): [Thing]
+                    }
+                    union Thing = Comment | Issue
+                    type Comment {
+                        id: ID!
+                    }
+                    type Issue {
+                        id: ID!
+                    }
+                """.trimIndent(),
+            ),
+        )
+
+        // When
+        val errors = validate(fixture)
+
+        // Then
+        assertTrue(errors.map { it.message }.isEmpty())
+    }
+}


### PR DESCRIPTION
Pending #644 

This validation focuses on the `@defaultHydration` itself.

Previously you could define invalid ones, and it would still be caught when hydration validation ran. This change adds an earlier layer of validation when you define it before a `@idHydrated` consumes it.