### PR TITLE
Wrapping all feild objects in lists

### DIFF
--- a/lib/src/main/java/graphql/nadel/NextgenEngine.kt
+++ b/lib/src/main/java/graphql/nadel/NextgenEngine.kt
@@ -201,19 +201,24 @@ internal class NextgenEngine(
                 val fields = fieldToService.getServicesForTopLevelFields(operation, executionHints)
                 val results = coroutineScope {
                     fields
-                        .map { (field, service) ->
-                            async {
-                                try {
-                                    val resolvedService = fieldToService.resolveDynamicService(field, service)
-                                    executeTopLevelField(
-                                        topLevelField = field,
-                                        service = resolvedService,
-                                        executionContext = executionContext,
-                                    )
-                                } catch (e: Throwable) {
-                                    when (e) {
-                                        is GraphQLError -> newServiceExecutionErrorResult(field, error = e)
-                                        else -> throw e
+                        // Each NadelFieldAndService may carry multiple top level fields destined
+                        // for the same service. For now the list always contains exactly one field,
+                        // so this preserves the existing one-field-per-call behaviour.
+                        .flatMap { (topLevelFields, service) ->
+                            topLevelFields.map { field ->
+                                async {
+                                    try {
+                                        val resolvedService = fieldToService.resolveDynamicService(field, service)
+                                        executeTopLevelField(
+                                            topLevelField = field,
+                                            service = resolvedService,
+                                            executionContext = executionContext,
+                                        )
+                                    } catch (e: Throwable) {
+                                        when (e) {
+                                            is GraphQLError -> newServiceExecutionErrorResult(field, error = e)
+                                            else -> throw e
+                                        }
                                     }
                                 }
                             }

--- a/lib/src/main/java/graphql/nadel/engine/transform/query/NadelFieldToService.kt
+++ b/lib/src/main/java/graphql/nadel/engine/transform/query/NadelFieldToService.kt
@@ -61,7 +61,7 @@ internal class NadelFieldToService(
             }
             .map { (service, childTopLevelFields) ->
                 NadelFieldAndService(
-                    field = topLevelField.copyWithChildren(childTopLevelFields),
+                    fields = listOf(topLevelField.copyWithChildren(childTopLevelFields)),
                     service = service,
                 )
             }
@@ -69,7 +69,7 @@ internal class NadelFieldToService(
 
     private fun getServicePairFor(field: ExecutableNormalizedField): NadelFieldAndService {
         return NadelFieldAndService(
-            field = field,
+            fields = listOf(field),
             service = getService(field),
         )
     }
@@ -110,7 +110,14 @@ internal class NadelFieldToService(
 }
 
 data class NadelFieldAndService(
-    val field: ExecutableNormalizedField,
+    /**
+     * The top level fields that are to be executed together against the [service].
+     *
+     * For now this list always contains exactly one field, so behaviour is unchanged.
+     * The list type exists to support batching of root fields in the future, where
+     * multiple root fields destined for the same service can be sent in a single call.
+     */
+    val fields: List<ExecutableNormalizedField>,
     val service: Service,
 )
 

--- a/lib/src/main/java/graphql/nadel/result/NadelResultMerger.kt
+++ b/lib/src/main/java/graphql/nadel/result/NadelResultMerger.kt
@@ -56,8 +56,8 @@ internal object NadelResultMerger {
         for ((topLevelResultKey, children) in requiredFieldMap) {
             val topLevelFieldDef by lazy {
                 fields
-                    .first { (field) -> field.resultKey == topLevelResultKey.value }
-                    .field
+                    .flatMap { it.fields }
+                    .first { field -> field.resultKey == topLevelResultKey.value }
                     .getFieldDefinitions(engineSchema)
                     .single() // This is under Query, Mutation etc. so there is only one field
             }
@@ -122,7 +122,7 @@ internal object NadelResultMerger {
 
         // NOTE: please ensure all fields are from object types and will NOT have multiple field defs
         // Other code in this file relies on this contract
-        for ((field) in fields) {
+        for (field in fields.flatMap { it.fields }) {
             val requiredChildFields = requiredFields
                 .computeIfAbsent(NadelResultKey(field.resultKey)) {
                     mutableListOf()


### PR DESCRIPTION
Please make sure you consider the following:

- [ ] Add tests that use __typename in queries
- [ ] Does this change work with all nadel transformations (rename, type rename, hydration, etc)? Add tests for this.
- [ ] Is it worth using hints for this change in order to be able to enable a percentage rollout?
- [ ] Do we need to add integration tests for this change in the graphql gateway?
- [ ] Do we need a pollinator check for this?
