### PR TITLE
Split publish from build + test so we can more easily read logs

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -32,8 +32,10 @@ jobs:
         with:
           output-modes: environment
 
-      - name: build test and publish
-        run: ./gradlew assemble && ./gradlew check --info && ./gradlew artifactoryPublish -x check --info
+      - name: Build and Test
+        run: ./gradlew assemble && ./gradlew check --info
+      - name: Publish
+        run: ./gradlew artifactoryPublish -x check --info
       - uses: actions/upload-artifact@v4
         with:
           name: my-artifact

--- a/lib/src/main/java/graphql/nadel/definition/coordinates/NadelInputCoordinates.kt
+++ b/lib/src/main/java/graphql/nadel/definition/coordinates/NadelInputCoordinates.kt
@@ -1,3 +1,3 @@
 package graphql.nadel.definition.coordinates
 
-sealed interface NadelInputCoordinates : NadelSchemaMemberCoordinates
+sealed interface NadelInputCoordinates : NadelChildCoordinates


### PR DESCRIPTION
This will make it easier for us to read the Publish logs in Github UI since individual steps can be collapsed.