### PR TITLE
Fix ID hydration for User types in union

### DIFF
--- a/lib/src/main/java/graphql/nadel/definition/hydration/NadelDefaultHydrationDefinition.kt
+++ b/lib/src/main/java/graphql/nadel/definition/hydration/NadelDefaultHydrationDefinition.kt
@@ -56,6 +56,30 @@ class NadelDefaultHydrationDefinition(
     val timeout: Int
         get() = appliedDirective.getArgument(Keyword.timeout).getValue()
 
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as NadelDefaultHydrationDefinition
+
+        if (backingField != other.backingField) return false
+        if (identifiedBy != other.identifiedBy) return false
+        if (idArgument != other.idArgument) return false
+        if (batchSize != other.batchSize) return false
+        if (timeout != other.timeout) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = backingField.hashCode()
+        result = 31 * result + (identifiedBy?.hashCode() ?: 0)
+        result = 31 * result + idArgument.hashCode()
+        result = 31 * result + batchSize
+        result = 31 * result + timeout
+        return result
+    }
+
     internal object Keyword {
         const val defaultHydration = "defaultHydration"
         const val field = "field"

--- a/lib/src/main/java/graphql/nadel/definition/hydration/NadelIdHydrationDefinition.kt
+++ b/lib/src/main/java/graphql/nadel/definition/hydration/NadelIdHydrationDefinition.kt
@@ -44,6 +44,24 @@ class NadelIdHydrationDefinition(
     val identifiedBy: String?
         get() = appliedDirective.getArgument(Keyword.identifiedBy).getValue()
 
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as NadelIdHydrationDefinition
+
+        if (idField != other.idField) return false
+        if (identifiedBy != other.identifiedBy) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = idField.hashCode()
+        result = 31 * result + (identifiedBy?.hashCode() ?: 0)
+        return result
+    }
+
     internal object Keyword {
         const val idHydrated = "idHydrated"
         const val idField = "idField"

--- a/lib/src/main/java/graphql/nadel/validation/NadelSchemaHydrationValidationError.kt
+++ b/lib/src/main/java/graphql/nadel/validation/NadelSchemaHydrationValidationError.kt
@@ -586,6 +586,22 @@ data class NadelMissingDefaultHydrationError(
     override val subject = virtualField
 }
 
+data class NadelAmbiguousUnionDefaultHydrationError(
+    val parentType: GraphQLFieldsContainer,
+    val virtualField: GraphQLFieldDefinition,
+    val backingField: List<String>,
+) : NadelSchemaValidationError {
+    override val message = run {
+        val backingType = virtualField.type.unwrapAll().name
+        val virtualField = makeFieldCoordinates(parentType.name, virtualField.name)
+        val defaultHydration = NadelDefaultHydrationDefinition.directiveDefinition.name
+        val idHydrated = NadelIdHydrationDefinition.directiveDefinition.name
+        "Field $virtualField tried to use @$idHydrated but its output union $backingType contains multiple types backed by $backingField with different @$defaultHydration configurations"
+    }
+
+    override val subject = virtualField
+}
+
 data class NadelDefaultHydrationFieldNotFoundError(
     val type: NadelServiceSchemaElement.Type,
     val defaultHydration: NadelDefaultHydrationDefinition,

--- a/test/src/test/kotlin/graphql/nadel/tests/next/SimpleClassNameTypeResolver.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/next/SimpleClassNameTypeResolver.kt
@@ -1,0 +1,11 @@
+package graphql.nadel.tests.next
+
+import graphql.TypeResolutionEnvironment
+import graphql.schema.GraphQLObjectType
+import graphql.schema.TypeResolver
+
+object SimpleClassNameTypeResolver : TypeResolver {
+    override fun getType(env: TypeResolutionEnvironment): GraphQLObjectType {
+        return env.schema.getObjectType(env.getObject<Any>().javaClass.simpleName)
+    }
+}

--- a/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/hydration/HydrationIdentifiedByRenamedFieldTest.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/hydration/HydrationIdentifiedByRenamedFieldTest.kt
@@ -1,0 +1,68 @@
+package graphql.nadel.tests.next.fixtures.hydration
+
+import graphql.nadel.tests.next.NadelIntegrationTest
+
+class HydrationIdentifiedByRenamedFieldTest : NadelIntegrationTest(
+    query = """
+        {
+          me {
+            friends {
+              name
+            }
+          }
+        }
+    """.trimIndent(),
+    services = listOf(
+        Service(
+            name = "myService",
+            overallSchema = """
+                type Query {
+                  me: Me
+                  users(ids: [ID!]!): [User]
+                }
+                type Me {
+                  friendIds: [ID!] @hidden
+                  friends: [User] @idHydrated(idField: "friendIds")
+                }
+                type User @defaultHydration(field: "users", idArgument: "ids", identifiedBy: "id", batchSize: 90) {
+                   id: ID @renamed(from: "canonicalAccountId")
+                   name: String
+                }
+            """.trimIndent(),
+            runtimeWiring = { wiring ->
+                data class Me(
+                    val friendIds: List<String>,
+                )
+
+                data class User(
+                    val canonicalAccountId: String,
+                    val name: String,
+                )
+
+                val usersByIds = listOf(
+                    User(
+                        canonicalAccountId = "i",
+                        name = "Imagine",
+                    ),
+                    User(
+                        canonicalAccountId = "2i",
+                        name = "Imagine 2 friends",
+                    ),
+                ).associateBy { it.canonicalAccountId }
+
+                wiring
+                    .type("Query") { type ->
+                        type
+                            .dataFetcher("me") { env ->
+                                Me(
+                                    friendIds = listOf("i", "2i"),
+                                )
+                            }
+                            .dataFetcher("users") { env ->
+                                env.getArgument<List<String>>("ids")?.map(usersByIds::get)
+                            }
+                    }
+            },
+        ),
+    ),
+)

--- a/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/hydration/HydrationIdentifiedByRenamedFieldTestSnapshot.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/hydration/HydrationIdentifiedByRenamedFieldTestSnapshot.kt
@@ -1,0 +1,124 @@
+// @formatter:off
+package graphql.nadel.tests.next.fixtures.hydration
+
+import graphql.nadel.tests.next.ExpectedNadelResult
+import graphql.nadel.tests.next.ExpectedServiceCall
+import graphql.nadel.tests.next.TestSnapshot
+import graphql.nadel.tests.next.listOfJsonStrings
+import kotlin.Suppress
+import kotlin.collections.List
+import kotlin.collections.listOf
+
+private suspend fun main() {
+    graphql.nadel.tests.next.update<HydrationIdentifiedByRenamedFieldTest>()
+}
+
+/**
+ * This class is generated. Do NOT modify.
+ *
+ * Refer to [graphql.nadel.tests.next.UpdateTestSnapshots
+ */
+@Suppress("unused")
+public class HydrationIdentifiedByRenamedFieldTestSnapshot : TestSnapshot() {
+    override val calls: List<ExpectedServiceCall> = listOf(
+            ExpectedServiceCall(
+                service = "myService",
+                query = """
+                | {
+                |   me {
+                |     batch_hydration__friends__friendIds: friendIds
+                |     __typename__batch_hydration__friends: __typename
+                |   }
+                | }
+                """.trimMargin(),
+                variables = " {}",
+                result = """
+                | {
+                |   "data": {
+                |     "me": {
+                |       "batch_hydration__friends__friendIds": [
+                |         "i",
+                |         "2i"
+                |       ],
+                |       "__typename__batch_hydration__friends": "Me"
+                |     }
+                |   }
+                | }
+                """.trimMargin(),
+                delayedResults = listOfJsonStrings(
+                ),
+            ),
+            ExpectedServiceCall(
+                service = "myService",
+                query = """
+                | {
+                |   users(ids: ["i", "2i"]) {
+                |     name
+                |     rename__batch_hydration__friends__id__canonicalAccountId: canonicalAccountId
+                |     __typename__rename__batch_hydration__friends__id: __typename
+                |   }
+                | }
+                """.trimMargin(),
+                variables = " {}",
+                result = """
+                | {
+                |   "data": {
+                |     "users": [
+                |       {
+                |         "name": "Imagine",
+                |         "rename__batch_hydration__friends__id__canonicalAccountId": "i",
+                |         "__typename__rename__batch_hydration__friends__id": "User"
+                |       },
+                |       {
+                |         "name": "Imagine 2 friends",
+                |         "rename__batch_hydration__friends__id__canonicalAccountId": "2i",
+                |         "__typename__rename__batch_hydration__friends__id": "User"
+                |       }
+                |     ]
+                |   }
+                | }
+                """.trimMargin(),
+                delayedResults = listOfJsonStrings(
+                ),
+            ),
+        )
+
+    /**
+     * ```json
+     * {
+     *   "data": {
+     *     "me": {
+     *       "friends": [
+     *         {
+     *           "name": "Imagine"
+     *         },
+     *         {
+     *           "name": "Imagine 2 friends"
+     *         }
+     *       ]
+     *     }
+     *   }
+     * }
+     * ```
+     */
+    override val result: ExpectedNadelResult = ExpectedNadelResult(
+            result = """
+            | {
+            |   "data": {
+            |     "me": {
+            |       "friends": [
+            |         {
+            |           "name": "Imagine"
+            |         },
+            |         {
+            |           "name": "Imagine 2 friends"
+            |         }
+            |       ]
+            |     }
+            |   }
+            | }
+            """.trimMargin(),
+            delayedResults = listOfJsonStrings(
+            ),
+        )
+}

--- a/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/hydration/HydrationUnionDuplicateDefaultHydratedTest.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/hydration/HydrationUnionDuplicateDefaultHydratedTest.kt
@@ -1,0 +1,81 @@
+package graphql.nadel.tests.next.fixtures.hydration
+
+import graphql.nadel.tests.next.NadelIntegrationTest
+import graphql.nadel.tests.next.SimpleClassNameTypeResolver
+
+class HydrationUnionDuplicateDefaultHydratedTest : NadelIntegrationTest(
+    query = """
+        {
+          issues {
+            user {
+              __typename
+            }
+          }
+        }
+    """.trimIndent(),
+    services = listOf(
+        Service(
+            name = "myService",
+            overallSchema = """
+                type Query {
+                  issues: [Issue]
+                  users(ids: [ID!]!): [User]
+                }
+                type Issue {
+                  userId: ID @hidden
+                  user: IssueUser @idHydrated(idField: "userId")
+                }
+                union IssueUser = CustomerUser | AtlassianAccountUser | AppUser
+                interface User {
+                  id: ID!
+                }
+                type CustomerUser implements User @defaultHydration(field: "users", idArgument: "ids") {
+                  id: ID!
+                }
+                type AtlassianAccountUser implements User @defaultHydration(field: "users", idArgument: "ids") {
+                  id: ID!
+                }
+                type AppUser implements User @defaultHydration(field: "users", idArgument: "ids") {
+                  id: ID!
+                }
+            """.trimIndent(),
+            runtimeWiring = { wiring ->
+                wiring
+                    .type("Query") { type ->
+                        data class Issue(val userId: String)
+                        data class AtlassianAccountUser(override val id: String) : User
+                        data class AppUser(override val id: String) : User
+                        data class CustomerUser(override val id: String) : User
+
+                        val usersById: Map<String, User> = listOf(
+                            AtlassianAccountUser(id = "aoeu"),
+                            CustomerUser(id = "asdf"),
+                            AppUser(id = "bot"),
+                        ).associateBy { it.id }
+
+                        type
+                            .dataFetcher("issues") { env ->
+                                listOf(
+                                    Issue(userId = "aoeu"),
+                                    Issue(userId = "asdf"),
+                                    Issue(userId = "wow"),
+                                )
+                            }
+                            .dataFetcher("users") { env ->
+                                env.getArgument<List<String>>("ids")?.map(usersById::get)
+                            }
+                    }
+                    .type("User") { type ->
+                        type.typeResolver(SimpleClassNameTypeResolver)
+                    }
+                    .type("IssueUser") { type ->
+                        type.typeResolver(SimpleClassNameTypeResolver)
+                    }
+            },
+        ),
+    ),
+) {
+    interface User {
+        val id: String
+    }
+}

--- a/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/hydration/HydrationUnionDuplicateDefaultHydratedTestSnapshot.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/hydration/HydrationUnionDuplicateDefaultHydratedTestSnapshot.kt
@@ -1,0 +1,139 @@
+// @formatter:off
+package graphql.nadel.tests.next.fixtures.hydration
+
+import graphql.nadel.tests.next.ExpectedNadelResult
+import graphql.nadel.tests.next.ExpectedServiceCall
+import graphql.nadel.tests.next.TestSnapshot
+import graphql.nadel.tests.next.listOfJsonStrings
+import kotlin.Suppress
+import kotlin.collections.List
+import kotlin.collections.listOf
+
+private suspend fun main() {
+    graphql.nadel.tests.next.update<HydrationUnionDuplicateDefaultHydratedTest>()
+}
+
+/**
+ * This class is generated. Do NOT modify.
+ *
+ * Refer to [graphql.nadel.tests.next.UpdateTestSnapshots]
+ */
+@Suppress("unused")
+public class HydrationUnionDuplicateDefaultHydratedTestSnapshot : TestSnapshot() {
+    override val calls: List<ExpectedServiceCall> = listOf(
+            ExpectedServiceCall(
+                service = "myService",
+                query = """
+                | {
+                |   issues {
+                |     __typename__batch_hydration__user: __typename
+                |     batch_hydration__user__userId: userId
+                |   }
+                | }
+                """.trimMargin(),
+                variables = "{}",
+                result = """
+                | {
+                |   "data": {
+                |     "issues": [
+                |       {
+                |         "batch_hydration__user__userId": "aoeu",
+                |         "__typename__batch_hydration__user": "Issue"
+                |       },
+                |       {
+                |         "batch_hydration__user__userId": "asdf",
+                |         "__typename__batch_hydration__user": "Issue"
+                |       },
+                |       {
+                |         "batch_hydration__user__userId": "wow",
+                |         "__typename__batch_hydration__user": "Issue"
+                |       }
+                |     ]
+                |   }
+                | }
+                """.trimMargin(),
+                delayedResults = listOfJsonStrings(
+                ),
+            ),
+            ExpectedServiceCall(
+                service = "myService",
+                query = """
+                | {
+                |   users(ids: ["aoeu", "asdf", "wow"]) {
+                |     __typename
+                |     batch_hydration__user__id: id
+                |   }
+                | }
+                """.trimMargin(),
+                variables = "{}",
+                result = """
+                | {
+                |   "data": {
+                |     "users": [
+                |       {
+                |         "__typename": "AtlassianAccountUser",
+                |         "batch_hydration__user__id": "aoeu"
+                |       },
+                |       {
+                |         "__typename": "CustomerUser",
+                |         "batch_hydration__user__id": "asdf"
+                |       },
+                |       null
+                |     ]
+                |   }
+                | }
+                """.trimMargin(),
+                delayedResults = listOfJsonStrings(
+                ),
+            ),
+        )
+
+    /**
+     * ```json
+     * {
+     *   "data": {
+     *     "issues": [
+     *       {
+     *         "user": {
+     *           "__typename": "AtlassianAccountUser"
+     *         }
+     *       },
+     *       {
+     *         "user": {
+     *           "__typename": "CustomerUser"
+     *         }
+     *       },
+     *       {
+     *         "user": null
+     *       }
+     *     ]
+     *   }
+     * }
+     * ```
+     */
+    override val result: ExpectedNadelResult = ExpectedNadelResult(
+            result = """
+            | {
+            |   "data": {
+            |     "issues": [
+            |       {
+            |         "user": {
+            |           "__typename": "AtlassianAccountUser"
+            |         }
+            |       },
+            |       {
+            |         "user": {
+            |           "__typename": "CustomerUser"
+            |         }
+            |       },
+            |       {
+            |         "user": null
+            |       }
+            |     ]
+            |   }
+            | }
+            """.trimMargin(),
+            delayedResults = listOfJsonStrings(
+            ),
+        )
+}


### PR DESCRIPTION
So the issue arises when an abstract type `User` is fulfilled by one field `users(ids: [ID!]!): [User]` and its concrete implementations are referenced in a union e.g.

```graphql
type Query {
  users(ids: [ID!]!): [User]
}

type Issue {
  userId: ID @hidden
  user: IssueUser @idHydrated(idField: "userId")
}
union IssueUser = CustomerUser | AtlassianAccountUser | AppUser

interface User {
  id: ID!
}
type CustomerUser implements User @defaultHydration(field: "users", idArgument: "ids") {
  id: ID!
}
type AtlassianAccountUser implements User @defaultHydration(field: "users", idArgument: "ids") {
  id: ID!
}
type AppUser implements User @defaultHydration(field: "users", idArgument: "ids") {
  id: ID!
}
```

In the previous implementation this would result in three hydration definitions on `Issue.user` but with this fix now it's deduplicated.

There's also validation that ensures that types backed by the same field have the same `@defaultHydration` config, otherwise the hydration configuration would be ambiguous.