### PR TITLE
Schema definition transformer

### DIFF
--- a/lib/src/main/java/graphql/nadel/NadelSchemas.kt
+++ b/lib/src/main/java/graphql/nadel/NadelSchemas.kt
@@ -1,5 +1,6 @@
 package graphql.nadel
 
+import graphql.nadel.schema.NadelSchemaDefinitionTransformationHook
 import graphql.nadel.schema.NeverWiringFactory
 import graphql.nadel.schema.OverallSchemaGenerator
 import graphql.nadel.schema.SchemaTransformationHook
@@ -23,10 +24,11 @@ data class NadelSchemas(
 
     class Builder {
         internal var schemaTransformationHook: SchemaTransformationHook = SchemaTransformationHook.Identity
+        internal var schemaDefinitionTransformationHook: NadelSchemaDefinitionTransformationHook =
+            NadelSchemaDefinitionTransformationHook.Identity
 
         internal var overallWiringFactory: WiringFactory = NeverWiringFactory()
         internal var underlyingWiringFactory: WiringFactory = NeverWiringFactory()
-
 
         internal var serviceExecutionFactory: ServiceExecutionFactory? = null
 
@@ -45,6 +47,10 @@ data class NadelSchemas(
 
         fun schemaTransformationHook(value: SchemaTransformationHook): Builder = also {
             schemaTransformationHook = value
+        }
+
+        fun schemaDefinitionTransformationHook(value: NadelSchemaDefinitionTransformationHook): Builder = also {
+            schemaDefinitionTransformationHook = value
         }
 
         fun overallWiringFactory(value: WiringFactory): Builder = also {
@@ -162,10 +168,12 @@ data class NadelSchemas(
             // Combine readers & type defs
             val readersToTypeDefs = underlyingSchemaReaders
                 .mapValues { (_, reader) ->
-                    SchemaUtil.parseTypeDefinitionRegistry(
-                        reader,
-                        captureSourceLocation = captureSourceLocation,
-                    )
+                    reader.use {
+                        SchemaUtil.parseTypeDefinitionRegistry(
+                            reader,
+                            captureSourceLocation = captureSourceLocation,
+                        )
+                    }
                 }
             val resolvedUnderlyingTypeDefs = readersToTypeDefs + underlyingTypeDefs
 
@@ -203,10 +211,12 @@ data class NadelSchemas(
             val underlyingSchemaGenerator = UnderlyingSchemaGenerator()
 
             return builder.overallSchemaReaders.map { (serviceName, reader) ->
-                val schemaDefinitions = SchemaUtil.parseSchemaDefinitions(
-                    reader,
-                    captureSourceLocation = captureSourceLocation,
-                )
+                val schemaDefinitions = reader.use {
+                    SchemaUtil.parseSchemaDefinitions(
+                        reader,
+                        captureSourceLocation = captureSourceLocation,
+                    )
+                }
                 val typeDefinitionRegistry = NadelTypeDefinitionRegistry.from(schemaDefinitions)
 
                 // Builder should enforce non-null entry
@@ -227,7 +237,8 @@ data class NadelSchemas(
             val serviceRegistries = services.map(Service::definitionRegistry)
             val schema = overallSchemaGenerator.buildOverallSchema(
                 serviceRegistries,
-                builder.overallWiringFactory
+                builder.overallWiringFactory,
+                builder.schemaDefinitionTransformationHook,
             )
             val newSchema = builder.schemaTransformationHook.apply(schema, services)
 
@@ -240,4 +251,3 @@ data class NadelSchemas(
         }
     }
 }
-

--- a/lib/src/main/java/graphql/nadel/schema/NadelFieldDefinitionVisibilityTransformation.kt
+++ b/lib/src/main/java/graphql/nadel/schema/NadelFieldDefinitionVisibilityTransformation.kt
@@ -15,6 +15,9 @@ import graphql.schema.idl.DirectiveInfo
 import graphql.schema.idl.ScalarInfo
 
 fun interface NadelFieldDefinitionVisibilityTransformationPredicate {
+    /**
+     * @return `true` to keep field and `false` to delete
+     */
     operator fun invoke(
         parent: ImplementingTypeDefinition<*>,
         field: FieldDefinition,

--- a/lib/src/main/java/graphql/nadel/schema/NadelFieldDefinitionVisibilityTransformation.kt
+++ b/lib/src/main/java/graphql/nadel/schema/NadelFieldDefinitionVisibilityTransformation.kt
@@ -1,0 +1,237 @@
+package graphql.nadel.schema
+
+import graphql.language.FieldDefinition
+import graphql.language.ImplementingTypeDefinition
+import graphql.language.InterfaceTypeDefinition
+import graphql.language.InterfaceTypeExtensionDefinition
+import graphql.language.ObjectTypeDefinition
+import graphql.language.ObjectTypeExtensionDefinition
+import graphql.nadel.NadelOperationKind
+import graphql.nadel.engine.util.unwrapAll
+import graphql.nadel.util.AnyImplementingTypeDefinition
+import graphql.nadel.util.AnyNamedNode
+import graphql.nadel.util.AnySDLDefinition
+import graphql.schema.idl.DirectiveInfo
+import graphql.schema.idl.ScalarInfo
+
+fun interface NadelFieldDefinitionVisibilityTransformationPredicate {
+    operator fun invoke(
+        parent: ImplementingTypeDefinition<*>,
+        field: FieldDefinition,
+    ): Boolean
+}
+
+class NadelFieldDefinitionVisibilityTransformation(
+    val fieldPredicate: NadelFieldDefinitionVisibilityTransformationPredicate,
+) : NadelSchemaDefinitionTransformationHook {
+    override fun apply(definitions: List<AnySDLDefinition>): List<AnySDLDefinition> {
+        return deleteFields(definitions)
+    }
+
+    fun deleteFields(definitions: List<AnySDLDefinition>): List<AnySDLDefinition> {
+        val newDefinitions = definitions
+            .map { definition ->
+                when (definition) {
+                    is InterfaceTypeExtensionDefinition -> transformExtensionType(definition)
+                    is InterfaceTypeDefinition -> transformType(definition)
+                    is ObjectTypeExtensionDefinition -> transformExtensionType(definition)
+                    is ObjectTypeDefinition -> transformType(definition)
+                    else -> definition
+                }
+            }
+
+        val observedBeforeTransform = getStronglyReferencedTypes(definitions)
+        val observedAfterTransform = getStronglyReferencedTypes(newDefinitions)
+
+        return newDefinitions
+            .filter { definition ->
+                if (definition is AnyNamedNode) {
+                    if (definition.name in observedBeforeTransform) {
+                        definition.name in observedAfterTransform
+                    } else {
+                        true
+                    }
+                } else {
+                    true
+                }
+            }
+    }
+
+    fun transformExtensionType(definition: InterfaceTypeExtensionDefinition): InterfaceTypeExtensionDefinition {
+        val newFields = filterFields(definition)
+        if (newFields.size == definition.fieldDefinitions.size) {
+            return definition
+        }
+
+        return definition.transformExtension { builder ->
+            builder.definitions(newFields)
+        }
+    }
+
+    fun transformType(definition: InterfaceTypeDefinition): InterfaceTypeDefinition {
+        val newFields = filterFields(definition)
+        if (newFields.size == definition.fieldDefinitions.size) {
+            return definition
+        }
+
+        return definition.transform { builder ->
+            builder.definitions(newFields)
+        }
+    }
+
+    fun transformExtensionType(definition: ObjectTypeExtensionDefinition): ObjectTypeExtensionDefinition {
+        val newFields = filterFields(definition)
+        if (newFields.size == definition.fieldDefinitions.size) {
+            return definition
+        }
+
+        return definition.transformExtension { builder ->
+            builder.fieldDefinitions(newFields)
+        }
+    }
+
+    fun transformType(definition: ObjectTypeDefinition): ObjectTypeDefinition {
+        val newFields = filterFields(definition)
+        if (newFields.size == definition.fieldDefinitions.size) {
+            return definition
+        }
+
+        return definition.transform { builder ->
+            builder.fieldDefinitions(newFields)
+        }
+    }
+
+    fun filterFields(
+        parent: ImplementingTypeDefinition<*>,
+    ): List<FieldDefinition> {
+        return parent.fieldDefinitions
+            .filter { field ->
+                fieldPredicate(parent, field)
+            }
+    }
+
+    fun getStronglyReferencedTypes(types: List<AnySDLDefinition>): Set<String> {
+        val typesByName = types
+            .groupBy {
+                (it as AnyNamedNode).name
+            }
+
+        val typeQueue = NadelOperationKind.entries
+            .asSequence()
+            .filter { it.name in typesByName }
+            .mapTo(mutableListOf()) { it.name }
+
+        val typeReferences = mutableSetOf<String>()
+
+        while (typeQueue.isNotEmpty()) {
+            // Exhaust queue
+            while (typeQueue.isNotEmpty()) {
+                val typeName = typeQueue.removeLast()
+                if (ScalarInfo.isGraphqlSpecifiedScalar(typeName) || DirectiveInfo.isGraphqlSpecifiedDirective(typeName)) {
+                    continue
+                }
+
+                val types = typesByName[typeName] ?: throw NullPointerException(typeName)
+                collectTypeReferences(types) { typeReference ->
+                    if (typeReference !in typeReferences) {
+                        typeReferences.add(typeReference)
+                        typeQueue.add(typeReference)
+                    }
+                }
+            }
+
+            // Populate queue up with interface implementations
+            types.forEach { type ->
+                if (type is AnyImplementingTypeDefinition) {
+                    if (type.name !in typeReferences) {
+                        if (type.implements.any { it.unwrapAll().name in typeReferences }) {
+                            typeReferences.add(type.name)
+                            typeQueue.add(type.name)
+                        }
+                    }
+                }
+            }
+        }
+
+        return typeReferences
+    }
+
+    private fun collectTypeReferences(
+        type: List<AnySDLDefinition>,
+        onTypeReferenced: (String) -> Unit,
+    ) {
+        NadelSchemaDefinitionTraverser()
+            .traverse(
+                roots = type
+                    .asSequence()
+                    .mapNotNull(NadelSchemaDefinitionTraverserElement::from)
+                    .asIterable(),
+                object : NadelSchemaDefinitionTraverserVisitor {
+                    override fun visitGraphQLArgument(element: NadelSchemaDefinitionTraverserElement.Argument): Boolean {
+                        return true
+                    }
+
+                    override fun visitGraphQLUnionType(element: NadelSchemaDefinitionTraverserElement.UnionType): Boolean {
+                        onTypeReferenced(element.node.name)
+                        return true
+                    }
+
+                    override fun visitGraphQLInterfaceType(element: NadelSchemaDefinitionTraverserElement.InterfaceType): Boolean {
+                        onTypeReferenced(element.node.name)
+                        return true
+                    }
+
+                    override fun visitGraphQLEnumType(element: NadelSchemaDefinitionTraverserElement.EnumType): Boolean {
+                        onTypeReferenced(element.node.name)
+                        return true
+                    }
+
+                    override fun visitGraphQLEnumValueDefinition(element: NadelSchemaDefinitionTraverserElement.EnumValueDefinition): Boolean {
+                        return true
+                    }
+
+                    override fun visitGraphQLFieldDefinition(element: NadelSchemaDefinitionTraverserElement.FieldDefinition): Boolean {
+                        return true
+                    }
+
+                    override fun visitGraphQLInputObjectField(element: NadelSchemaDefinitionTraverserElement.InputObjectField): Boolean {
+                        return true
+                    }
+
+                    override fun visitGraphQLInputObjectType(element: NadelSchemaDefinitionTraverserElement.InputObjectType): Boolean {
+                        onTypeReferenced(element.node.name)
+                        return true
+                    }
+
+                    override fun visitGraphQLObjectType(element: NadelSchemaDefinitionTraverserElement.ObjectType): Boolean {
+                        onTypeReferenced(element.node.name)
+                        return true
+                    }
+
+                    override fun visitGraphQLScalarType(element: NadelSchemaDefinitionTraverserElement.ScalarType): Boolean {
+                        onTypeReferenced(element.node.name)
+                        return true
+                    }
+
+                    override fun visitGraphQLDirective(element: NadelSchemaDefinitionTraverserElement.Directive): Boolean {
+                        onTypeReferenced(element.node.name)
+                        return true
+                    }
+
+                    override fun visitGraphQLAppliedDirective(element: NadelSchemaDefinitionTraverserElement.AppliedDirective): Boolean {
+                        onTypeReferenced(element.node.name)
+                        return true
+                    }
+
+                    override fun visitGraphQLAppliedDirectiveArgument(element: NadelSchemaDefinitionTraverserElement.AppliedDirectiveArgument): Boolean {
+                        return true
+                    }
+
+                    override fun visitTypeReference(element: NadelSchemaDefinitionTraverserElement.TypeReference): Boolean {
+                        onTypeReferenced(element.node.unwrapAll().name)
+                        return true
+                    }
+                }
+            )
+    }
+}

--- a/lib/src/main/java/graphql/nadel/schema/NadelFieldDefinitionVisibilityTransformation.kt
+++ b/lib/src/main/java/graphql/nadel/schema/NadelFieldDefinitionVisibilityTransformation.kt
@@ -24,11 +24,11 @@ fun interface NadelFieldDefinitionVisibilityTransformationPredicate {
 class NadelFieldDefinitionVisibilityTransformation(
     val fieldPredicate: NadelFieldDefinitionVisibilityTransformationPredicate,
 ) : NadelSchemaDefinitionTransformationHook {
-    override fun apply(definitions: List<AnySDLDefinition>): List<AnySDLDefinition> {
+    override fun invoke(definitions: List<AnySDLDefinition>): List<AnySDLDefinition> {
         return deleteFields(definitions)
     }
 
-    fun deleteFields(definitions: List<AnySDLDefinition>): List<AnySDLDefinition> {
+    private fun deleteFields(definitions: List<AnySDLDefinition>): List<AnySDLDefinition> {
         val newDefinitions = definitions
             .map { definition ->
                 when (definition) {
@@ -57,7 +57,7 @@ class NadelFieldDefinitionVisibilityTransformation(
             }
     }
 
-    fun transformExtensionType(definition: InterfaceTypeExtensionDefinition): InterfaceTypeExtensionDefinition {
+    private fun transformExtensionType(definition: InterfaceTypeExtensionDefinition): InterfaceTypeExtensionDefinition {
         val newFields = filterFields(definition)
         if (newFields.size == definition.fieldDefinitions.size) {
             return definition
@@ -68,7 +68,7 @@ class NadelFieldDefinitionVisibilityTransformation(
         }
     }
 
-    fun transformType(definition: InterfaceTypeDefinition): InterfaceTypeDefinition {
+    private fun transformType(definition: InterfaceTypeDefinition): InterfaceTypeDefinition {
         val newFields = filterFields(definition)
         if (newFields.size == definition.fieldDefinitions.size) {
             return definition
@@ -79,7 +79,7 @@ class NadelFieldDefinitionVisibilityTransformation(
         }
     }
 
-    fun transformExtensionType(definition: ObjectTypeExtensionDefinition): ObjectTypeExtensionDefinition {
+    private fun transformExtensionType(definition: ObjectTypeExtensionDefinition): ObjectTypeExtensionDefinition {
         val newFields = filterFields(definition)
         if (newFields.size == definition.fieldDefinitions.size) {
             return definition
@@ -90,7 +90,7 @@ class NadelFieldDefinitionVisibilityTransformation(
         }
     }
 
-    fun transformType(definition: ObjectTypeDefinition): ObjectTypeDefinition {
+    private fun transformType(definition: ObjectTypeDefinition): ObjectTypeDefinition {
         val newFields = filterFields(definition)
         if (newFields.size == definition.fieldDefinitions.size) {
             return definition
@@ -101,7 +101,7 @@ class NadelFieldDefinitionVisibilityTransformation(
         }
     }
 
-    fun filterFields(
+    private fun filterFields(
         parent: ImplementingTypeDefinition<*>,
     ): List<FieldDefinition> {
         return parent.fieldDefinitions
@@ -110,7 +110,7 @@ class NadelFieldDefinitionVisibilityTransformation(
             }
     }
 
-    fun getStronglyReferencedTypes(types: List<AnySDLDefinition>): Set<String> {
+    private fun getStronglyReferencedTypes(types: List<AnySDLDefinition>): Set<String> {
         val typesByName = types
             .groupBy {
                 (it as AnyNamedNode).name

--- a/lib/src/main/java/graphql/nadel/schema/NadelSchemaDefinitionTransformationHook.kt
+++ b/lib/src/main/java/graphql/nadel/schema/NadelSchemaDefinitionTransformationHook.kt
@@ -1,0 +1,11 @@
+package graphql.nadel.schema
+
+import graphql.nadel.util.AnySDLDefinition
+
+fun interface NadelSchemaDefinitionTransformationHook {
+    fun apply(definitions: List<AnySDLDefinition>): List<AnySDLDefinition>
+
+    companion object {
+        val Identity = NadelSchemaDefinitionTransformationHook { originalSchema -> originalSchema }
+    }
+}

--- a/lib/src/main/java/graphql/nadel/schema/NadelSchemaDefinitionTransformationHook.kt
+++ b/lib/src/main/java/graphql/nadel/schema/NadelSchemaDefinitionTransformationHook.kt
@@ -3,7 +3,7 @@ package graphql.nadel.schema
 import graphql.nadel.util.AnySDLDefinition
 
 fun interface NadelSchemaDefinitionTransformationHook {
-    fun apply(definitions: List<AnySDLDefinition>): List<AnySDLDefinition>
+    operator fun invoke(definitions: List<AnySDLDefinition>): List<AnySDLDefinition>
 
     companion object {
         val Identity = NadelSchemaDefinitionTransformationHook { originalSchema -> originalSchema }

--- a/lib/src/main/java/graphql/nadel/schema/OverallSchemaGenerator.kt
+++ b/lib/src/main/java/graphql/nadel/schema/OverallSchemaGenerator.kt
@@ -34,7 +34,7 @@ internal class OverallSchemaGenerator {
 
         val definitions = getDefinitions(serviceRegistries)
             .let {
-                schemaDefinitionTransformationHook.apply(it)
+                schemaDefinitionTransformationHook.invoke(it)
             }
 
         val typeRegistry = createTypeRegistry(definitions)

--- a/lib/src/main/java/graphql/nadel/schema/OverallSchemaGenerator.kt
+++ b/lib/src/main/java/graphql/nadel/schema/OverallSchemaGenerator.kt
@@ -24,25 +24,30 @@ internal class OverallSchemaGenerator {
     fun buildOverallSchema(
         serviceRegistries: List<NadelTypeDefinitionRegistry>,
         wiringFactory: WiringFactory,
+        schemaDefinitionTransformationHook: NadelSchemaDefinitionTransformationHook,
     ): GraphQLSchema {
         val schemaGenerator = SchemaGenerator()
         val runtimeWiring = RuntimeWiring.newRuntimeWiring()
             .wiringFactory(wiringFactory)
-            .codeRegistry(
-                NeverWiringFactory.NEVER_CODE_REGISTRY
-            )
+            .codeRegistry(NeverWiringFactory.NEVER_CODE_REGISTRY)
             .build()
 
-        return schemaGenerator.makeExecutableSchema(createTypeRegistry(serviceRegistries), runtimeWiring)
+        val definitions = getDefinitions(serviceRegistries)
+            .let {
+                schemaDefinitionTransformationHook.apply(it)
+            }
+
+        val typeRegistry = createTypeRegistry(definitions)
+
+        return schemaGenerator.makeExecutableSchema(typeRegistry, runtimeWiring)
     }
 
-    private fun createTypeRegistry(serviceRegistries: List<NadelTypeDefinitionRegistry>): TypeDefinitionRegistry {
+    private fun getDefinitions(serviceRegistries: List<NadelTypeDefinitionRegistry>): List<AnySDLDefinition> {
         val topLevelFields = NadelOperationKind.entries
             .associateWith {
                 mutableListOf<FieldDefinition>()
             }
 
-        val overallRegistry = TypeDefinitionRegistry()
         val allDefinitions = ArrayList<AnySDLDefinition>()
 
         for (definitionRegistry in serviceRegistries) {
@@ -53,7 +58,7 @@ internal class OverallSchemaGenerator {
         topLevelFields.keys.forEach { operationKind ->
             val fields = topLevelFields[operationKind]
             if (fields?.isNotEmpty() == true) {
-                overallRegistry.add(
+                allDefinitions.add(
                     newObjectTypeDefinition()
                         .name(operationKind.defaultTypeName)
                         .sourceLocation(SourceLocation(-1, -1, "Generated"))
@@ -64,30 +69,36 @@ internal class OverallSchemaGenerator {
         }
 
         // add our custom directives if they are not present
-        addIfNotPresent(overallRegistry, allDefinitions, NadelDirectives.nadelHydrationArgumentDefinition)
-        addIfNotPresent(overallRegistry, allDefinitions, NadelDirectives.hydratedDirectiveDefinition)
-        addIfNotPresent(overallRegistry, allDefinitions, NadelDirectives.virtualTypeDirectiveDefinition)
-        addIfNotPresent(overallRegistry, allDefinitions, NadelDirectives.defaultHydrationDirectiveDefinition)
-        addIfNotPresent(overallRegistry, allDefinitions, NadelDirectives.idHydratedDirectiveDefinition)
-        addIfNotPresent(overallRegistry, allDefinitions, NadelDirectives.stubbedDirectiveDefinition)
-        addIfNotPresent(overallRegistry, allDefinitions, NadelDirectives.renamedDirectiveDefinition)
-        addIfNotPresent(overallRegistry, allDefinitions, NadelDirectives.hiddenDirectiveDefinition)
-        addIfNotPresent(overallRegistry, allDefinitions, NadelDirectives.nadelBatchObjectIdentifiedByDefinition)
-        addIfNotPresent(overallRegistry, allDefinitions, NadelDirectives.nadelHydrationResultFieldPredicateDefinition)
-        addIfNotPresent(overallRegistry, allDefinitions, NadelDirectives.nadelHydrationResultConditionDefinition)
-        addIfNotPresent(overallRegistry, allDefinitions, NadelDirectives.nadelHydrationConditionDefinition)
-        addIfNotPresent(overallRegistry, allDefinitions, NadelDirectives.nadelHydrationRemainingArguments)
-        addIfNotPresent(overallRegistry, allDefinitions, NadelDirectives.deferDirectiveDefinition)
-        addIfNotPresent(overallRegistry, allDefinitions, NadelDirectives.namespacedDirectiveDefinition)
-        addIfNotPresent(overallRegistry, allDefinitions, NadelDirectives.partitionDirectiveDefinition)
+        addIfNotPresent(allDefinitions, NadelDirectives.nadelHydrationArgumentDefinition)
+        addIfNotPresent(allDefinitions, NadelDirectives.hydratedDirectiveDefinition)
+        addIfNotPresent(allDefinitions, NadelDirectives.virtualTypeDirectiveDefinition)
+        addIfNotPresent(allDefinitions, NadelDirectives.defaultHydrationDirectiveDefinition)
+        addIfNotPresent(allDefinitions, NadelDirectives.idHydratedDirectiveDefinition)
+        addIfNotPresent(allDefinitions, NadelDirectives.stubbedDirectiveDefinition)
+        addIfNotPresent(allDefinitions, NadelDirectives.renamedDirectiveDefinition)
+        addIfNotPresent(allDefinitions, NadelDirectives.hiddenDirectiveDefinition)
+        addIfNotPresent(allDefinitions, NadelDirectives.nadelBatchObjectIdentifiedByDefinition)
+        addIfNotPresent(allDefinitions, NadelDirectives.nadelHydrationResultFieldPredicateDefinition)
+        addIfNotPresent(allDefinitions, NadelDirectives.nadelHydrationResultConditionDefinition)
+        addIfNotPresent(allDefinitions, NadelDirectives.nadelHydrationConditionDefinition)
+        addIfNotPresent(allDefinitions, NadelDirectives.nadelHydrationRemainingArguments)
+        addIfNotPresent(allDefinitions, NadelDirectives.deferDirectiveDefinition)
+        addIfNotPresent(allDefinitions, NadelDirectives.namespacedDirectiveDefinition)
+        addIfNotPresent(allDefinitions, NadelDirectives.partitionDirectiveDefinition)
 
         addIfNotPresent(
-            overallRegistry, allDefinitions, newScalarTypeDefinition()
+            allDefinitions, newScalarTypeDefinition()
                 .name(ExtendedScalars.Json.name)
                 .build()
         )
 
-        for (definition in allDefinitions) {
+        return allDefinitions
+    }
+
+    private fun createTypeRegistry(definitions: List<AnySDLDefinition>): TypeDefinitionRegistry {
+        val overallRegistry = TypeDefinitionRegistry()
+
+        for (definition in definitions) {
             val error = overallRegistry.add(definition)
             if (error.isPresent) {
                 throw GraphQLException("Unable to add definition to overall registry: " + error.get().message)
@@ -98,12 +109,11 @@ internal class OverallSchemaGenerator {
     }
 
     private inline fun <reified T : AnySDLNamedDefinition> addIfNotPresent(
-        overallRegistry: TypeDefinitionRegistry,
-        allDefinitions: List<AnySDLDefinition>,
+        allDefinitions: MutableList<AnySDLDefinition>,
         namedDefinition: T,
     ) {
         if (!containsElement(allDefinitions, namedDefinition)) {
-            overallRegistry.add(namedDefinition)
+            allDefinitions.add(namedDefinition)
         }
     }
 
@@ -115,7 +125,7 @@ internal class OverallSchemaGenerator {
             .asSequence()
             .filterIsInstance<AnyNamedNode>()
             .filter { it.name == def.name }
-            // if it's an `extent type Foo` then it does not count since we need an actual `type Foo` defined
+            // if it's an `extend type Foo` then it does not count since we need an actual `type Foo` defined
             .filterNot { it.isExtensionDef }
             .any { element ->
                 require(element is T) {

--- a/lib/src/main/java/graphql/nadel/schema/SchemaTransformationHook.kt
+++ b/lib/src/main/java/graphql/nadel/schema/SchemaTransformationHook.kt
@@ -9,28 +9,28 @@ import graphql.schema.GraphQLSchema
  *
  *
  * Example usage, to delete a field:
- * `
+ * ```
  * SchemaTransformation transformation = originalSchema -> {
- * @Override
- * GraphQLSchema apply(GraphQLSchema originalSchema) {
- * return SchemaTransformer.transformSchema(originalSchema, new GraphQLTypeVisitorStub() {
- * @Override
- * TraversalControl visitGraphQLFieldDefinition(GraphQLFieldDefinition node, TraverserContext<GraphQLSchemaElement> context) {
- * if (node.getName() == "secretField") {
- * return TreeTransformerUtil.deleteNode(node);
+ *   @Override
+ *   GraphQLSchema apply(GraphQLSchema originalSchema) {
+ *     return SchemaTransformer.transformSchema(originalSchema, new GraphQLTypeVisitorStub() {
+ *       @Override
+ *       TraversalControl visitGraphQLFieldDefinition(GraphQLFieldDefinition node, TraverserContext<GraphQLSchemaElement> context) {
+ *         if (node.getName() == "secretField") {
+ *           return TreeTransformerUtil.deleteNode(node);
+ *         }
+ *         return TraversalControl.CONTINUE;
+ *       }
+ *     }
+ *   }
  * }
- *
- * return TraversalControl.CONTINUE;
- * }
- * }
- * }
- * }
-` *
+ * ```
  *
  * @see graphql.schema.SchemaTransformer
  *
  * @see graphql.schema.GraphQLTypeVisitorStub
  */
+@Deprecated(message = "Performance is not good enough")
 fun interface SchemaTransformationHook {
     /**
      * Apply a transformation to a schema object, returning the new schema.


### PR DESCRIPTION
The existing `FieldVisibilitySchemaTransformation` operates on `GraphQLSchema` and is very slow and consumes a lot of memory.

This PR adds a new capability to transform `SDLDefinition` to let us save on time and memory.

The equivalent field visibility implementation is in `NadelFieldDefinitionVisibilityTransformation`

This allows our CLI to run validation with less memory from `-Xmx850m` to `-Xmx580m` so decrease of 270MB.

It is significantly faster to transform Central Schema now.

```
Took 246ms to transform DEFINITIONS to hide lifecycle fields
Took 11638ms to transform SCHEMA to hide lifecycle fields
```

See test done in 515b78623108d113fb4f1ebf5ef57875a2e98272
