### PR TITLE
Support Enum into String for hydration

### DIFF
--- a/lib/src/main/java/graphql/nadel/validation/hydration/NadelHydrationArgumentTypeValidation.kt
+++ b/lib/src/main/java/graphql/nadel/validation/hydration/NadelHydrationArgumentTypeValidation.kt
@@ -175,7 +175,7 @@ internal class NadelHydrationArgumentTypeValidation(
                 }
                 is GraphQLObjectType -> return NadelHydrationArgumentTypeValidationResult.Success
             }
-        } else if (requiredTypeUnwrapped is GraphQLScalarType && suppliedTypeUnwrapped is GraphQLScalarType) {
+        } else if (requiredTypeUnwrapped is GraphQLScalarType && suppliedTypeUnwrapped is GraphQLNamedInputType) {
             if (isScalarCompatible(suppliedTypeUnwrapped, requiredTypeUnwrapped)) {
                 return NadelHydrationArgumentTypeValidationResult.Success
             }
@@ -220,9 +220,10 @@ internal class NadelHydrationArgumentTypeValidation(
                 suppliedType.name == ExtendedScalars.GraphQLLong.name
         }
 
-        // Accept ID into String for compatibility
+        // Accept ID or enum into String for compatibility
         if (requiredType.name == Scalars.GraphQLString.name) {
-            return suppliedType.name == Scalars.GraphQLID.name
+            return suppliedType.name == Scalars.GraphQLID.name ||
+                suppliedType is GraphQLEnumType
         }
 
         return false

--- a/lib/src/test/kotlin/graphql/nadel/validation/NadelHydrationArgumentTypeValidationTest.kt
+++ b/lib/src/test/kotlin/graphql/nadel/validation/NadelHydrationArgumentTypeValidationTest.kt
@@ -390,6 +390,37 @@ class NadelHydrationArgumentTypeValidationTest {
     }
 
     @Test
+    fun `non-batched hydration succeeds if enum is supplied where String is required`() {
+        val fixture = NadelValidationTestFixture(
+            overallSchema = mapOf(
+                "jira" to /*language=GraphQL*/ """
+                    type Query {
+                        issueById(search: String): JiraIssue
+                    }
+                    enum IssueType {
+                      Story
+                      Task
+                      Bug
+                    }
+                    type JiraIssue {
+                        info: IssueType
+                        related: JiraIssue @hydrated(
+                            field: "issueById"
+                            arguments: [{ name: "search", value: "$source.info" }]
+                        )
+                    }
+                """.trimIndent(),
+            ),
+        )
+
+        // When
+        val errors = validate(fixture)
+
+        // Then
+        assertTrue(errors.isEmpty())
+    }
+
+    @Test
     fun `non-batched hydration fails if required argument is missing`() {
         val fixture = NadelValidationTestFixture(
             overallSchema = mapOf(


### PR DESCRIPTION
In GraphQL, `enum` types are serialised into `String` - as such, it is reasonable to expect that we can supply an `enum` type to a field expecting a `String` as input.

See also https://github.com/atlassian-labs/nadel/pull/723 which  lays the groundwork for conditional hydration (which would be built off in a subsequent PR).
