### PR TITLE
add finalize to NadelTransform

### DIFF
--- a/lib/src/main/java/graphql/nadel/engine/transform/NadelTransform.kt
+++ b/lib/src/main/java/graphql/nadel/engine/transform/NadelTransform.kt
@@ -85,6 +85,24 @@ interface NadelTransform<State : Any> {
         state: State,
         nodes: JsonNodes,
     ): List<NadelResultInstruction>
+
+    /**
+     * Called once after all other functions of a transform ran on all fields in the query.
+     * Override this function to perform cleanup or finalization tasks.
+     * This method is optional for implementing classes.
+     *
+     * @param states - list with all [State] objects created during the transform execution
+     */
+    suspend fun finalize(
+        executionContext: NadelExecutionContext,
+        serviceExecutionContext: NadelServiceExecutionContext,
+        executionBlueprint: NadelOverallExecutionBlueprint,
+        service: Service,
+        result: ServiceExecutionResult,
+        states: List<State>,
+        nodes: JsonNodes,
+    ) {
+    }
 }
 
 data class NadelTransformFieldResult(

--- a/lib/src/main/java/graphql/nadel/engine/transform/NadelTransformJavaCompat.kt
+++ b/lib/src/main/java/graphql/nadel/engine/transform/NadelTransformJavaCompat.kt
@@ -65,6 +65,21 @@ interface NadelTransformJavaCompat<State : Any> {
         nodes: JsonNodes,
     ): CompletableFuture<List<NadelResultInstruction>>
 
+    /**
+     * See [NadelTransform.finalize]
+     */
+    fun finalize(
+        executionContext: NadelExecutionContext,
+        serviceExecutionContext: NadelServiceExecutionContext,
+        executionBlueprint: NadelOverallExecutionBlueprint,
+        service: Service,
+        result: ServiceExecutionResult,
+        states: List<State>,
+        nodes: JsonNodes,
+    ): CompletableFuture<Void> {
+        return CompletableFuture.completedFuture(null)
+    }
+
     companion object {
         @JvmStatic
         fun <State : Any> create(compat: NadelTransformJavaCompat<State>): NadelTransform<State> {
@@ -136,6 +151,26 @@ interface NadelTransformJavaCompat<State : Any> {
                         underlyingParentField = underlyingParentField,
                         result = result,
                         state = state,
+                        nodes = nodes,
+                    ).asDeferred().await()
+                }
+
+                override suspend fun finalize(
+                    executionContext: NadelExecutionContext,
+                    serviceExecutionContext: NadelServiceExecutionContext,
+                    executionBlueprint: NadelOverallExecutionBlueprint,
+                    service: Service,
+                    result: ServiceExecutionResult,
+                    states: List<State>,
+                    nodes: JsonNodes,
+                ) {
+                    compat.finalize(
+                        executionContext = executionContext,
+                        serviceExecutionContext = serviceExecutionContext,
+                        executionBlueprint = executionBlueprint,
+                        service = service,
+                        result = result,
+                        states = states,
                         nodes = nodes,
                     ).asDeferred().await()
                 }

--- a/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/execution/ServiceExecutionContextTestSnapshot.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/execution/ServiceExecutionContextTestSnapshot.kt
@@ -5,9 +5,6 @@ import graphql.nadel.tests.next.ExpectedNadelResult
 import graphql.nadel.tests.next.ExpectedServiceCall
 import graphql.nadel.tests.next.TestSnapshot
 import graphql.nadel.tests.next.listOfJsonStrings
-import kotlin.Suppress
-import kotlin.collections.List
-import kotlin.collections.listOf
 
 private suspend fun main() {
     graphql.nadel.tests.next.update<ServiceExecutionContextTest>()
@@ -16,10 +13,9 @@ private suspend fun main() {
 /**
  * This class is generated. Do NOT modify.
  *
- * Refer to [graphql.nadel.tests.next.UpdateTestSnapshots
+ * Refer to [graphql.nadel.tests.next.UpdateTestSnapshots]
  */
-@Suppress("unused")
-public class ServiceExecutionContextTestSnapshot : TestSnapshot() {
+@Suppress("unused") class ServiceExecutionContextTestSnapshot : TestSnapshot() {
     override val calls: List<ExpectedServiceCall> = listOf(
             ExpectedServiceCall(
                 service = "monolith",
@@ -70,8 +66,8 @@ public class ServiceExecutionContextTestSnapshot : TestSnapshot() {
                 query = """
                 | {
                 |   me {
-                |     hydration__lastWorkedOn__lastWorkedOnId: lastWorkedOnId
                 |     __typename__hydration__lastWorkedOn: __typename
+                |     hydration__lastWorkedOn__lastWorkedOnId: lastWorkedOnId
                 |   }
                 | }
                 """.trimMargin(),


### PR DESCRIPTION
Please make sure you consider the following:

- [ ] Add tests that use __typename in queries
- [ ] Does this change work with all nadel transformations (rename, type rename, hydration, etc)? Add tests for this.
- [ ] Is it worth using hints for this change in order to be able to enable a percentage rollout?
- [ ] Do we need to add integration tests for this change in the graphql gateway?
- [ ] Do we need a pollinator check for this?
