### PR TITLE
Add Request Partitioning to the 'hydrated' Directive

### DIFF
--- a/lib/src/main/java/graphql/nadel/definition/hydration/NadelHydrationDefinition.kt
+++ b/lib/src/main/java/graphql/nadel/definition/hydration/NadelHydrationDefinition.kt
@@ -49,6 +49,8 @@ interface NadelHydrationDefinition : NadelInstructionDefinition {
                     arguments: [NadelHydrationArgument!]!
                     "Specify a condition for the hydration to activate"
                     when: NadelHydrationCondition
+                    "The name of the argument to partition by. When specified, hydration calls are grouped by partition key extracted from values of this argument."
+                    pathToPartitionArg: String
                 ) repeatable on FIELD_DEFINITION
             """.trimIndent(),
         )
@@ -70,6 +72,8 @@ interface NadelHydrationDefinition : NadelInstructionDefinition {
 
     val inputIdentifiedBy: List<NadelBatchObjectIdentifiedByDefinition>?
 
+    val pathToPartitionArg: String?
+
     object Keyword {
         const val hydrated = "hydrated"
         const val field = "field"
@@ -81,6 +85,7 @@ interface NadelHydrationDefinition : NadelInstructionDefinition {
         const val timeout = "timeout"
         const val `when` = "when"
         const val inputIdentifiedBy = "inputIdentifiedBy"
+        const val pathToPartitionArg = "pathToPartitionArg"
     }
 }
 
@@ -121,4 +126,7 @@ private class NadelHydrationDefinitionImpl(
             ?.map {
                 NadelBatchObjectIdentifiedByDefinition(it as ObjectValue)
             }
+
+    override val pathToPartitionArg: String?
+        get() = appliedDirective.getArgument(Keyword.pathToPartitionArg).getValue()
 }

--- a/lib/src/main/java/graphql/nadel/engine/blueprint/NadelFieldInstruction.kt
+++ b/lib/src/main/java/graphql/nadel/engine/blueprint/NadelFieldInstruction.kt
@@ -151,6 +151,11 @@ data class NadelBatchHydrationFieldInstruction(
     override val condition: NadelHydrationCondition?,
     val batchSize: Int,
     val batchHydrationMatchStrategy: NadelBatchHydrationMatchStrategy,
+    /**
+     * The name of the argument to partition by. When specified, the [graphql.nadel.hooks.NadelExecutionHooks.partitionBatchHydrationArgumentList]
+     * hook will be called and hydration calls will be grouped by partition key.
+     */
+    val pathToPartitionArg: String?,
 ) : NadelFieldInstruction(), NadelGenericHydrationInstruction
 
 data class NadelDeepRenameFieldInstruction(

--- a/lib/src/main/java/graphql/nadel/validation/NadelSchemaValidationError.kt
+++ b/lib/src/main/java/graphql/nadel/validation/NadelSchemaValidationError.kt
@@ -448,6 +448,52 @@ sealed interface NadelSchemaValidationError : NadelSchemaValidationResult {
 
         override val subject = parentType.overall
     }
+
+    data class InvalidPathToPartitionArg(
+        val parentType: NadelServiceSchemaElement,
+        val overallField: GraphQLFieldDefinition,
+        val path: String,
+        val validArgs: List<String>,
+    ) : NadelSchemaValidationError {
+        val service: Service get() = parentType.service
+
+        override val message = run {
+            val of = makeFieldCoordinates(parentType.overall.name, overallField.name)
+            "Field $of has pathToPartitionArg '$path' that does not reference a valid hydration argument. Valid arguments are: ${validArgs.joinToString()}"
+        }
+
+        override val subject = overallField
+    }
+
+    data class PathToPartitionArgNotList(
+        val parentType: NadelServiceSchemaElement,
+        val overallField: GraphQLFieldDefinition,
+        val path: String,
+    ) : NadelSchemaValidationError {
+        val service: Service get() = parentType.service
+
+        override val message = run {
+            val of = makeFieldCoordinates(parentType.overall.name, overallField.name)
+            "Field $of has pathToPartitionArg '$path' but that argument does not have a list type. Only list arguments can be used for partitioning"
+        }
+
+        override val subject = overallField
+    }
+
+    data class PathToPartitionArgMustBeSourceField(
+        val parentType: NadelServiceSchemaElement,
+        val overallField: GraphQLFieldDefinition,
+        val path: String,
+    ) : NadelSchemaValidationError {
+        val service: Service get() = parentType.service
+
+        override val message = run {
+            val of = makeFieldCoordinates(parentType.overall.name, overallField.name)
+            "Field $of has pathToPartitionArg '$path' but that argument must use a source field value (e.g. \$source.someField), not a static value"
+        }
+
+        override val subject = overallField
+    }
 }
 
 private fun toString(element: GraphQLNamedSchemaElement): String {

--- a/lib/src/main/java/graphql/nadel/validation/hydration/NadelHydrationValidation.kt
+++ b/lib/src/main/java/graphql/nadel/validation/hydration/NadelHydrationValidation.kt
@@ -354,6 +354,9 @@ class NadelHydrationValidation internal constructor(
             sourceFieldValidation2.getBatchHydrationSourceFields(arguments, matchStrategy, hydrationCondition)
                 .onError { return it }
 
+        val pathToPartitionArgError = validatePathToPartitionArg()
+        if (pathToPartitionArgError != null) return pathToPartitionArgError
+
         return NadelValidatedFieldResult(
             service = parent.service,
             fieldInstruction = NadelBatchHydrationFieldInstruction(
@@ -371,8 +374,45 @@ class NadelHydrationValidation internal constructor(
                 condition = hydrationCondition,
                 batchSize = hydrationDefinition.batchSize,
                 batchHydrationMatchStrategy = matchStrategy,
+                pathToPartitionArg = hydrationDefinition.pathToPartitionArg,
             )
         )
+    }
+
+    context(NadelValidationContext, NadelHydrationValidationContext)
+    private fun validatePathToPartitionArg(): NadelSchemaValidationResult? {
+        val path = hydrationDefinition.pathToPartitionArg ?: return null
+
+        val argNames = hydrationDefinition.arguments.map { it.name }
+        if (path !in argNames) {
+            return NadelSchemaValidationError.InvalidPathToPartitionArg(
+                parentType = parent,
+                overallField = virtualField,
+                path = path,
+                validArgs = argNames,
+            )
+        }
+
+        // The referenced argument must be a source field value (not static) and must be a list
+        val arg = hydrationDefinition.arguments.find { it.name == path }!!
+        if (arg !is NadelHydrationArgumentDefinition.ObjectField) {
+            return NadelSchemaValidationError.PathToPartitionArgMustBeSourceField(
+                parentType = parent,
+                overallField = virtualField,
+                path = path,
+            )
+        }
+
+        val backingArgDef = backingField.getArgument(path)
+        if (backingArgDef != null && !backingArgDef.type.isList) {
+            return NadelSchemaValidationError.PathToPartitionArgNotList(
+                parentType = parent,
+                overallField = virtualField,
+                path = path,
+            )
+        }
+
+        return null
     }
 
     context(NadelValidationContext)

--- a/lib/src/test/kotlin/graphql/nadel/validation/NadelHydrationPartitionValidationTest.kt
+++ b/lib/src/test/kotlin/graphql/nadel/validation/NadelHydrationPartitionValidationTest.kt
@@ -1,0 +1,238 @@
+package graphql.nadel.validation
+
+import graphql.nadel.validation.NadelSchemaValidationError.InvalidPathToPartitionArg
+import graphql.nadel.validation.NadelSchemaValidationError.PathToPartitionArgMustBeSourceField
+import graphql.nadel.validation.NadelSchemaValidationError.PathToPartitionArgNotList
+import graphql.nadel.validation.util.assertSingleOfType
+import org.junit.jupiter.api.Test
+
+private const val source = "$" + "source"
+
+class NadelHydrationPartitionValidationTest {
+
+    @Test
+    fun `passes when pathToPartitionArg references a valid list argument`() {
+        val fixture = NadelValidationTestFixture(
+            overallSchema = mapOf(
+                "issues" to """
+                    type Query {
+                        issues: [Issue]
+                    }
+                    type Issue {
+                        id: ID
+                        authorIds: [ID]
+                        authors: [User]
+                        @hydrated(
+                            service: "users"
+                            field: "usersByIds"
+                            arguments: [{name: "id", value: "$source.authorIds"}]
+                            identifiedBy: "id"
+                            pathToPartitionArg: "id"
+                        )
+                    }
+                """.trimIndent(),
+                "users" to """
+                    type Query {
+                        usersByIds(id: [ID]): [User]
+                    }
+                    type User {
+                        id: ID
+                    }
+                """.trimIndent(),
+            ),
+            underlyingSchema = mapOf(
+                "issues" to """
+                    type Query {
+                        issues: [Issue]
+                    }
+                    type Issue {
+                        id: ID
+                        authorIds: [ID]
+                    }
+                """.trimIndent(),
+                "users" to """
+                    type Query {
+                        usersByIds(id: [ID]): [User]
+                    }
+                    type User {
+                        id: ID
+                    }
+                """.trimIndent(),
+            ),
+        )
+
+        val errors = validate(fixture)
+        assert(errors.map { it.message }.isEmpty())
+    }
+
+    @Test
+    fun `fails when pathToPartitionArg references a non-existent argument`() {
+        val fixture = NadelValidationTestFixture(
+            overallSchema = mapOf(
+                "issues" to """
+                    type Query {
+                        issues: [Issue]
+                    }
+                    type Issue {
+                        id: ID
+                        authorIds: [ID]
+                        authors: [User]
+                        @hydrated(
+                            service: "users"
+                            field: "usersByIds"
+                            arguments: [{name: "id", value: "$source.authorIds"}]
+                            identifiedBy: "id"
+                            pathToPartitionArg: "nonexistent"
+                        )
+                    }
+                """.trimIndent(),
+                "users" to """
+                    type Query {
+                        usersByIds(id: [ID]): [User]
+                    }
+                    type User {
+                        id: ID
+                    }
+                """.trimIndent(),
+            ),
+            underlyingSchema = mapOf(
+                "issues" to """
+                    type Query {
+                        issues: [Issue]
+                    }
+                    type Issue {
+                        id: ID
+                        authorIds: [ID]
+                    }
+                """.trimIndent(),
+                "users" to """
+                    type Query {
+                        usersByIds(id: [ID]): [User]
+                    }
+                    type User {
+                        id: ID
+                    }
+                """.trimIndent(),
+            ),
+        )
+
+        val errors = validate(fixture)
+        val error = errors.assertSingleOfType<InvalidPathToPartitionArg>()
+        assert(error.path == "nonexistent")
+        assert(error.validArgs == listOf("id"))
+    }
+
+    @Test
+    fun `fails when pathToPartitionArg references a static argument`() {
+        val fixture = NadelValidationTestFixture(
+            overallSchema = mapOf(
+                "issues" to """
+                    type Query {
+                        issues: [Issue]
+                    }
+                    type Issue {
+                        id: ID
+                        authorIds: [ID]
+                        authors: [User]
+                        @hydrated(
+                            service: "users"
+                            field: "usersByIds"
+                            arguments: [
+                                {name: "id", value: "$source.authorIds"}
+                                {name: "type", value: "USER"}
+                            ]
+                            identifiedBy: "id"
+                            pathToPartitionArg: "type"
+                        )
+                    }
+                """.trimIndent(),
+                "users" to """
+                    type Query {
+                        usersByIds(id: [ID], type: String): [User]
+                    }
+                    type User {
+                        id: ID
+                    }
+                """.trimIndent(),
+            ),
+            underlyingSchema = mapOf(
+                "issues" to """
+                    type Query {
+                        issues: [Issue]
+                    }
+                    type Issue {
+                        id: ID
+                        authorIds: [ID]
+                    }
+                """.trimIndent(),
+                "users" to """
+                    type Query {
+                        usersByIds(id: [ID], type: String): [User]
+                    }
+                    type User {
+                        id: ID
+                    }
+                """.trimIndent(),
+            ),
+        )
+
+        val errors = validate(fixture)
+        val error = errors.assertSingleOfType<PathToPartitionArgMustBeSourceField>()
+        assert(error.path == "type")
+    }
+
+    @Test
+    fun `fails when pathToPartitionArg references a non-list argument`() {
+        val fixture = NadelValidationTestFixture(
+            overallSchema = mapOf(
+                "issues" to """
+                    type Query {
+                        issues: [Issue]
+                    }
+                    type Issue {
+                        id: ID
+                        authorId: ID
+                        author: User
+                        @hydrated(
+                            service: "users"
+                            field: "userById"
+                            arguments: [{name: "id", value: "$source.authorId"}]
+                            pathToPartitionArg: "id"
+                        )
+                    }
+                """.trimIndent(),
+                "users" to """
+                    type Query {
+                        userById(id: ID): User
+                    }
+                    type User {
+                        id: ID
+                    }
+                """.trimIndent(),
+            ),
+            underlyingSchema = mapOf(
+                "issues" to """
+                    type Query {
+                        issues: [Issue]
+                    }
+                    type Issue {
+                        id: ID
+                        authorId: ID
+                    }
+                """.trimIndent(),
+                "users" to """
+                    type Query {
+                        userById(id: ID): User
+                    }
+                    type User {
+                        id: ID
+                    }
+                """.trimIndent(),
+            ),
+        )
+
+        val errors = validate(fixture)
+        val error = errors.assertSingleOfType<PathToPartitionArgNotList>()
+        assert(error.path == "id")
+    }
+}

--- a/test/src/test/kotlin/graphql/nadel/tests/hooks/basic-hydration-partitioning.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/hooks/basic-hydration-partitioning.kt
@@ -1,0 +1,34 @@
+package graphql.nadel.tests.hooks
+
+import graphql.nadel.Nadel
+import graphql.nadel.engine.blueprint.NadelBatchHydrationFieldInstruction
+import graphql.nadel.hooks.NadelExecutionHooks
+import graphql.nadel.tests.EngineTestHook
+import graphql.nadel.tests.UseHook
+
+private class HydrationPartitioningHooks : NadelExecutionHooks {
+    override fun <T> partitionBatchHydrationArgumentList(
+        argumentValues: List<T>,
+        instruction: NadelBatchHydrationFieldInstruction,
+        userContext: Any?,
+    ): List<List<T>> {
+        // Only partition when pathToPartitionArg is set
+        if (instruction.pathToPartitionArg == null) {
+            return listOf(argumentValues)
+        }
+        // Group by the prefix before "/" e.g. "CLOUD-1/USER-1" -> "CLOUD-1"
+        return argumentValues
+            .groupBy { value ->
+                (value as String).substringBefore("/")
+            }
+            .values
+            .toList()
+    }
+}
+
+@UseHook
+class `basic-hydration-partitioning` : EngineTestHook {
+    override fun makeNadel(builder: Nadel.Builder): Nadel.Builder {
+        return builder.executionHooks(HydrationPartitioningHooks())
+    }
+}

--- a/test/src/test/kotlin/graphql/nadel/tests/hooks/hydration-partitioning-with-renamed-field.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/hooks/hydration-partitioning-with-renamed-field.kt
@@ -1,0 +1,31 @@
+package graphql.nadel.tests.hooks
+
+import graphql.nadel.Nadel
+import graphql.nadel.engine.blueprint.NadelBatchHydrationFieldInstruction
+import graphql.nadel.hooks.NadelExecutionHooks
+import graphql.nadel.tests.EngineTestHook
+import graphql.nadel.tests.UseHook
+
+@UseHook
+class `hydration-partitioning-with-renamed-field` : EngineTestHook {
+    override fun makeNadel(builder: Nadel.Builder): Nadel.Builder {
+        return builder.executionHooks(object : NadelExecutionHooks {
+            override fun <T> partitionBatchHydrationArgumentList(
+                argumentValues: List<T>,
+                instruction: NadelBatchHydrationFieldInstruction,
+                userContext: Any?,
+            ): List<List<T>> {
+                if (instruction.pathToPartitionArg == null) {
+                    return listOf(argumentValues)
+                }
+                // Group by the prefix before "/" e.g. "CLOUD-1/USER-1" -> "CLOUD-1"
+                return argumentValues
+                    .groupBy { value ->
+                        (value as String).substringBefore("/")
+                    }
+                    .values
+                    .toList()
+            }
+        })
+    }
+}

--- a/test/src/test/kotlin/graphql/nadel/tests/hooks/hydration-partitioning-with-type-rename.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/hooks/hydration-partitioning-with-type-rename.kt
@@ -1,0 +1,31 @@
+package graphql.nadel.tests.hooks
+
+import graphql.nadel.Nadel
+import graphql.nadel.engine.blueprint.NadelBatchHydrationFieldInstruction
+import graphql.nadel.hooks.NadelExecutionHooks
+import graphql.nadel.tests.EngineTestHook
+import graphql.nadel.tests.UseHook
+
+@UseHook
+class `hydration-partitioning-with-type-rename` : EngineTestHook {
+    override fun makeNadel(builder: Nadel.Builder): Nadel.Builder {
+        return builder.executionHooks(object : NadelExecutionHooks {
+            override fun <T> partitionBatchHydrationArgumentList(
+                argumentValues: List<T>,
+                instruction: NadelBatchHydrationFieldInstruction,
+                userContext: Any?,
+            ): List<List<T>> {
+                if (instruction.pathToPartitionArg == null) {
+                    return listOf(argumentValues)
+                }
+                // Group by the prefix before "/" e.g. "CLOUD-1/USER-1" -> "CLOUD-1"
+                return argumentValues
+                    .groupBy { value ->
+                        (value as String).substringBefore("/")
+                    }
+                    .values
+                    .toList()
+            }
+        })
+    }
+}

--- a/test/src/test/kotlin/graphql/nadel/tests/hooks/hydration-partitioning-with-typename-in-query.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/hooks/hydration-partitioning-with-typename-in-query.kt
@@ -1,0 +1,31 @@
+package graphql.nadel.tests.hooks
+
+import graphql.nadel.Nadel
+import graphql.nadel.engine.blueprint.NadelBatchHydrationFieldInstruction
+import graphql.nadel.hooks.NadelExecutionHooks
+import graphql.nadel.tests.EngineTestHook
+import graphql.nadel.tests.UseHook
+
+@UseHook
+class `hydration-partitioning-with-typename-in-query` : EngineTestHook {
+    override fun makeNadel(builder: Nadel.Builder): Nadel.Builder {
+        return builder.executionHooks(object : NadelExecutionHooks {
+            override fun <T> partitionBatchHydrationArgumentList(
+                argumentValues: List<T>,
+                instruction: NadelBatchHydrationFieldInstruction,
+                userContext: Any?,
+            ): List<List<T>> {
+                if (instruction.pathToPartitionArg == null) {
+                    return listOf(argumentValues)
+                }
+                // Group by the prefix before "/" e.g. "CLOUD-1/USER-1" -> "CLOUD-1"
+                return argumentValues
+                    .groupBy { value ->
+                        (value as String).substringBefore("/")
+                    }
+                    .values
+                    .toList()
+            }
+        })
+    }
+}

--- a/test/src/test/resources/fixtures/new hydration/partitioning/basic-hydration-partitioning.yml
+++ b/test/src/test/resources/fixtures/new hydration/partitioning/basic-hydration-partitioning.yml
@@ -1,0 +1,176 @@
+name: "basic hydration partitioning"
+enabled: true
+# language=GraphQL
+overallSchema:
+  # language=GraphQL
+  UserService: |
+    type Query {
+      usersByIds(id: [ID]): [User]
+    }
+    type User {
+      id: ID
+    }
+  # language=GraphQL
+  Issues: |
+    type Query {
+      issues: [Issue]
+    }
+    type Issue {
+      id: ID
+      authors: [User]
+      @hydrated(
+        service: "UserService"
+        field: "usersByIds"
+        arguments: [{name: "id" value: "$source.authorIds"}]
+        identifiedBy: "id"
+        batchSize: 3
+        pathToPartitionArg: "id"
+      )
+    }
+# language=GraphQL
+underlyingSchema:
+  # language=GraphQL
+  UserService: |
+    type Query {
+      usersByIds(id: [ID]): [User]
+    }
+    type User {
+      id: ID
+    }
+  # language=GraphQL
+  Issues: |
+    type Issue {
+      authorIds: [ID]
+      id: ID
+    }
+    type Query {
+      issues: [Issue]
+    }
+# language=GraphQL
+query: |
+  query {
+    issues {
+      id
+      authors {
+        id
+      }
+    }
+  }
+variables: { }
+serviceCalls:
+  - serviceName: "Issues"
+    request:
+      # language=GraphQL
+      query: |
+        query {
+          issues {
+            __typename__batch_hydration__authors: __typename
+            batch_hydration__authors__authorIds: authorIds
+            id
+          }
+        }
+      variables: { }
+    # language=JSON
+    response: |-
+      {
+        "data": {
+          "issues": [
+            {
+              "__typename__batch_hydration__authors": "Issue",
+              "batch_hydration__authors__authorIds": [
+                "CLOUD-1/USER-1",
+                "CLOUD-2/USER-2"
+              ],
+              "id": "ISSUE-1"
+            },
+            {
+              "__typename__batch_hydration__authors": "Issue",
+              "batch_hydration__authors__authorIds": [
+                "CLOUD-1/USER-3"
+              ],
+              "id": "ISSUE-2"
+            }
+          ]
+        },
+        "extensions": {}
+      }
+  - serviceName: "UserService"
+    request:
+      # language=GraphQL
+      query: |
+        query {
+          usersByIds(id: ["CLOUD-1/USER-1", "CLOUD-1/USER-3"]) {
+            id
+            batch_hydration__authors__id: id
+          }
+        }
+      variables: { }
+    # language=JSON
+    response: |-
+      {
+        "data": {
+          "usersByIds": [
+            {
+              "id": "CLOUD-1/USER-1",
+              "batch_hydration__authors__id": "CLOUD-1/USER-1"
+            },
+            {
+              "id": "CLOUD-1/USER-3",
+              "batch_hydration__authors__id": "CLOUD-1/USER-3"
+            }
+          ]
+        },
+        "extensions": {}
+      }
+  - serviceName: "UserService"
+    request:
+      # language=GraphQL
+      query: |
+        query {
+          usersByIds(id: ["CLOUD-2/USER-2"]) {
+            id
+            batch_hydration__authors__id: id
+          }
+        }
+      variables: { }
+    # language=JSON
+    response: |-
+      {
+        "data": {
+          "usersByIds": [
+            {
+              "id": "CLOUD-2/USER-2",
+              "batch_hydration__authors__id": "CLOUD-2/USER-2"
+            }
+          ]
+        },
+        "extensions": {}
+      }
+# language=JSON
+response: |-
+  {
+    "data": {
+      "issues": [
+        {
+          "id": "ISSUE-1",
+          "authors": [
+            {
+              "id": "CLOUD-1/USER-1"
+            },
+            {
+              "id": "CLOUD-2/USER-2"
+            }
+          ]
+        },
+        {
+          "id": "ISSUE-2",
+          "authors": [
+            {
+              "id": "CLOUD-1/USER-3"
+            }
+          ]
+        }
+      ]
+    },
+    "extensions": {}
+  }

--- a/test/src/test/resources/fixtures/new hydration/partitioning/hydration-partitioning-with-renamed-field.yml
+++ b/test/src/test/resources/fixtures/new hydration/partitioning/hydration-partitioning-with-renamed-field.yml
@@ -1,0 +1,187 @@
+name: "hydration partitioning with renamed field"
+enabled: true
+# language=GraphQL
+overallSchema:
+  # language=GraphQL
+  UserService: |
+    type Query {
+      usersQuery(id: [ID]): [User] @renamed(from: "usersByIds")
+    }
+    type User {
+      id: ID
+      name: String
+    }
+  # language=GraphQL
+  Issues: |
+    type Query {
+      issues: [Issue]
+    }
+    type Issue {
+      id: ID
+      authors: [User]
+      @hydrated(
+        service: "UserService"
+        field: "usersQuery"
+        arguments: [{name: "id" value: "$source.authorIds"}]
+        identifiedBy: "id"
+        batchSize: 3
+        pathToPartitionArg: "id"
+      )
+    }
+# language=GraphQL
+underlyingSchema:
+  # language=GraphQL
+  UserService: |
+    type Query {
+      usersByIds(id: [ID]): [User]
+    }
+    type User {
+      id: ID
+      name: String
+    }
+  # language=GraphQL
+  Issues: |
+    type Issue {
+      authorIds: [ID]
+      id: ID
+    }
+    type Query {
+      issues: [Issue]
+    }
+# language=GraphQL
+query: |
+  query {
+    issues {
+      id
+      authors {
+        id
+        name
+      }
+    }
+  }
+variables: { }
+serviceCalls:
+  - serviceName: "Issues"
+    request:
+      # language=GraphQL
+      query: |
+        query {
+          issues {
+            __typename__batch_hydration__authors: __typename
+            batch_hydration__authors__authorIds: authorIds
+            id
+          }
+        }
+      variables: { }
+    # language=JSON
+    response: |-
+      {
+        "data": {
+          "issues": [
+            {
+              "__typename__batch_hydration__authors": "Issue",
+              "batch_hydration__authors__authorIds": [
+                "CLOUD-1/USER-1",
+                "CLOUD-2/USER-2"
+              ],
+              "id": "ISSUE-1"
+            },
+            {
+              "__typename__batch_hydration__authors": "Issue",
+              "batch_hydration__authors__authorIds": [
+                "CLOUD-1/USER-3"
+              ],
+              "id": "ISSUE-2"
+            }
+          ]
+        },
+        "extensions": {}
+      }
+  - serviceName: "UserService"
+    request:
+      # language=GraphQL
+      query: |
+        query {
+          rename__usersQuery__usersByIds: usersByIds(id: ["CLOUD-1/USER-1", "CLOUD-1/USER-3"]) {
+            id
+            batch_hydration__authors__id: id
+            name
+          }
+        }
+      variables: { }
+    # language=JSON
+    response: |-
+      {
+        "data": {
+          "rename__usersQuery__usersByIds": [
+            {
+              "id": "CLOUD-1/USER-1",
+              "batch_hydration__authors__id": "CLOUD-1/USER-1",
+              "name": "User One"
+            },
+            {
+              "id": "CLOUD-1/USER-3",
+              "batch_hydration__authors__id": "CLOUD-1/USER-3",
+              "name": "User Three"
+            }
+          ]
+        },
+        "extensions": {}
+      }
+  - serviceName: "UserService"
+    request:
+      # language=GraphQL
+      query: |
+        query {
+          rename__usersQuery__usersByIds: usersByIds(id: ["CLOUD-2/USER-2"]) {
+            id
+            batch_hydration__authors__id: id
+            name
+          }
+        }
+      variables: { }
+    # language=JSON
+    response: |-
+      {
+        "data": {
+          "rename__usersQuery__usersByIds": [
+            {
+              "id": "CLOUD-2/USER-2",
+              "batch_hydration__authors__id": "CLOUD-2/USER-2",
+              "name": "User Two"
+            }
+          ]
+        },
+        "extensions": {}
+      }
+# language=JSON
+response: |-
+  {
+    "data": {
+      "issues": [
+        {
+          "id": "ISSUE-1",
+          "authors": [
+            {
+              "id": "CLOUD-1/USER-1",
+              "name": "User One"
+            },
+            {
+              "id": "CLOUD-2/USER-2",
+              "name": "User Two"
+            }
+          ]
+        },
+        {
+          "id": "ISSUE-2",
+          "authors": [
+            {
+              "id": "CLOUD-1/USER-3",
+              "name": "User Three"
+            }
+          ]
+        }
+      ]
+    },
+    "extensions": {}
+  }

--- a/test/src/test/resources/fixtures/new hydration/partitioning/hydration-partitioning-with-type-rename.yml
+++ b/test/src/test/resources/fixtures/new hydration/partitioning/hydration-partitioning-with-type-rename.yml
@@ -1,0 +1,196 @@
+name: "hydration partitioning with type rename"
+enabled: true
+# language=GraphQL
+overallSchema:
+  # language=GraphQL
+  UserService: |
+    type Query {
+      usersByIds(id: [ID]): [User]
+    }
+    type User @renamed(from: "UserUnderlying") {
+      id: ID
+      name: String
+    }
+  # language=GraphQL
+  Issues: |
+    type Query {
+      issues: [Issue]
+    }
+    type Issue {
+      id: ID
+      authors: [User]
+      @hydrated(
+        service: "UserService"
+        field: "usersByIds"
+        arguments: [{name: "id" value: "$source.authorIds"}]
+        identifiedBy: "id"
+        batchSize: 3
+        pathToPartitionArg: "id"
+      )
+    }
+# language=GraphQL
+underlyingSchema:
+  # language=GraphQL
+  UserService: |
+    type Query {
+      usersByIds(id: [ID]): [UserUnderlying]
+    }
+    type UserUnderlying {
+      id: ID
+      name: String
+    }
+  # language=GraphQL
+  Issues: |
+    type Issue {
+      authorIds: [ID]
+      id: ID
+    }
+    type Query {
+      issues: [Issue]
+    }
+# language=GraphQL
+query: |
+  query {
+    issues {
+      id
+      authors {
+        __typename
+        id
+        name
+      }
+    }
+  }
+variables: { }
+serviceCalls:
+  - serviceName: "Issues"
+    request:
+      # language=GraphQL
+      query: |
+        query {
+          issues {
+            __typename__batch_hydration__authors: __typename
+            batch_hydration__authors__authorIds: authorIds
+            id
+          }
+        }
+      variables: { }
+    # language=JSON
+    response: |-
+      {
+        "data": {
+          "issues": [
+            {
+              "__typename__batch_hydration__authors": "Issue",
+              "batch_hydration__authors__authorIds": [
+                "CLOUD-1/USER-1",
+                "CLOUD-2/USER-2"
+              ],
+              "id": "ISSUE-1"
+            },
+            {
+              "__typename__batch_hydration__authors": "Issue",
+              "batch_hydration__authors__authorIds": [
+                "CLOUD-1/USER-3"
+              ],
+              "id": "ISSUE-2"
+            }
+          ]
+        },
+        "extensions": {}
+      }
+  - serviceName: "UserService"
+    request:
+      # language=GraphQL
+      query: |
+        query {
+          usersByIds(id: ["CLOUD-1/USER-1", "CLOUD-1/USER-3"]) {
+            __typename
+            id
+            batch_hydration__authors__id: id
+            name
+          }
+        }
+      variables: { }
+    # language=JSON
+    response: |-
+      {
+        "data": {
+          "usersByIds": [
+            {
+              "__typename": "UserUnderlying",
+              "id": "CLOUD-1/USER-1",
+              "batch_hydration__authors__id": "CLOUD-1/USER-1",
+              "name": "User One"
+            },
+            {
+              "__typename": "UserUnderlying",
+              "id": "CLOUD-1/USER-3",
+              "batch_hydration__authors__id": "CLOUD-1/USER-3",
+              "name": "User Three"
+            }
+          ]
+        },
+        "extensions": {}
+      }
+  - serviceName: "UserService"
+    request:
+      # language=GraphQL
+      query: |
+        query {
+          usersByIds(id: ["CLOUD-2/USER-2"]) {
+            __typename
+            id
+            batch_hydration__authors__id: id
+            name
+          }
+        }
+      variables: { }
+    # language=JSON
+    response: |-
+      {
+        "data": {
+          "usersByIds": [
+            {
+              "__typename": "UserUnderlying",
+              "id": "CLOUD-2/USER-2",
+              "batch_hydration__authors__id": "CLOUD-2/USER-2",
+              "name": "User Two"
+            }
+          ]
+        },
+        "extensions": {}
+      }
+# language=JSON
+response: |-
+  {
+    "data": {
+      "issues": [
+        {
+          "id": "ISSUE-1",
+          "authors": [
+            {
+              "__typename": "User",
+              "id": "CLOUD-1/USER-1",
+              "name": "User One"
+            },
+            {
+              "__typename": "User",
+              "id": "CLOUD-2/USER-2",
+              "name": "User Two"
+            }
+          ]
+        },
+        {
+          "id": "ISSUE-2",
+          "authors": [
+            {
+              "__typename": "User",
+              "id": "CLOUD-1/USER-3",
+              "name": "User Three"
+            }
+          ]
+        }
+      ]
+    },
+    "extensions": {}
+  }

--- a/test/src/test/resources/fixtures/new hydration/partitioning/hydration-partitioning-with-typename-in-query.yml
+++ b/test/src/test/resources/fixtures/new hydration/partitioning/hydration-partitioning-with-typename-in-query.yml
@@ -1,0 +1,202 @@
+name: "hydration partitioning with typename in query"
+enabled: true
+# language=GraphQL
+overallSchema:
+  # language=GraphQL
+  UserService: |
+    type Query {
+      usersByIds(id: [ID]): [User]
+    }
+    type User {
+      id: ID
+      name: String
+    }
+  # language=GraphQL
+  Issues: |
+    type Query {
+      issues: [Issue]
+    }
+    type Issue {
+      id: ID
+      authors: [User]
+      @hydrated(
+        service: "UserService"
+        field: "usersByIds"
+        arguments: [{name: "id" value: "$source.authorIds"}]
+        identifiedBy: "id"
+        batchSize: 3
+        pathToPartitionArg: "id"
+      )
+    }
+# language=GraphQL
+underlyingSchema:
+  # language=GraphQL
+  UserService: |
+    type Query {
+      usersByIds(id: [ID]): [User]
+    }
+    type User {
+      id: ID
+      name: String
+    }
+  # language=GraphQL
+  Issues: |
+    type Issue {
+      authorIds: [ID]
+      id: ID
+    }
+    type Query {
+      issues: [Issue]
+    }
+# language=GraphQL
+query: |
+  query {
+    issues {
+      __typename
+      id
+      authors {
+        __typename
+        id
+        name
+      }
+    }
+  }
+variables: { }
+serviceCalls:
+  - serviceName: "Issues"
+    request:
+      # language=GraphQL
+      query: |
+        query {
+          issues {
+            __typename
+            __typename__batch_hydration__authors: __typename
+            batch_hydration__authors__authorIds: authorIds
+            id
+          }
+        }
+      variables: { }
+    # language=JSON
+    response: |-
+      {
+        "data": {
+          "issues": [
+            {
+              "__typename": "Issue",
+              "__typename__batch_hydration__authors": "Issue",
+              "batch_hydration__authors__authorIds": [
+                "CLOUD-1/USER-1",
+                "CLOUD-2/USER-2"
+              ],
+              "id": "ISSUE-1"
+            },
+            {
+              "__typename": "Issue",
+              "__typename__batch_hydration__authors": "Issue",
+              "batch_hydration__authors__authorIds": [
+                "CLOUD-1/USER-3"
+              ],
+              "id": "ISSUE-2"
+            }
+          ]
+        },
+        "extensions": {}
+      }
+  - serviceName: "UserService"
+    request:
+      # language=GraphQL
+      query: |
+        query {
+          usersByIds(id: ["CLOUD-1/USER-1", "CLOUD-1/USER-3"]) {
+            __typename
+            id
+            batch_hydration__authors__id: id
+            name
+          }
+        }
+      variables: { }
+    # language=JSON
+    response: |-
+      {
+        "data": {
+          "usersByIds": [
+            {
+              "__typename": "User",
+              "id": "CLOUD-1/USER-1",
+              "batch_hydration__authors__id": "CLOUD-1/USER-1",
+              "name": "User One"
+            },
+            {
+              "__typename": "User",
+              "id": "CLOUD-1/USER-3",
+              "batch_hydration__authors__id": "CLOUD-1/USER-3",
+              "name": "User Three"
+            }
+          ]
+        },
+        "extensions": {}
+      }
+  - serviceName: "UserService"
+    request:
+      # language=GraphQL
+      query: |
+        query {
+          usersByIds(id: ["CLOUD-2/USER-2"]) {
+            __typename
+            id
+            batch_hydration__authors__id: id
+            name
+          }
+        }
+      variables: { }
+    # language=JSON
+    response: |-
+      {
+        "data": {
+          "usersByIds": [
+            {
+              "__typename": "User",
+              "id": "CLOUD-2/USER-2",
+              "batch_hydration__authors__id": "CLOUD-2/USER-2",
+              "name": "User Two"
+            }
+          ]
+        },
+        "extensions": {}
+      }
+# language=JSON
+response: |-
+  {
+    "data": {
+      "issues": [
+        {
+          "__typename": "Issue",
+          "id": "ISSUE-1",
+          "authors": [
+            {
+              "__typename": "User",
+              "id": "CLOUD-1/USER-1",
+              "name": "User One"
+            },
+            {
+              "__typename": "User",
+              "id": "CLOUD-2/USER-2",
+              "name": "User Two"
+            }
+          ]
+        },
+        {
+          "__typename": "Issue",
+          "id": "ISSUE-2",
+          "authors": [
+            {
+              "__typename": "User",
+              "id": "CLOUD-1/USER-3",
+              "name": "User Three"
+            }
+          ]
+        }
+      ]
+    },
+    "extensions": {}
+  }


### PR DESCRIPTION
Extend the `@hydrated` directive with a `pathToPartitionArg` argument to enable automatic partitioning of batch hydration calls.

The format and functionality follow the existing `@partition` directive.

## Changes

Add one new argument to the existing `@hydrated` directive:

```graphql
directive @hydrated(
    ...
    pathToPartitionArg: String
)
```

## Checklist

- [x] Add tests that use __typename in queries
- [x] _Does this change work with all nadel transformations (rename, type rename, hydration, etc)?_ Yes, added.
- [x] _Is it worth using hints for this change in order to be able to enable a percentage rollout?_. No, the feature is already opt-in via the schema directive.
- [x] _Do we need a pollinator check for this?_. No, the default behavior is unchanged.
- [x] _Do we need to add integration tests for this change in the graphql gateway?_. Yes, we will need to implement integration tests for this new field. It is opt-in with default behavior left unchanged.
