### PR TITLE
don't expand abstract types to object fragments where possible

### DIFF
--- a/lib/src/main/java/graphql/nadel/NadelExecutionHints.kt
+++ b/lib/src/main/java/graphql/nadel/NadelExecutionHints.kt
@@ -7,6 +7,7 @@ import graphql.nadel.hints.NadelDisableSharedTypesHint
 import graphql.nadel.hints.NadelExecuteOnEngineSchemaHint
 import graphql.nadel.hints.NadelHydrationExecutableSourceFields
 import graphql.nadel.hints.NadelHydrationFilterObjectTypesHint
+import graphql.nadel.hints.NadelNoInterfaceToObjectFragmentExpansionHint
 import graphql.nadel.hints.NadelReachableUnderlyingServiceTypesHint
 import graphql.nadel.hints.NadelShadowUnderlyingTypeNameInvestigation
 import graphql.nadel.hints.NadelSharedTypeRenamesHint
@@ -28,6 +29,7 @@ data class NadelExecutionHints(
     val shadowUnderlyingTypeNameInvestigation: NadelShadowUnderlyingTypeNameInvestigation,
     val disableSharedTypes: NadelDisableSharedTypesHint,
     val useReachableUnderlyingServiceTypes: NadelReachableUnderlyingServiceTypesHint,
+    val noInterfaceToObjectFragmentExpansion: NadelNoInterfaceToObjectFragmentExpansionHint,
 ) {
     /**
      * Returns a builder with the same field values as this object.
@@ -53,6 +55,7 @@ data class NadelExecutionHints(
         private var shadowUnderlyingTypeNameInvestigation = NadelShadowUnderlyingTypeNameInvestigation { false }
         private var disableSharedTypes = NadelDisableSharedTypesHint { false }
         private var useReachableUnderlyingServiceTypes = NadelReachableUnderlyingServiceTypesHint { false }
+        private var noInterfaceToObjectFragmentExpansion = NadelNoInterfaceToObjectFragmentExpansionHint { false }
 
         constructor()
 
@@ -70,6 +73,7 @@ data class NadelExecutionHints(
             shadowUnderlyingTypeNameInvestigation = nadelExecutionHints.shadowUnderlyingTypeNameInvestigation
             disableSharedTypes = nadelExecutionHints.disableSharedTypes
             useReachableUnderlyingServiceTypes = nadelExecutionHints.useReachableUnderlyingServiceTypes
+            noInterfaceToObjectFragmentExpansion = nadelExecutionHints.noInterfaceToObjectFragmentExpansion
         }
 
         fun legacyOperationNames(flag: LegacyOperationNamesHint): Builder {
@@ -137,6 +141,11 @@ data class NadelExecutionHints(
             return this
         }
 
+        fun noInterfaceToObjectFragmentExpansion(flag: NadelNoInterfaceToObjectFragmentExpansionHint): Builder {
+            noInterfaceToObjectFragmentExpansion = flag
+            return this
+        }
+
         fun build(): NadelExecutionHints {
             return NadelExecutionHints(
                 legacyOperationNames,
@@ -152,6 +161,7 @@ data class NadelExecutionHints(
                 shadowUnderlyingTypeNameInvestigation,
                 disableSharedTypes,
                 useReachableUnderlyingServiceTypes,
+                noInterfaceToObjectFragmentExpansion,
             )
         }
     }

--- a/lib/src/main/java/graphql/nadel/NextgenEngine.kt
+++ b/lib/src/main/java/graphql/nadel/NextgenEngine.kt
@@ -325,6 +325,7 @@ internal class NextgenEngine(
                 executionContext = executionContext,
                 serviceExecutionContext = serviceExecutionContext,
                 executionHydrationDetails = executionContext.hydrationDetails,
+                forcePrintBareFields = queryTransform.forcePrintBareFields,
             )
         }
         if (result is NadelIncrementalServiceExecutionResult) {
@@ -375,6 +376,7 @@ internal class NextgenEngine(
         executionContext: NadelExecutionContext,
         serviceExecutionContext: NadelServiceExecutionContext,
         executionHydrationDetails: ServiceExecutionHydrationDetails? = null,
+        forcePrintBareFields: Set<ExecutableNormalizedField> = emptySet(),
     ): ServiceExecutionResult {
         val timer = executionContext.timer
 
@@ -390,6 +392,7 @@ internal class NextgenEngine(
                 topLevelFields = topLevelFields,
                 variablePredicate = jsonPredicate,
                 deferSupport = executionContext.hints.deferSupport(),
+                forcePrintBareFields = forcePrintBareFields,
             )
         }
 

--- a/lib/src/main/java/graphql/nadel/engine/compiler/NadelArgumentMaker.java
+++ b/lib/src/main/java/graphql/nadel/engine/compiler/NadelArgumentMaker.java
@@ -1,0 +1,112 @@
+package graphql.nadel.engine.compiler;
+
+import graphql.execution.directives.QueryAppliedDirective;
+import graphql.execution.directives.QueryAppliedDirectiveArgument;
+import graphql.execution.directives.QueryDirectives;
+import graphql.language.Argument;
+import graphql.language.ArrayValue;
+import graphql.language.NullValue;
+import graphql.language.ObjectField;
+import graphql.language.ObjectValue;
+import graphql.language.Value;
+import graphql.normalized.ExecutableNormalizedField;
+import graphql.normalized.NormalizedInputValue;
+import graphql.normalized.VariableAccumulator;
+import graphql.normalized.VariableValueWithDefinition;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static graphql.collect.ImmutableKit.emptyMap;
+import static graphql.collect.ImmutableKit.map;
+import static graphql.language.Argument.newArgument;
+
+/**
+ * Verbatim copy of graphql-java's package-private graphql.normalized.ArgumentMaker (pinned version
+ * 0.0.0-2026-03-18T00-52-57-e53ab1a), re-homed into Nadel so {@link NadelExecutableNormalizedOperationToAstCompiler}
+ * can reach it from this package. Keep in sync when bumping graphql-java.
+ */
+class NadelArgumentMaker {
+
+    static List<Argument> createArguments(ExecutableNormalizedField executableNormalizedField,
+                                          VariableAccumulator variableAccumulator) {
+        List<Argument> result = new ArrayList<>();
+        Map<String, NormalizedInputValue> normalizedArguments = executableNormalizedField.getNormalizedArguments();
+        for (String argName : normalizedArguments.keySet()) {
+            NormalizedInputValue normalizedInputValue = normalizedArguments.get(argName);
+            Value<?> value = argValue(executableNormalizedField, null, argName, normalizedInputValue, variableAccumulator);
+            Argument argument = newArgument()
+                    .name(argName)
+                    .value(value)
+                    .build();
+            result.add(argument);
+        }
+        return result;
+    }
+
+    static List<Argument> createDirectiveArguments(ExecutableNormalizedField executableNormalizedField,
+                                                   QueryDirectives queryDirectives,
+                                                   QueryAppliedDirective queryAppliedDirective,
+                                                   VariableAccumulator variableAccumulator) {
+
+        Map<String, NormalizedInputValue> argValueMap = queryDirectives.getNormalizedInputValueByImmediateAppliedDirectives().getOrDefault(queryAppliedDirective, emptyMap());
+
+        List<Argument> result = new ArrayList<>();
+        for (QueryAppliedDirectiveArgument directiveArgument : queryAppliedDirective.getArguments()) {
+            String argName = directiveArgument.getName();
+            if (argValueMap != null && argValueMap.containsKey(argName)) {
+                NormalizedInputValue normalizedInputValue = argValueMap.get(argName);
+                Value<?> value = argValue(executableNormalizedField, queryAppliedDirective, argName, normalizedInputValue, variableAccumulator);
+                Argument argument = newArgument()
+                        .name(argName)
+                        .value(value)
+                        .build();
+                result.add(argument);
+            }
+        }
+        return result;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Value<?> argValue(ExecutableNormalizedField executableNormalizedField,
+                                     QueryAppliedDirective queryAppliedDirective,
+                                     String argName,
+                                     @Nullable Object value,
+                                     VariableAccumulator variableAccumulator) {
+        if (value instanceof List) {
+            ArrayValue.Builder arrayValue = ArrayValue.newArrayValue();
+            arrayValue.values(map((List<Object>) value, val -> argValue(executableNormalizedField, queryAppliedDirective, argName, val, variableAccumulator)));
+            return arrayValue.build();
+        }
+        if (value instanceof Map) {
+            ObjectValue.Builder objectValue = ObjectValue.newObjectValue();
+            Map<String, Object> map = (Map<String, Object>) value;
+            for (String fieldName : map.keySet()) {
+                Value<?> fieldValue = argValue(executableNormalizedField, queryAppliedDirective, argName, (NormalizedInputValue) map.get(fieldName), variableAccumulator);
+                objectValue.objectField(ObjectField.newObjectField().name(fieldName).value(fieldValue).build());
+            }
+            return objectValue.build();
+        }
+        if (value == null) {
+            return NullValue.newNullValue().build();
+        }
+        return (Value<?>) value;
+    }
+
+    @NonNull
+    private static Value<?> argValue(ExecutableNormalizedField executableNormalizedField,
+                                     QueryAppliedDirective queryAppliedDirective,
+                                     String argName,
+                                     NormalizedInputValue normalizedInputValue,
+                                     VariableAccumulator variableAccumulator) {
+        if (variableAccumulator.shouldMakeVariable(executableNormalizedField, queryAppliedDirective, argName, normalizedInputValue)) {
+            VariableValueWithDefinition variableWithDefinition = variableAccumulator.accumulateVariable(normalizedInputValue);
+            return variableWithDefinition.getVariableReference();
+        } else {
+            return argValue(executableNormalizedField, queryAppliedDirective, argName, normalizedInputValue.getValue(), variableAccumulator);
+        }
+    }
+}

--- a/lib/src/main/java/graphql/nadel/engine/compiler/NadelExecutableNormalizedOperationToAstCompiler.java
+++ b/lib/src/main/java/graphql/nadel/engine/compiler/NadelExecutableNormalizedOperationToAstCompiler.java
@@ -1,0 +1,380 @@
+package graphql.nadel.engine.compiler;
+
+import graphql.Assert;
+import graphql.Directives;
+import graphql.execution.directives.QueryAppliedDirective;
+import graphql.execution.directives.QueryDirectives;
+import graphql.introspection.Introspection;
+import graphql.language.Argument;
+import graphql.language.Directive;
+import graphql.language.Document;
+import graphql.language.Field;
+import graphql.language.InlineFragment;
+import graphql.language.OperationDefinition;
+import graphql.language.Selection;
+import graphql.language.SelectionSet;
+import graphql.language.StringValue;
+import graphql.language.TypeName;
+import graphql.normalized.ExecutableNormalizedField;
+import graphql.normalized.ExecutableNormalizedOperationToAstCompiler.CompilerResult;
+import graphql.normalized.VariableAccumulator;
+import graphql.normalized.VariablePredicate;
+import graphql.normalized.incremental.NormalizedDeferredExecution;
+import graphql.schema.GraphQLCompositeType;
+import graphql.schema.GraphQLFieldDefinition;
+import graphql.schema.GraphQLObjectType;
+import graphql.schema.GraphQLSchema;
+import graphql.schema.GraphQLUnmodifiedType;
+import graphql.util.LinkedHashMapFactory;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static graphql.collect.ImmutableKit.emptyList;
+import static graphql.language.Argument.newArgument;
+import static graphql.language.Field.newField;
+import static graphql.language.InlineFragment.newInlineFragment;
+import static graphql.language.SelectionSet.newSelectionSet;
+import static graphql.language.TypeName.newTypeName;
+import static graphql.schema.GraphQLTypeUtil.unwrapAll;
+
+/**
+ * Nadel fork of graphql-java's {@code graphql.normalized.ExecutableNormalizedOperationToAstCompiler}
+ * (pinned version 0.0.0-2026-03-18T00-52-57-e53ab1a). It is a verbatim copy of the upstream logic with a
+ * single behavioural addition: any {@link ExecutableNormalizedField} in {@code forcePrintBareFields} is emitted
+ * bare (no {@code ... on Type} inline fragment) even though its {@code objectTypeNames} is a strict subset of
+ * its parent's possible types. This lets Nadel keep {@code objectTypeNames} honest while still sending an
+ * interface/union-level selection bare to the underlying service (GQLGW-6377). With an empty
+ * {@code forcePrintBareFields} the output is byte-identical to upstream (see NadelAstCompilerDifferentialTest).
+ * The one package-private helper it needs, {@link NadelArgumentMaker}, is copied alongside it.
+ *
+ * <p>Membership is by object identity ({@link ExecutableNormalizedField} does not override equals/hashCode);
+ * callers must pass the exact instances that reach this compiler (the rebuilt underlying tree).
+ *
+ * <p>Keep in sync when bumping graphql-java.
+ */
+public class NadelExecutableNormalizedOperationToAstCompiler {
+
+    public static CompilerResult compileToDocument(@NonNull GraphQLSchema schema,
+                                                   OperationDefinition.@NonNull Operation operationKind,
+                                                   @Nullable String operationName,
+                                                   @NonNull List<ExecutableNormalizedField> topLevelFields,
+                                                   @Nullable VariablePredicate variablePredicate,
+                                                   @NonNull Set<ExecutableNormalizedField> forcePrintBareFields) {
+        return compileToDocument(schema, operationKind, operationName, topLevelFields, LinkedHashMapFactory.of(), variablePredicate, forcePrintBareFields, false);
+    }
+
+    public static CompilerResult compileToDocumentWithDeferSupport(@NonNull GraphQLSchema schema,
+                                                                   OperationDefinition.@NonNull Operation operationKind,
+                                                                   @Nullable String operationName,
+                                                                   @NonNull List<ExecutableNormalizedField> topLevelFields,
+                                                                   @Nullable VariablePredicate variablePredicate,
+                                                                   @NonNull Set<ExecutableNormalizedField> forcePrintBareFields) {
+        return compileToDocument(schema, operationKind, operationName, topLevelFields, LinkedHashMapFactory.of(), variablePredicate, forcePrintBareFields, true);
+    }
+
+    private static CompilerResult compileToDocument(@NonNull GraphQLSchema schema,
+                                                    OperationDefinition.@NonNull Operation operationKind,
+                                                    @Nullable String operationName,
+                                                    @NonNull List<ExecutableNormalizedField> topLevelFields,
+                                                    @NonNull Map<ExecutableNormalizedField, QueryDirectives> normalizedFieldToQueryDirectives,
+                                                    @Nullable VariablePredicate variablePredicate,
+                                                    @NonNull Set<ExecutableNormalizedField> forcePrintBareFields,
+                                                    boolean deferSupport) {
+        GraphQLObjectType operationType = getOperationType(schema, operationKind);
+
+        VariableAccumulator variableAccumulator = new VariableAccumulator(variablePredicate);
+        List<Selection<?>> selections = subselectionsForNormalizedField(schema, operationType.getName(), topLevelFields, normalizedFieldToQueryDirectives, variableAccumulator, forcePrintBareFields, deferSupport);
+        SelectionSet selectionSet = new SelectionSet(selections);
+
+        OperationDefinition.Builder definitionBuilder = OperationDefinition.newOperationDefinition()
+                .name(operationName)
+                .operation(operationKind)
+                .selectionSet(selectionSet);
+
+        definitionBuilder.variableDefinitions(variableAccumulator.getVariableDefinitions());
+
+        return new CompilerResult(
+                Document.newDocument()
+                        .definition(definitionBuilder.build())
+                        .build(),
+                variableAccumulator.getVariablesMap()
+        );
+    }
+
+    private static List<Selection<?>> subselectionsForNormalizedField(GraphQLSchema schema,
+                                                                      @NonNull String parentOutputType,
+                                                                      List<ExecutableNormalizedField> executableNormalizedFields,
+                                                                      @NonNull Map<ExecutableNormalizedField, QueryDirectives> normalizedFieldToQueryDirectives,
+                                                                      VariableAccumulator variableAccumulator,
+                                                                      @NonNull Set<ExecutableNormalizedField> forcePrintBareFields,
+                                                                      boolean deferSupport) {
+        if (deferSupport) {
+            return subselectionsForNormalizedFieldWithDeferSupport(schema, parentOutputType, executableNormalizedFields, normalizedFieldToQueryDirectives, variableAccumulator, forcePrintBareFields);
+        } else {
+            return subselectionsForNormalizedFieldNoDeferSupport(schema, parentOutputType, executableNormalizedFields, normalizedFieldToQueryDirectives, variableAccumulator, forcePrintBareFields);
+        }
+    }
+
+    private static List<Selection<?>> subselectionsForNormalizedFieldNoDeferSupport(GraphQLSchema schema,
+                                                                                    @NonNull String parentOutputType,
+                                                                                    List<ExecutableNormalizedField> executableNormalizedFields,
+                                                                                    @NonNull Map<ExecutableNormalizedField, QueryDirectives> normalizedFieldToQueryDirectives,
+                                                                                    VariableAccumulator variableAccumulator,
+                                                                                    @NonNull Set<ExecutableNormalizedField> forcePrintBareFields) {
+        List<Selection<?>> selections = new ArrayList<>();
+
+        // All conditional fields go here instead of directly to selections, so they can be grouped together
+        // in the same inline fragment in the output
+        Map<String, List<Field>> fieldsByTypeCondition = new LinkedHashMap<>();
+
+        for (ExecutableNormalizedField nf : executableNormalizedFields) {
+            // Nadel: forcePrintBareFields are emitted bare even when isConditional would wrap them in a fragment.
+            if (nf.isConditional(schema) && !forcePrintBareFields.contains(nf)) {
+                selectionForNormalizedField(schema, nf, normalizedFieldToQueryDirectives, variableAccumulator, forcePrintBareFields, false)
+                        .forEach((objectTypeName, field) ->
+                                fieldsByTypeCondition
+                                        .computeIfAbsent(objectTypeName, ignored -> new ArrayList<>())
+                                        .add(field));
+            } else {
+                selections.add(selectionForNormalizedField(schema, parentOutputType, nf, normalizedFieldToQueryDirectives, variableAccumulator, forcePrintBareFields, false));
+            }
+        }
+
+        fieldsByTypeCondition.forEach((objectTypeName, fields) -> {
+            TypeName typeName = newTypeName(objectTypeName).build();
+            InlineFragment inlineFragment = newInlineFragment()
+                    .typeCondition(typeName)
+                    .selectionSet(selectionSet(fields))
+                    .build();
+            selections.add(inlineFragment);
+        });
+
+        return selections;
+    }
+
+
+    private static List<Selection<?>> subselectionsForNormalizedFieldWithDeferSupport(GraphQLSchema schema,
+                                                                                      @NonNull String parentOutputType,
+                                                                                      List<ExecutableNormalizedField> executableNormalizedFields,
+                                                                                      @NonNull Map<ExecutableNormalizedField, QueryDirectives> normalizedFieldToQueryDirectives,
+                                                                                      VariableAccumulator variableAccumulator,
+                                                                                      @NonNull Set<ExecutableNormalizedField> forcePrintBareFields) {
+        List<Selection<?>> selections = new ArrayList<>();
+
+        // All conditional and deferred fields go here instead of directly to selections, so they can be grouped together
+        // in the same inline fragment in the output
+        //
+        Map<ExecutionFragmentDetails, List<Field>> fieldsByFragmentDetails = new LinkedHashMap<>();
+
+        for (ExecutableNormalizedField nf : executableNormalizedFields) {
+            LinkedHashSet<NormalizedDeferredExecution> deferredExecutions = nf.getDeferredExecutions();
+
+            // Nadel: forcePrintBareFields are emitted bare even when isConditional would wrap them in a fragment.
+            if (nf.isConditional(schema) && !forcePrintBareFields.contains(nf)) {
+                selectionForNormalizedField(schema, nf, normalizedFieldToQueryDirectives, variableAccumulator, forcePrintBareFields, true)
+                        .forEach((objectTypeName, field) -> {
+                            if (deferredExecutions == null || deferredExecutions.isEmpty()) {
+                                fieldsByFragmentDetails
+                                        .computeIfAbsent(new ExecutionFragmentDetails(objectTypeName, null), ignored -> new ArrayList<>())
+                                        .add(field);
+                            } else {
+                                deferredExecutions.forEach(deferredExecution -> {
+                                    fieldsByFragmentDetails
+                                            .computeIfAbsent(new ExecutionFragmentDetails(objectTypeName, deferredExecution), ignored -> new ArrayList<>())
+                                            .add(field);
+                                });
+                            }
+                        });
+
+            } else if (deferredExecutions != null && !deferredExecutions.isEmpty()) {
+                Field field = selectionForNormalizedField(schema, parentOutputType, nf, normalizedFieldToQueryDirectives, variableAccumulator, forcePrintBareFields, true);
+
+                deferredExecutions.forEach(deferredExecution -> {
+                    fieldsByFragmentDetails
+                            .computeIfAbsent(new ExecutionFragmentDetails(null, deferredExecution), ignored -> new ArrayList<>())
+                            .add(field);
+                });
+            } else {
+                selections.add(selectionForNormalizedField(schema, parentOutputType, nf, normalizedFieldToQueryDirectives, variableAccumulator, forcePrintBareFields, true));
+            }
+        }
+
+        fieldsByFragmentDetails.forEach((typeAndDeferPair, fields) -> {
+            InlineFragment.Builder fragmentBuilder = newInlineFragment()
+                    .selectionSet(selectionSet(fields));
+
+            if (typeAndDeferPair.typeName != null) {
+                TypeName typeName = newTypeName(typeAndDeferPair.typeName).build();
+                fragmentBuilder.typeCondition(typeName);
+            }
+
+            if (typeAndDeferPair.deferredExecution != null) {
+                Directive.Builder deferBuilder = Directive.newDirective().name(Directives.DeferDirective.getName());
+
+                if (typeAndDeferPair.deferredExecution.getLabel() != null) {
+                    deferBuilder.argument(newArgument().name("label").value(StringValue.of(typeAndDeferPair.deferredExecution.getLabel())).build());
+                }
+
+                fragmentBuilder.directive(deferBuilder.build());
+            }
+
+
+            selections.add(fragmentBuilder.build());
+        });
+
+        return selections;
+    }
+
+    /**
+     * @return Map of object type names to list of fields
+     */
+    private static Map<String, Field> selectionForNormalizedField(GraphQLSchema schema,
+                                                                  ExecutableNormalizedField executableNormalizedField,
+                                                                  @NonNull Map<ExecutableNormalizedField, QueryDirectives> normalizedFieldToQueryDirectives,
+                                                                  VariableAccumulator variableAccumulator,
+                                                                  @NonNull Set<ExecutableNormalizedField> forcePrintBareFields,
+                                                                  boolean deferSupport) {
+        Map<String, Field> groupedFields = new LinkedHashMap<>();
+
+        for (String objectTypeName : executableNormalizedField.getObjectTypeNames()) {
+            groupedFields.put(objectTypeName, selectionForNormalizedField(schema, objectTypeName, executableNormalizedField, normalizedFieldToQueryDirectives, variableAccumulator, forcePrintBareFields, deferSupport));
+        }
+
+        return groupedFields;
+    }
+
+    /**
+     * @return a single {@link Field} resolved in the context of the given object type
+     */
+    private static Field selectionForNormalizedField(GraphQLSchema schema,
+                                                     String objectTypeName,
+                                                     ExecutableNormalizedField executableNormalizedField,
+                                                     @NonNull Map<ExecutableNormalizedField, QueryDirectives> normalizedFieldToQueryDirectives,
+                                                     VariableAccumulator variableAccumulator,
+                                                     @NonNull Set<ExecutableNormalizedField> forcePrintBareFields,
+                                                     boolean deferSupport) {
+        final List<Selection<?>> subSelections;
+        if (executableNormalizedField.getChildren().isEmpty()) {
+            subSelections = emptyList();
+        } else {
+            GraphQLFieldDefinition fieldDef = getFieldDefinition(schema, objectTypeName, executableNormalizedField);
+            GraphQLUnmodifiedType fieldOutputType = unwrapAll(fieldDef.getType());
+
+            subSelections = subselectionsForNormalizedField(
+                    schema,
+                    fieldOutputType.getName(),
+                    executableNormalizedField.getChildren(),
+                    normalizedFieldToQueryDirectives,
+                    variableAccumulator,
+                    forcePrintBareFields,
+                    deferSupport
+            );
+        }
+
+        SelectionSet selectionSet = selectionSetOrNullIfEmpty(subSelections);
+        List<Argument> arguments = NadelArgumentMaker.createArguments(executableNormalizedField, variableAccumulator);
+
+        QueryDirectives queryDirectives = normalizedFieldToQueryDirectives.get(executableNormalizedField);
+
+        Field.Builder builder = newField()
+                .name(executableNormalizedField.getFieldName())
+                .alias(executableNormalizedField.getAlias())
+                .selectionSet(selectionSet)
+                .arguments(arguments);
+
+        List<Directive> directives = buildDirectives(executableNormalizedField, queryDirectives, variableAccumulator);
+        return builder
+                .directives(directives)
+                .build();
+    }
+
+    private static @NonNull List<Directive> buildDirectives(ExecutableNormalizedField executableNormalizedField, QueryDirectives queryDirectives, VariableAccumulator variableAccumulator) {
+        if (queryDirectives == null || queryDirectives.getImmediateAppliedDirectivesByField().isEmpty()) {
+            return emptyList();
+        }
+        return queryDirectives.getImmediateAppliedDirectivesByField().entrySet().stream()
+                .flatMap(entry -> entry.getValue().stream())
+                .map(queryAppliedDirective -> buildDirective(executableNormalizedField, queryDirectives, queryAppliedDirective, variableAccumulator))
+                .collect(Collectors.toList());
+    }
+
+    private static Directive buildDirective(ExecutableNormalizedField executableNormalizedField, QueryDirectives queryDirectives, QueryAppliedDirective queryAppliedDirective, VariableAccumulator variableAccumulator) {
+
+        List<Argument> arguments = NadelArgumentMaker.createDirectiveArguments(executableNormalizedField, queryDirectives, queryAppliedDirective, variableAccumulator);
+        return Directive.newDirective()
+                .name(queryAppliedDirective.getName())
+                .arguments(arguments).build();
+    }
+
+    @Nullable
+    private static SelectionSet selectionSetOrNullIfEmpty(List<Selection<?>> selections) {
+        return selections.isEmpty() ? null : newSelectionSet().selections(selections).build();
+    }
+
+    private static SelectionSet selectionSet(List<Field> fields) {
+        return newSelectionSet().selections(fields).build();
+    }
+
+
+    @NonNull
+    private static GraphQLFieldDefinition getFieldDefinition(GraphQLSchema schema,
+                                                             String parentType,
+                                                             ExecutableNormalizedField nf) {
+        return Introspection.getFieldDef(schema, (GraphQLCompositeType) schema.getType(parentType), nf.getName());
+    }
+
+
+    @Nullable
+    private static GraphQLObjectType getOperationType(@NonNull GraphQLSchema schema,
+                                                      OperationDefinition.@NonNull Operation operationKind) {
+        switch (operationKind) {
+            case QUERY:
+                return schema.getQueryType();
+            case MUTATION:
+                return schema.getMutationType();
+            case SUBSCRIPTION:
+                return schema.getSubscriptionType();
+        }
+
+        return Assert.assertShouldNeverHappen("Unknown operation kind " + operationKind);
+    }
+
+    /**
+     * Represents important execution details that can be associated with a fragment.
+     */
+    private static class ExecutionFragmentDetails {
+        private final String typeName;
+        private final NormalizedDeferredExecution deferredExecution;
+
+        public ExecutionFragmentDetails(String typeName, NormalizedDeferredExecution deferredExecution) {
+            this.typeName = typeName;
+            this.deferredExecution = deferredExecution;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            ExecutionFragmentDetails that = (ExecutionFragmentDetails) o;
+            return Objects.equals(typeName, that.typeName) && Objects.equals(deferredExecution, that.deferredExecution);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(typeName, deferredExecution);
+        }
+    }
+}

--- a/lib/src/main/java/graphql/nadel/engine/plan/NadelExecutionPlanFactory.kt
+++ b/lib/src/main/java/graphql/nadel/engine/plan/NadelExecutionPlanFactory.kt
@@ -7,6 +7,7 @@ import graphql.nadel.engine.NadelExecutionContext
 import graphql.nadel.engine.NadelServiceExecutionContext
 import graphql.nadel.engine.blueprint.NadelOverallExecutionBlueprint
 import graphql.nadel.engine.transform.NadelDeepRenameTransform
+import graphql.nadel.engine.transform.NadelNoInterfaceToObjectFragmentExpansionTransform
 import graphql.nadel.engine.transform.NadelRenameArgumentInputTypesTransform
 import graphql.nadel.engine.transform.NadelRenameTransform
 import graphql.nadel.engine.transform.NadelServiceTypeFilterTransform
@@ -164,6 +165,9 @@ internal class NadelExecutionPlanFactory(
                     NadelBatchHydrationTransform(engine),
                     NadelRenameArgumentInputTypesTransform(),
                     NadelRenameTransform(),
+                    // Must run last: no other transform should see the widened objectTypeNames, and its
+                    // result-side hiding must apply after any type-rename.
+                    NadelNoInterfaceToObjectFragmentExpansionTransform(),
                 ),
             )
         }

--- a/lib/src/main/java/graphql/nadel/engine/transform/NadelNoInterfaceToObjectFragmentExpansionTransform.kt
+++ b/lib/src/main/java/graphql/nadel/engine/transform/NadelNoInterfaceToObjectFragmentExpansionTransform.kt
@@ -1,0 +1,231 @@
+package graphql.nadel.engine.transform
+
+import graphql.introspection.Introspection
+import graphql.introspection.Introspection.TypeNameMetaFieldDef
+import graphql.nadel.Service
+import graphql.nadel.ServiceExecutionHydrationDetails
+import graphql.nadel.ServiceExecutionResult
+import graphql.nadel.engine.NadelExecutionContext
+import graphql.nadel.engine.NadelServiceExecutionContext
+import graphql.nadel.engine.blueprint.IntrospectionService
+import graphql.nadel.engine.blueprint.NadelFieldInstruction
+import graphql.nadel.engine.blueprint.NadelOverallExecutionBlueprint
+import graphql.nadel.engine.transform.NadelNoInterfaceToObjectFragmentExpansionTransform.State
+import graphql.nadel.engine.transform.artificial.NadelAliasHelper
+import graphql.nadel.engine.transform.query.NadelQueryTransformer
+import graphql.nadel.engine.transform.result.NadelResultInstruction
+import graphql.nadel.engine.transform.result.NadelResultKey
+import graphql.nadel.engine.transform.result.json.JsonNodes
+import graphql.nadel.engine.util.JsonMap
+import graphql.nadel.engine.util.queryPath
+import graphql.nadel.engine.util.toBuilder
+import graphql.normalized.ExecutableNormalizedField
+import graphql.normalized.ExecutableNormalizedField.newNormalizedField
+import graphql.schema.GraphQLInterfaceType
+import graphql.schema.GraphQLTypeUtil.unwrapAll
+import graphql.schema.GraphQLUnionType
+
+/**
+ * Sends a field the client selected at an interface/union level (an interface field, or `__typename`) to the
+ * underlying service **bare** instead of expanding it into a `... on ConcreteType` fragment per exposed member,
+ * so a not-yet-deployed sibling type can't be injected into a query the client never named. Hiding is preserved
+ * on the result side: an aliased `__typename` is injected, and any node whose concrete type isn't exposed is
+ * stripped back to `{}`.
+ *
+ * Gated per-service by [graphql.nadel.hints.NadelNoInterfaceToObjectFragmentExpansionHint]; inert when off.
+ * Registered last so its result-side removals run after type renames. Only plain fields (no
+ * [NadelFieldInstruction]) are relaxed.
+ */
+class NadelNoInterfaceToObjectFragmentExpansionTransform : NadelTransform<State> {
+    data class State(
+        val aliasHelper: NadelAliasHelper,
+        val exposedOverallImplNames: Set<String>,
+        val widenToOverallNames: List<String>,
+        val relaxedFieldResultKey: String,
+    )
+
+    override suspend fun isApplicable(
+        executionContext: NadelExecutionContext,
+        serviceExecutionContext: NadelServiceExecutionContext,
+        executionBlueprint: NadelOverallExecutionBlueprint,
+        services: Map<String, Service>,
+        service: Service,
+        overallField: ExecutableNormalizedField,
+        transformServiceExecutionContext: NadelTransformServiceExecutionContext?,
+        hydrationDetails: ServiceExecutionHydrationDetails?,
+    ): State? {
+        if (!executionContext.hints.noInterfaceToObjectFragmentExpansion(service)) {
+            return null
+        }
+        if (service.name == IntrospectionService.name) {
+            return null
+        }
+        // Do nothing for defer
+        if (overallField.deferredExecutions.isNotEmpty()) {
+            return null
+        }
+        val parent = overallField.parent ?: return null
+
+        val relaxationContext = computeAbstractTypeRelaxationContext(executionBlueprint, service, overallField)
+            ?: return null
+
+        // Do nothing for fields with instructions (rename/hydration/stub/…)
+        val hasFieldInstructions = runCatching {
+            executionBlueprint.getTypeNameToInstructionMap<NadelFieldInstruction>(overallField).isNotEmpty()
+        }.getOrDefault(true)
+        if (hasFieldInstructions) {
+            return null
+        }
+
+        return State(
+            aliasHelper = NadelAliasHelper.forField(tag = "abstract_member", field = parent),
+            exposedOverallImplNames = relaxationContext.exposedOverallImplNames,
+            widenToOverallNames = relaxationContext.widenToOverallNames,
+            relaxedFieldResultKey = overallField.resultKey,
+        )
+    }
+
+    override suspend fun transformField(
+        executionContext: NadelExecutionContext,
+        serviceExecutionContext: NadelServiceExecutionContext,
+        transformer: NadelQueryTransformer,
+        executionBlueprint: NadelOverallExecutionBlueprint,
+        service: Service,
+        field: ExecutableNormalizedField,
+        state: State,
+        transformServiceExecutionContext: NadelTransformServiceExecutionContext?,
+    ): NadelTransformFieldResult {
+        // Widen to all members so graphql-java prints the field bare.
+        val bareField = field.toBuilder()
+            .clearObjectTypesNames()
+            .objectTypeNames(state.widenToOverallNames)
+            .build()
+
+        // Aliased __typename (also bare) so the result side can tell each node's concrete type.
+        val typeNameField = newNormalizedField()
+            .objectTypeNames(state.widenToOverallNames)
+            .alias(state.aliasHelper.typeNameResultKey)
+            .fieldName(Introspection.TypeNameMetaFieldDef.name)
+            .build()
+
+        return NadelTransformFieldResult(
+            newField = bareField,
+            artificialFields = listOf(typeNameField),
+        )
+    }
+
+    override suspend fun getResultInstructions(
+        executionContext: NadelExecutionContext,
+        serviceExecutionContext: NadelServiceExecutionContext,
+        executionBlueprint: NadelOverallExecutionBlueprint,
+        service: Service,
+        overallField: ExecutableNormalizedField,
+        underlyingParentField: ExecutableNormalizedField?,
+        result: ServiceExecutionResult,
+        state: State,
+        nodes: JsonNodes,
+        transformServiceExecutionContext: NadelTransformServiceExecutionContext?,
+    ): List<NadelResultInstruction> {
+        val parentPath = underlyingParentField?.queryPath ?: overallField.parent?.queryPath ?: return emptyList()
+        val parentNodes = nodes.getNodesAt(parentPath, flatten = true)
+        val key = state.aliasHelper.typeNameResultKey
+
+        val instructions = mutableListOf<NadelResultInstruction>()
+        for (node in parentNodes) {
+            @Suppress("UNCHECKED_CAST")
+            val nodeMap = node.value as? JsonMap ?: continue
+            val underlyingTypeName = nodeMap[key] as String?
+            val overallTypeName = underlyingTypeName?.let { executionBlueprint.getOverallTypeName(service, it) }
+            val isExposed = overallTypeName != null && overallTypeName in state.exposedOverallImplNames
+            if (!isExposed) {
+                // Fail closed: hide any node whose concrete type isn't exposed (reduces it to `{}`).
+                instructions += NadelResultInstruction.Remove(
+                    subject = node,
+                    key = NadelResultKey(state.relaxedFieldResultKey),
+                )
+            }
+        }
+        return instructions
+    }
+}
+
+/**
+ * Structural preconditions for bare emission, or `null` if [overallField] isn't a candidate: the parent is a
+ * single interface/union, the field is selectable at that level (an interface field, or `__typename`), the
+ * selection covers exactly the exposed members, and at least one underlying member is hidden. Doesn't consider
+ * the hint or field instructions — the caller does.
+ */
+private fun computeAbstractTypeRelaxationContext(
+    executionBlueprint: NadelOverallExecutionBlueprint,
+    service: Service,
+    overallField: ExecutableNormalizedField,
+): NadelAbstractTypeRelaxationContext? {
+    val parent = overallField.parent ?: return null
+
+    val engineSchema = executionBlueprint.engineSchema
+    val isTypename = overallField.fieldName == TypeNameMetaFieldDef.name
+
+    // getFieldDefinitions can throw while planning a hydration backing query; any failure => not a candidate.
+    val parentOutputTypes = runCatching {
+        parent.getFieldDefinitions(engineSchema)
+            .asSequence()
+            .map { unwrapAll(it.type) }
+            .toSet()
+    }.getOrNull() ?: return null
+
+    // Exposed members, gated on the field being selectable at that level (union => __typename only).
+    val exposedOverallImplNames: Set<String>
+    val parentAbstractTypeName: String
+    when (val parentType = parentOutputTypes.singleOrNull()) {
+        is GraphQLInterfaceType -> {
+            if (!isTypename && parentType.getFieldDefinition(overallField.fieldName) == null) {
+                return null
+            }
+            exposedOverallImplNames = engineSchema.getImplementations(parentType).map { it.name }.toSet()
+            parentAbstractTypeName = parentType.name
+        }
+        is GraphQLUnionType -> {
+            if (!isTypename) {
+                return null
+            }
+            exposedOverallImplNames = parentType.types.map { it.name }.toSet()
+            parentAbstractTypeName = parentType.name
+        }
+        else -> return null
+    }
+
+    // Means the client used fragments with explicit objects. don't relax.
+    if (overallField.objectTypeNames.toSet() != exposedOverallImplNames) {
+        return null
+    }
+
+    val underlyingTypeName = executionBlueprint.getUnderlyingTypeName(parentAbstractTypeName)
+    val underlyingMemberNames = when (val underlyingType = service.underlyingSchema.getType(underlyingTypeName)) {
+        is GraphQLInterfaceType -> service.underlyingSchema.getImplementations(underlyingType).map { it.name }
+        is GraphQLUnionType -> underlyingType.types.map { it.name }
+        else -> return null
+    }
+    if (underlyingMemberNames.isEmpty()) {
+        return null
+    }
+
+    // Nothing to hide unless a member is hidden (and graphql-java already prints bare when none is).
+    val hasHiddenImpl = underlyingMemberNames.any { underlyingName ->
+        executionBlueprint.getOverallTypeName(service, underlyingName) !in exposedOverallImplNames
+    }
+    if (!hasHiddenImpl) {
+        return null
+    }
+
+    val widenToOverallNames = underlyingMemberNames.map { executionBlueprint.getOverallTypeName(service, it) }
+
+    return NadelAbstractTypeRelaxationContext(
+        exposedOverallImplNames = exposedOverallImplNames,
+        widenToOverallNames = widenToOverallNames,
+    )
+}
+
+private data class NadelAbstractTypeRelaxationContext(
+    val exposedOverallImplNames: Set<String>,
+    val widenToOverallNames: List<String>,
+)

--- a/lib/src/main/java/graphql/nadel/engine/transform/NadelNoInterfaceToObjectFragmentExpansionTransform.kt
+++ b/lib/src/main/java/graphql/nadel/engine/transform/NadelNoInterfaceToObjectFragmentExpansionTransform.kt
@@ -40,7 +40,7 @@ class NadelNoInterfaceToObjectFragmentExpansionTransform : NadelTransform<State>
     data class State(
         val aliasHelper: NadelAliasHelper,
         val exposedOverallImplNames: Set<String>,
-        val widenToOverallNames: List<String>,
+        val allUnderlyingMembersAsOverallNames: List<String>,
         val relaxedFieldResultKey: String,
     )
 
@@ -80,7 +80,7 @@ class NadelNoInterfaceToObjectFragmentExpansionTransform : NadelTransform<State>
         return State(
             aliasHelper = NadelAliasHelper.forField(tag = "abstract_member", field = parent),
             exposedOverallImplNames = relaxationContext.exposedOverallImplNames,
-            widenToOverallNames = relaxationContext.widenToOverallNames,
+            allUnderlyingMembersAsOverallNames = relaxationContext.allUnderlyingMembersAsOverallNames,
             relaxedFieldResultKey = overallField.resultKey,
         )
     }
@@ -95,15 +95,15 @@ class NadelNoInterfaceToObjectFragmentExpansionTransform : NadelTransform<State>
         state: State,
         transformServiceExecutionContext: NadelTransformServiceExecutionContext?,
     ): NadelTransformFieldResult {
-        // Widen to all members so graphql-java prints the field bare.
+        // Widen objectTypeNames to cover every underlying member so graphql-java prints the field bare.
         val bareField = field.toBuilder()
             .clearObjectTypesNames()
-            .objectTypeNames(state.widenToOverallNames)
+            .objectTypeNames(state.allUnderlyingMembersAsOverallNames)
             .build()
 
         // Aliased __typename (also bare) so the result side can tell each node's concrete type.
         val typeNameField = newNormalizedField()
-            .objectTypeNames(state.widenToOverallNames)
+            .objectTypeNames(state.allUnderlyingMembersAsOverallNames)
             .alias(state.aliasHelper.typeNameResultKey)
             .fieldName(Introspection.TypeNameMetaFieldDef.name)
             .build()
@@ -217,15 +217,16 @@ private fun computeAbstractTypeRelaxationContext(
         return null
     }
 
-    val widenToOverallNames = underlyingMemberNames.map { executionBlueprint.getOverallTypeName(service, it) }
+    // Every underlying member (incl. hidden ones), named in overall terms so it can go on the overall ENF;
+    val allUnderlyingMembersAsOverallNames = underlyingMemberNames.map { executionBlueprint.getOverallTypeName(service, it) }
 
     return NadelAbstractTypeRelaxationContext(
         exposedOverallImplNames = exposedOverallImplNames,
-        widenToOverallNames = widenToOverallNames,
+        allUnderlyingMembersAsOverallNames = allUnderlyingMembersAsOverallNames,
     )
 }
 
 private data class NadelAbstractTypeRelaxationContext(
     val exposedOverallImplNames: Set<String>,
-    val widenToOverallNames: List<String>,
+    val allUnderlyingMembersAsOverallNames: List<String>,
 )

--- a/lib/src/main/java/graphql/nadel/engine/transform/NadelNoInterfaceToObjectFragmentExpansionTransform.kt
+++ b/lib/src/main/java/graphql/nadel/engine/transform/NadelNoInterfaceToObjectFragmentExpansionTransform.kt
@@ -18,7 +18,6 @@ import graphql.nadel.engine.transform.result.NadelResultKey
 import graphql.nadel.engine.transform.result.json.JsonNodes
 import graphql.nadel.engine.util.JsonMap
 import graphql.nadel.engine.util.queryPath
-import graphql.nadel.engine.util.toBuilder
 import graphql.normalized.ExecutableNormalizedField
 import graphql.normalized.ExecutableNormalizedField.newNormalizedField
 import graphql.schema.GraphQLInterfaceType
@@ -40,7 +39,6 @@ class NadelNoInterfaceToObjectFragmentExpansionTransform : NadelTransform<State>
     data class State(
         val aliasHelper: NadelAliasHelper,
         val exposedOverallImplNames: Set<String>,
-        val allUnderlyingMembersAsOverallNames: List<String>,
         val relaxedFieldResultKey: String,
     )
 
@@ -66,7 +64,7 @@ class NadelNoInterfaceToObjectFragmentExpansionTransform : NadelTransform<State>
         }
         val parent = overallField.parent ?: return null
 
-        val relaxationContext = computeAbstractTypeRelaxationContext(executionBlueprint, service, overallField)
+        val exposedOverallImplNames = computeExposedImplNamesIfRelaxable(executionBlueprint, service, overallField)
             ?: return null
 
         // Do nothing for fields with instructions (rename/hydration/stub/…)
@@ -79,8 +77,7 @@ class NadelNoInterfaceToObjectFragmentExpansionTransform : NadelTransform<State>
 
         return State(
             aliasHelper = NadelAliasHelper.forField(tag = "abstract_member", field = parent),
-            exposedOverallImplNames = relaxationContext.exposedOverallImplNames,
-            allUnderlyingMembersAsOverallNames = relaxationContext.allUnderlyingMembersAsOverallNames,
+            exposedOverallImplNames = exposedOverallImplNames,
             relaxedFieldResultKey = overallField.resultKey,
         )
     }
@@ -95,22 +92,19 @@ class NadelNoInterfaceToObjectFragmentExpansionTransform : NadelTransform<State>
         state: State,
         transformServiceExecutionContext: NadelTransformServiceExecutionContext?,
     ): NadelTransformFieldResult {
-        // Widen objectTypeNames to cover every underlying member so graphql-java prints the field bare.
-        val bareField = field.toBuilder()
-            .clearObjectTypesNames()
-            .objectTypeNames(state.allUnderlyingMembersAsOverallNames)
-            .build()
-
-        // Aliased __typename (also bare) so the result side can tell each node's concrete type.
+        // Keep objectTypeNames honest (only the exposed members). Rather than widen them, flag the field and
+        // the injected __typename as forcePrintBare so the forked compiler emits them without a `... on Type`
+        // fragment. See [NadelTransformFieldResult.forcePrintBare].
         val typeNameField = newNormalizedField()
-            .objectTypeNames(state.allUnderlyingMembersAsOverallNames)
+            .objectTypeNames(state.exposedOverallImplNames.toList())
             .alias(state.aliasHelper.typeNameResultKey)
             .fieldName(Introspection.TypeNameMetaFieldDef.name)
             .build()
 
         return NadelTransformFieldResult(
-            newField = bareField,
+            newField = field,
             artificialFields = listOf(typeNameField),
+            forcePrintBare = true,
         )
     }
 
@@ -150,16 +144,16 @@ class NadelNoInterfaceToObjectFragmentExpansionTransform : NadelTransform<State>
 }
 
 /**
- * Structural preconditions for bare emission, or `null` if [overallField] isn't a candidate: the parent is a
- * single interface/union, the field is selectable at that level (an interface field, or `__typename`), the
- * selection covers exactly the exposed members, and at least one underlying member is hidden. Doesn't consider
- * the hint or field instructions — the caller does.
+ * The exposed overall implementation names if [overallField] is relaxable, else `null`. Relaxable means: the
+ * parent is a single interface/union, the field is selectable at that level (an interface field, or
+ * `__typename`), the selection covers exactly the exposed members, and at least one underlying member is
+ * hidden. Doesn't consider the hint or field instructions - the caller does.
  */
-private fun computeAbstractTypeRelaxationContext(
+private fun computeExposedImplNamesIfRelaxable(
     executionBlueprint: NadelOverallExecutionBlueprint,
     service: Service,
     overallField: ExecutableNormalizedField,
-): NadelAbstractTypeRelaxationContext? {
+): Set<String>? {
     val parent = overallField.parent ?: return null
 
     val engineSchema = executionBlueprint.engineSchema
@@ -217,16 +211,5 @@ private fun computeAbstractTypeRelaxationContext(
         return null
     }
 
-    // Every underlying member (incl. hidden ones), named in overall terms so it can go on the overall ENF;
-    val allUnderlyingMembersAsOverallNames = underlyingMemberNames.map { executionBlueprint.getOverallTypeName(service, it) }
-
-    return NadelAbstractTypeRelaxationContext(
-        exposedOverallImplNames = exposedOverallImplNames,
-        allUnderlyingMembersAsOverallNames = allUnderlyingMembersAsOverallNames,
-    )
+    return exposedOverallImplNames
 }
-
-private data class NadelAbstractTypeRelaxationContext(
-    val exposedOverallImplNames: Set<String>,
-    val allUnderlyingMembersAsOverallNames: List<String>,
-)

--- a/lib/src/main/java/graphql/nadel/engine/transform/NadelNoInterfaceToObjectFragmentExpansionTransform.kt
+++ b/lib/src/main/java/graphql/nadel/engine/transform/NadelNoInterfaceToObjectFragmentExpansionTransform.kt
@@ -20,7 +20,11 @@ import graphql.nadel.engine.util.JsonMap
 import graphql.nadel.engine.util.queryPath
 import graphql.normalized.ExecutableNormalizedField
 import graphql.normalized.ExecutableNormalizedField.newNormalizedField
+import graphql.schema.GraphQLFieldsContainer
 import graphql.schema.GraphQLInterfaceType
+import graphql.schema.GraphQLNamedType
+import graphql.schema.GraphQLSchema
+import graphql.schema.GraphQLType
 import graphql.schema.GraphQLTypeUtil.unwrapAll
 import graphql.schema.GraphQLUnionType
 
@@ -68,9 +72,9 @@ class NadelNoInterfaceToObjectFragmentExpansionTransform : NadelTransform<State>
             ?: return null
 
         // Do nothing for fields with instructions (rename/hydration/stub/…)
-        val hasFieldInstructions = runCatching {
-            executionBlueprint.getTypeNameToInstructionMap<NadelFieldInstruction>(overallField).isNotEmpty()
-        }.getOrDefault(true)
+        val hasFieldInstructions = overallField.objectTypeNames.any { objectTypeName ->
+            executionBlueprint.fieldInstructions.get(objectTypeName, overallField.name)?.isNotEmpty() == true
+        }
         if (hasFieldInstructions) {
             return null
         }
@@ -145,9 +149,10 @@ class NadelNoInterfaceToObjectFragmentExpansionTransform : NadelTransform<State>
 
 /**
  * The exposed overall implementation names if [overallField] is relaxable, else `null`. Relaxable means: the
- * parent is a single interface/union, the field is selectable at that level (an interface field, or
- * `__typename`), the selection covers exactly the exposed members, and at least one underlying member is
- * hidden. Doesn't consider the hint or field instructions - the caller does.
+ * parent's output is one or more interfaces (or a single union), the field is selectable at that level (an
+ * interface field present on every parent interface, or `__typename`), the selection covers exactly the exposed
+ * members, and at least one underlying member is hidden. Doesn't consider the hint or field instructions - the
+ * caller does.
  */
 private fun computeExposedImplNamesIfRelaxable(
     executionBlueprint: NadelOverallExecutionBlueprint,
@@ -155,61 +160,59 @@ private fun computeExposedImplNamesIfRelaxable(
     overallField: ExecutableNormalizedField,
 ): Set<String>? {
     val parent = overallField.parent ?: return null
-
     val engineSchema = executionBlueprint.engineSchema
     val isTypename = overallField.fieldName == TypeNameMetaFieldDef.name
 
-    // getFieldDefinitions can throw while planning a hydration backing query; any failure => not a candidate.
-    val parentOutputTypes = runCatching {
-        parent.getFieldDefinitions(engineSchema)
-            .asSequence()
-            .map { unwrapAll(it.type) }
-            .toSet()
-    }.getOrNull() ?: return null
+    val parentOutputTypes = parent.objectTypeNames.map { parentTypeName ->
+        val parentType = engineSchema.getType(parentTypeName) as? GraphQLFieldsContainer ?: return null
+        val parentFieldDef = parentType.getFieldDefinition(parent.fieldName) ?: return null
+        unwrapAll(parentFieldDef.type)
+    }.toSet()
 
-    // Exposed members, gated on the field being selectable at that level (union => __typename only).
-    val exposedOverallImplNames: Set<String>
-    val parentAbstractTypeName: String
-    when (val parentType = parentOutputTypes.singleOrNull()) {
-        is GraphQLInterfaceType -> {
-            if (!isTypename && parentType.getFieldDefinition(overallField.fieldName) == null) {
+    val parentAbstractTypes: List<GraphQLNamedType> =
+        if (parentOutputTypes.isNotEmpty() && parentOutputTypes.all { it is GraphQLInterfaceType }) {
+            val interfaces = parentOutputTypes.filterIsInstance<GraphQLInterfaceType>()
+            val fieldIsOnEveryInterface =
+                isTypename || interfaces.all { it.getFieldDefinition(overallField.fieldName) != null }
+            if (!fieldIsOnEveryInterface) {
                 return null
             }
-            exposedOverallImplNames = engineSchema.getImplementations(parentType).map { it.name }.toSet()
-            parentAbstractTypeName = parentType.name
-        }
-        is GraphQLUnionType -> {
+            interfaces
+        } else {
+            val union = parentOutputTypes.singleOrNull() as? GraphQLUnionType ?: return null
             if (!isTypename) {
                 return null
             }
-            exposedOverallImplNames = parentType.types.map { it.name }.toSet()
-            parentAbstractTypeName = parentType.name
+            listOf(union)
         }
-        else -> return null
-    }
 
+    val exposedOverallImplNames =
+        parentAbstractTypes.flatMap { abstractMemberNames(engineSchema, it) ?: return null }.toSet()
     // Means the client used fragments with explicit objects. don't relax.
     if (overallField.objectTypeNames.toSet() != exposedOverallImplNames) {
         return null
     }
 
-    val underlyingTypeName = executionBlueprint.getUnderlyingTypeName(parentAbstractTypeName)
-    val underlyingMemberNames = when (val underlyingType = service.underlyingSchema.getType(underlyingTypeName)) {
-        is GraphQLInterfaceType -> service.underlyingSchema.getImplementations(underlyingType).map { it.name }
-        is GraphQLUnionType -> underlyingType.types.map { it.name }
-        else -> return null
+    val underlyingMemberNames = parentAbstractTypes.flatMap { abstractType ->
+        val underlyingTypeName = executionBlueprint.getUnderlyingTypeName(abstractType.name)
+        val underlyingType = service.underlyingSchema.getType(underlyingTypeName)
+        abstractMemberNames(service.underlyingSchema, underlyingType) ?: return null
     }
-    if (underlyingMemberNames.isEmpty()) {
-        return null
-    }
-
-    // Nothing to hide unless a member is hidden (and graphql-java already prints bare when none is).
-    val hasHiddenImpl = underlyingMemberNames.any { underlyingName ->
+    // Relax only if some underlying member is hidden from the overall (graphql-java already prints bare when none is).
+    val hasHiddenMember = underlyingMemberNames.any { underlyingName ->
         executionBlueprint.getOverallTypeName(service, underlyingName) !in exposedOverallImplNames
     }
-    if (!hasHiddenImpl) {
+    if (!hasHiddenMember) {
         return null
     }
 
     return exposedOverallImplNames
 }
+
+/** The implementation/member type names of an interface or union in [schema], or `null` if [type] is neither. */
+private fun abstractMemberNames(schema: GraphQLSchema, type: GraphQLType?): List<String>? =
+    when (type) {
+        is GraphQLInterfaceType -> schema.getImplementations(type).map { it.name }
+        is GraphQLUnionType -> type.types.map { it.name }
+        else -> null
+    }

--- a/lib/src/main/java/graphql/nadel/engine/transform/NadelTransform.kt
+++ b/lib/src/main/java/graphql/nadel/engine/transform/NadelTransform.kt
@@ -132,7 +132,7 @@ interface NadelTransform<State : Any> {
     }
 }
 
-data class NadelTransformFieldResult(
+data class NadelTransformFieldResult @JvmOverloads constructor(
     /**
      * The original field given in [NadelTransform.transformField].
      *
@@ -148,6 +148,13 @@ data class NadelTransformFieldResult(
      * fields specified by the incoming query to be in the result.
      */
     val artificialFields: List<ExecutableNormalizedField> = emptyList(),
+    /**
+     * When true, [newField] and this result's [artificialFields] are sent to the underlying service "bare"
+     * (no `... on Type` inline fragment) even if their `objectTypeNames` is a strict subset of the parent's
+     * possible types. Lets a transform keep `objectTypeNames` honest while still sending an interface/union
+     * selection bare. Honoured by the forked document compiler; see GQLGW-6377.
+     */
+    val forcePrintBare: Boolean = false,
 ) {
     companion object {
         /**

--- a/lib/src/main/java/graphql/nadel/engine/transform/query/NadelQueryTransformer.kt
+++ b/lib/src/main/java/graphql/nadel/engine/transform/query/NadelQueryTransformer.kt
@@ -50,6 +50,7 @@ class NadelQueryTransformer private constructor(
                     result = result,
                     artificialFields = transformContext.artificialFields,
                     overallToUnderlyingFields = transformContext.overallToUnderlyingFields,
+                    forcePrintBareFields = transformContext.forcePrintBareFields,
                 )
             }
         }
@@ -58,6 +59,8 @@ class NadelQueryTransformer private constructor(
     private data class TransformContext(
         val artificialFields: MutableList<ExecutableNormalizedField> = mutableListOf(),
         val overallToUnderlyingFields: MutableMap<ExecutableNormalizedField, MutableList<ExecutableNormalizedField>> = mutableMapOf(),
+        // Underlying fields the forked compiler must emit bare. Populated from NadelTransformFieldResult.forcePrintBare.
+        val forcePrintBareFields: MutableSet<ExecutableNormalizedField> = mutableSetOf(),
     )
 
     data class TransformResult(
@@ -70,6 +73,11 @@ class NadelQueryTransformer private constructor(
          */
         val artificialFields: List<ExecutableNormalizedField>,
         val overallToUnderlyingFields: Map<ExecutableNormalizedField, List<ExecutableNormalizedField>>,
+        /**
+         * Underlying fields that must be emitted bare - no `... on Type` wrapper - by the
+         * forked document compiler. See [NadelTransformFieldResult.forcePrintBare].
+         */
+        val forcePrintBareFields: Set<ExecutableNormalizedField> = emptySet(),
     )
 
     /**
@@ -118,6 +126,13 @@ class NadelQueryTransformer private constructor(
             },
         )
 
+        // Record the REBUILT underlying instances (the ones the compiler will see) so the forked compiler
+        // emits them bare. We key by identity here because these are exactly the instances that flow to compile.
+        if (transformResult.forcePrintBare) {
+            transformContext.forcePrintBareFields.addAll(newField)
+            transformContext.forcePrintBareFields.addAll(artificialFields)
+        }
+
         transformContext.artificialFields.addAll(artificialFields)
 
         // Track overall -> underlying fields
@@ -164,6 +179,7 @@ class NadelQueryTransformer private constructor(
     ): NadelTransformFieldResult {
         var newField: ExecutableNormalizedField = field
         val artificialFields = mutableListOf<ExecutableNormalizedField>()
+        var forcePrintBare = false
 
         for (transformStep in transformationSteps) {
             val transformServiceExecutionContext = executionPlan.transformContexts[transformStep.transform]
@@ -180,13 +196,15 @@ class NadelQueryTransformer private constructor(
                 )
             }
             artificialFields.addAll(transformResultForStep.artificialFields)
+            forcePrintBare = forcePrintBare || transformResultForStep.forcePrintBare
             newField = transformResultForStep.newField
-                ?: return NadelTransformFieldResult(null, artificialFields)
+                ?: return NadelTransformFieldResult(null, artificialFields, forcePrintBare)
         }
 
         return NadelTransformFieldResult(
             newField = newField,
             artificialFields = artificialFields,
+            forcePrintBare = forcePrintBare,
         )
     }
 

--- a/lib/src/main/java/graphql/nadel/engine/util/GraphQLUtil.kt
+++ b/lib/src/main/java/graphql/nadel/engine/util/GraphQLUtil.kt
@@ -47,10 +47,10 @@ import graphql.nadel.ServiceExecutionResult
 import graphql.nadel.engine.transform.query.NadelQueryPath
 import graphql.nadel.instrumentation.NadelInstrumentation
 import graphql.nadel.instrumentation.parameters.NadelInstrumentationExecuteOperationParameters
+import graphql.nadel.engine.compiler.NadelExecutableNormalizedOperationToAstCompiler
 import graphql.nadel.util.ErrorUtil.createGraphQLErrorsFromRawErrors
 import graphql.normalized.ExecutableNormalizedField
 import graphql.normalized.ExecutableNormalizedOperation
-import graphql.normalized.ExecutableNormalizedOperationToAstCompiler
 import graphql.normalized.ExecutableNormalizedOperationToAstCompiler.CompilerResult
 import graphql.normalized.NormalizedInputValue
 import graphql.normalized.VariablePredicate
@@ -648,22 +648,25 @@ fun compileToDocument(
     topLevelFields: List<ExecutableNormalizedField>,
     variablePredicate: VariablePredicate?,
     deferSupport: Boolean = false,
+    forcePrintBareFields: Set<ExecutableNormalizedField> = emptySet(),
 ): CompilerResult {
     if (deferSupport) {
-        return ExecutableNormalizedOperationToAstCompiler.compileToDocumentWithDeferSupport(
+        return NadelExecutableNormalizedOperationToAstCompiler.compileToDocumentWithDeferSupport(
             schema,
             operationKind,
             operationName,
             topLevelFields,
             variablePredicate,
+            forcePrintBareFields,
         )
     } else {
-        return ExecutableNormalizedOperationToAstCompiler.compileToDocument(
+        return NadelExecutableNormalizedOperationToAstCompiler.compileToDocument(
             schema,
             operationKind,
             operationName,
             topLevelFields,
             variablePredicate,
+            forcePrintBareFields,
         )
     }
 }

--- a/lib/src/main/java/graphql/nadel/hints/NadelNoInterfaceToObjectFragmentExpansionHint.kt
+++ b/lib/src/main/java/graphql/nadel/hints/NadelNoInterfaceToObjectFragmentExpansionHint.kt
@@ -1,0 +1,12 @@
+package graphql.nadel.hints
+
+import graphql.nadel.Service
+
+/**
+ * When ON for a [service], an interface/union field the client selected at the abstract-type level is sent to
+ * the underlying service **bare** rather than expanded into `... on ConcreteType` fragments, so a sibling type
+ * the client didn't name can't be injected into the query. Per-service for gradual rollout; defaults to `false`.
+ */
+fun interface NadelNoInterfaceToObjectFragmentExpansionHint {
+    operator fun invoke(service: Service): Boolean
+}

--- a/lib/src/test/kotlin/graphql/nadel/engine/compiler/NadelAstCompilerDifferentialTest.kt
+++ b/lib/src/test/kotlin/graphql/nadel/engine/compiler/NadelAstCompilerDifferentialTest.kt
@@ -1,0 +1,92 @@
+package graphql.nadel.engine.compiler
+
+import graphql.execution.RawVariables
+import graphql.language.AstPrinter
+import graphql.language.OperationDefinition.Operation.QUERY
+import graphql.normalized.ExecutableNormalizedOperationFactory.createExecutableNormalizedOperationWithRawVariables
+import graphql.normalized.ExecutableNormalizedOperationToAstCompiler
+import graphql.normalized.VariablePredicate
+import graphql.parser.Parser
+import graphql.schema.idl.RuntimeWiring
+import graphql.schema.idl.SchemaGenerator
+import graphql.schema.idl.SchemaParser
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+/**
+ * [NadelExecutableNormalizedOperationToAstCompiler] is a fork of graphql-java's
+ * ExecutableNormalizedOperationToAstCompiler with one addition (forcePrintBareFields). This test pins that,
+ * with an EMPTY force-bare set, it produces output byte-identical to upstream across the bare, inline-fragment,
+ * argument and variable paths - so the fork stays a faithful mirror when graphql-java is bumped.
+ */
+class NadelAstCompilerDifferentialTest {
+    private val schema = SchemaGenerator().makeExecutableSchema(
+        SchemaParser().parse(
+            """
+            type Query {
+              animals: [Animal]
+              issues(first: Int, filter: IssueFilter): [Issue]
+            }
+            interface Animal {
+              id: ID
+            }
+            type Cat implements Animal {
+              id: ID
+              meow: String
+            }
+            type Dog implements Animal {
+              id: ID
+              woof: String
+            }
+            type Issue {
+              id: ID
+              title: String
+            }
+            input IssueFilter {
+              text: String
+            }
+            """.trimIndent(),
+        ),
+        RuntimeWiring.newRuntimeWiring()
+            .type("Animal") { it.typeResolver { null } }
+            .build(),
+    )
+
+    private fun assertForkMatchesUpstream(query: String, makeVariables: Boolean) {
+        val predicate = VariablePredicate { _, _, _ -> makeVariables }
+
+        val operation = createExecutableNormalizedOperationWithRawVariables(
+            schema,
+            Parser().parseDocument(query),
+            null,
+            RawVariables.emptyVariables(),
+        )
+        val topLevelFields = operation.topLevelFields
+
+        val expected = ExecutableNormalizedOperationToAstCompiler.compileToDocument(
+            schema, QUERY, null, topLevelFields, predicate,
+        )
+        val actual = NadelExecutableNormalizedOperationToAstCompiler.compileToDocument(
+            schema, QUERY, null, topLevelFields, predicate, emptySet(),
+        )
+
+        assertEquals(AstPrinter.printAst(expected.document), AstPrinter.printAst(actual.document))
+        assertEquals(expected.variables, actual.variables)
+    }
+
+    @Test
+    fun `bare interface field, inline fragment and inlined arguments match upstream`() {
+        assertForkMatchesUpstream(
+            "query { animals { id ... on Cat { meow } } issues(first: 10, filter: { text: \"x\" }) { id title } }",
+            makeVariables = false,
+        )
+    }
+
+    @Test
+    fun `arguments hoisted to variables match upstream`() {
+        assertForkMatchesUpstream(
+            "query { issues(first: 10, filter: { text: \"x\" }) { id title } }",
+            makeVariables = true,
+        )
+    }
+}

--- a/test/build.gradle.kts
+++ b/test/build.gradle.kts
@@ -28,6 +28,31 @@ tasks.withType<Test> {
     useJUnitPlatform()
 }
 
+// Generates/updates the *Snapshot.kt files used by NadelIntegrationTest tests.
+// This is the CLI equivalent of the "Update Test Snapshots" IntelliJ run config.
+//
+// Usage:
+//   ./gradlew :test:updateTestSnapshots                       # generate only missing snapshots
+//   ./gradlew :test:updateTestSnapshots --args="graphql.nadel.tests.next.fixtures.hydration.HydrationTest"
+//                                                             # (re)generate snapshots for the given test FQN(s)
+//   ./gradlew :test:updateTestSnapshots --args="graphql.nadel.tests.next.fixtures.execution"
+//                                                             # (re)generate every snapshot under a package/folder, recursively
+//                                                             # (a filesystem path to the folder works too)
+tasks.register<JavaExec>("updateTestSnapshots") {
+    group = "verification"
+    description = "Generates/updates test snapshots (pass test FQNs via --args to regenerate specific ones)."
+
+    mainClass.set("graphql.nadel.tests.next.UpdateTestSnapshotsKt")
+    classpath = sourceSets["test"].runtimeClasspath
+
+    // The generator resolves the source root via the relative path "test/src/test/kotlin/",
+    // so it must run from the repository root.
+    workingDir = rootProject.projectDir
+
+    // Ensure test sources are compiled before generating snapshots.
+    dependsOn(tasks.named("testClasses"))
+}
+
 tasks.withType<KotlinCompile>().configureEach {
     kotlinOptions.apply {
         jvmTarget = JavaVersion.VERSION_11.toString()

--- a/test/src/test/kotlin/graphql/nadel/tests/next/NadelIntegrationTest.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/next/NadelIntegrationTest.kt
@@ -160,10 +160,11 @@ abstract class NadelIntegrationTest(
         val nadel = makeNadel()
             .build()
 
+        val executionInput = makeExecutionInput().build()
         val result = nadel
-            .execute(makeExecutionInput().build())
+            .execute(executionInput)
             .let {
-                executionCapture.capture(it.await())
+                executionCapture.capture(executionInput, it.await())
             }
 
         if (result is IncrementalExecutionResult) {

--- a/test/src/test/kotlin/graphql/nadel/tests/next/TestExecutionCapture.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/next/TestExecutionCapture.kt
@@ -5,6 +5,7 @@ import graphql.ExecutionResult
 import graphql.incremental.DelayedIncrementalPartialResult
 import graphql.incremental.IncrementalExecutionResult
 import graphql.incremental.IncrementalExecutionResultImpl
+import graphql.nadel.NadelExecutionInput
 import graphql.language.AstPrinter
 import graphql.language.AstSorter
 import graphql.nadel.engine.util.JsonMap
@@ -19,6 +20,9 @@ class TestExecutionCapture {
     private val _calls = synchronizedMutableListOf<Call>()
     val calls: List<Call>
         get() = _calls
+
+    var executionInput: NadelExecutionInput? = null
+        private set
 
     var result: ExecutionResult? = null
         private set
@@ -62,6 +66,11 @@ class TestExecutionCapture {
         return spyOnIncrementalResults(result) {
             delayedResults.add(deepClone(it))
         }
+    }
+
+    fun capture(executionInput: NadelExecutionInput, result: ExecutionResult): ExecutionResult {
+        this.executionInput = executionInput
+        return capture(result)
     }
 
     fun capture(result: ExecutionResult): ExecutionResult {

--- a/test/src/test/kotlin/graphql/nadel/tests/next/UpdateTestSnapshots.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/next/UpdateTestSnapshots.kt
@@ -38,14 +38,22 @@ private suspend fun main(vararg args: String) {
     val sourceRoot = File("test/src/test/kotlin/")
     require(sourceRoot.exists() && sourceRoot.isDirectory)
 
+    // Each arg targets tests to (re)generate. An arg can be an exact test class FQN, or a
+    // package/folder prefix that matches every test in that package and its subpackages
+    // (recursively). Filesystem-style paths are accepted and converted to a package prefix.
+    val targets = args.map(::toPackagePrefix)
+
     getTestClassSequence()
-        .filter {
-            args.isEmpty() || args.contains(it.qualifiedName)
-        }
-        // Only process non-existent by default
+        // Keep tests matching one of the targets, by exact FQN or package prefix.
         .filter { klass ->
-            classForNameOrNull(getSnapshotClassName(klass.asClassName()).reflectionName()) == null
-                || (args.isNotEmpty() && klass.qualifiedName in args)
+            if (targets.isEmpty()) return@filter true
+            val fqn = klass.qualifiedName ?: return@filter false
+            targets.any { fqn == it || fqn.startsWith("$it.") }
+        }
+        // With no targets, only generate snapshots that don't exist yet; targeted tests always regenerate.
+        .filter { klass ->
+            targets.isNotEmpty()
+                || classForNameOrNull(getSnapshotClassName(klass.asClassName()).reflectionName()) == null
         }
         .onEach { klass ->
             println("Loading ${klass.qualifiedName}")
@@ -150,8 +158,14 @@ private fun makeServiceCallsProperty(captured: TestExecutionCapture): PropertySp
     val callsType = List::class.asClassName().parameterizedBy(ExpectedServiceCall::class.asTypeName())
 
     // override val calls: List<ExpectedServiceCall> = listOf(…)
+    val executionInput = captured.executionInput!!
     return PropertySpec.builder(TestSnapshot::calls.name, callsType)
         .addModifiers(KModifier.OVERRIDE)
+        .addKdoc(
+            "Query\n\n```graphql\n%L\n```\n\nVariables\n\n```json\n%L\n```",
+            executionInput.query,
+            jsonObjectMapper.withPrettierPrinter().writeValueAsString(executionInput.variables),
+        )
         .initializer(
             buildCodeBlock {
                 add("%M", listOf)
@@ -266,6 +280,23 @@ private fun writeResultJson(result: ExecutionResult): String {
 
 private fun writeResultJson(result: DelayedIncrementalPartialResult): String {
     return writeResultJson(result.toSpecification())
+}
+
+/**
+ * Normalizes a target arg into a package prefix.
+ *
+ * Accepts either a dotted FQN/package (used as-is) or a filesystem path (e.g. copied from the
+ * IDE, absolute or relative) which is stripped to below the source root and dotted.
+ */
+private fun toPackagePrefix(arg: String): String {
+    if ('/' !in arg) {
+        return arg
+    }
+
+    return arg
+        .substringAfter("test/src/test/kotlin/")
+        .trim('/')
+        .replace('/', '.')
 }
 
 private fun classForNameOrNull(name: String): Class<*>? {

--- a/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/execution/interfaceexpansion/allvisible/AllImplementationsVisibleRelaxedTest.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/execution/interfaceexpansion/allvisible/AllImplementationsVisibleRelaxedTest.kt
@@ -1,0 +1,35 @@
+package graphql.nadel.tests.next.fixtures.execution.interfaceexpansion.allvisible
+
+import graphql.nadel.NadelExecutionHints
+
+/**
+ * The allvisible control with the hint ON: nothing is hidden, so relaxation never fires and behaviour matches
+ * hint-OFF.
+ */
+class AllVisibleRelaxedBareInterfaceFieldTest : AllImplementationsVisibleTestBase(
+    query = """
+        query {
+          nodes {
+            id
+          }
+        }
+    """.trimIndent(),
+) {
+    override fun makeExecutionHints(): NadelExecutionHints.Builder {
+        return super.makeExecutionHints().noInterfaceToObjectFragmentExpansion { _ -> true }
+    }
+}
+
+class AllVisibleRelaxedBareTypenameTest : AllImplementationsVisibleTestBase(
+    query = """
+        query {
+          nodes {
+            __typename
+          }
+        }
+    """.trimIndent(),
+) {
+    override fun makeExecutionHints(): NadelExecutionHints.Builder {
+        return super.makeExecutionHints().noInterfaceToObjectFragmentExpansion { _ -> true }
+    }
+}

--- a/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/execution/interfaceexpansion/allvisible/AllImplementationsVisibleTest.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/execution/interfaceexpansion/allvisible/AllImplementationsVisibleTest.kt
@@ -1,0 +1,80 @@
+package graphql.nadel.tests.next.fixtures.execution.interfaceexpansion.allvisible
+
+import graphql.nadel.tests.next.NadelIntegrationTest
+import org.intellij.lang.annotations.Language
+
+/**
+ * Control: Issue/Story/Task all implement Node in both schemas, so nothing is hidden and a bare interface
+ * selection is already sent bare — with or without the hint. Contrast the hiddenmembership/underlyingonly fixtures.
+ */
+abstract class AllImplementationsVisibleTestBase(
+    @Language("GraphQL") query: String,
+) : NadelIntegrationTest(
+    query = query,
+    services = listOf(
+        Service(
+            name = "data",
+            overallSchema = """
+                type Query {
+                  nodes: [Node]
+                }
+                interface Node {
+                  id: ID
+                }
+                type Issue implements Node {
+                  id: ID
+                  issueField: String
+                }
+                type Story implements Node {
+                  id: ID
+                  storyField: String
+                }
+                type Task implements Node {
+                  id: ID
+                  taskField: String
+                }
+            """.trimIndent(),
+            runtimeWiring = { wiring ->
+                data class Issue(val id: String, val issueField: String)
+                data class Story(val id: String, val storyField: String)
+                data class Task(val id: String, val taskField: String)
+
+                wiring
+                    .type("Node") { type ->
+                        type.typeResolver { env ->
+                            env.schema.getObjectType(env.getObject<Any>().javaClass.simpleName)
+                        }
+                    }
+                    .type("Query") { type ->
+                        type.dataFetcher("nodes") { _ ->
+                            listOf(
+                                Issue(id = "ISSUE-1", issueField = "i"),
+                                Story(id = "STORY-1", storyField = "s"),
+                                Task(id = "TASK-1", taskField = "t"),
+                            )
+                        }
+                    }
+            },
+        ),
+    ),
+)
+
+class AllVisibleBareInterfaceFieldTest : AllImplementationsVisibleTestBase(
+    query = """
+        query {
+          nodes {
+            id
+          }
+        }
+    """.trimIndent(),
+)
+
+class AllVisibleBareTypenameTest : AllImplementationsVisibleTestBase(
+    query = """
+        query {
+          nodes {
+            __typename
+          }
+        }
+    """.trimIndent(),
+)

--- a/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/execution/interfaceexpansion/allvisible/AllVisibleBareInterfaceFieldTestSnapshot.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/execution/interfaceexpansion/allvisible/AllVisibleBareInterfaceFieldTestSnapshot.kt
@@ -1,0 +1,113 @@
+// @formatter:off
+package graphql.nadel.tests.next.fixtures.execution.interfaceexpansion.allvisible
+
+import graphql.nadel.tests.next.ExpectedNadelResult
+import graphql.nadel.tests.next.ExpectedServiceCall
+import graphql.nadel.tests.next.TestSnapshot
+import graphql.nadel.tests.next.listOfJsonStrings
+import kotlin.Suppress
+import kotlin.collections.List
+import kotlin.collections.listOf
+
+private suspend fun main() {
+    graphql.nadel.tests.next.update<AllVisibleBareInterfaceFieldTest>()
+}
+
+/**
+ * This class is generated. Do NOT modify.
+ *
+ * Refer to [graphql.nadel.tests.next.UpdateTestSnapshots]
+ */
+@Suppress("unused")
+public class AllVisibleBareInterfaceFieldTestSnapshot : TestSnapshot() {
+    /**
+     * Query
+     *
+     * ```graphql
+     * query {
+     *   nodes {
+     *     id
+     *   }
+     * }
+     * ```
+     *
+     * Variables
+     *
+     * ```json
+     * {}
+     * ```
+     */
+    override val calls: List<ExpectedServiceCall> = listOf(
+            ExpectedServiceCall(
+                service = "data",
+                query = """
+                | {
+                |   nodes {
+                |     id
+                |   }
+                | }
+                """.trimMargin(),
+                variables = "{}",
+                result = """
+                | {
+                |   "data": {
+                |     "nodes": [
+                |       {
+                |         "id": "ISSUE-1"
+                |       },
+                |       {
+                |         "id": "STORY-1"
+                |       },
+                |       {
+                |         "id": "TASK-1"
+                |       }
+                |     ]
+                |   }
+                | }
+                """.trimMargin(),
+                delayedResults = listOfJsonStrings(
+                ),
+            ),
+        )
+
+    /**
+     * ```json
+     * {
+     *   "data": {
+     *     "nodes": [
+     *       {
+     *         "id": "ISSUE-1"
+     *       },
+     *       {
+     *         "id": "STORY-1"
+     *       },
+     *       {
+     *         "id": "TASK-1"
+     *       }
+     *     ]
+     *   }
+     * }
+     * ```
+     */
+    override val result: ExpectedNadelResult = ExpectedNadelResult(
+            result = """
+            | {
+            |   "data": {
+            |     "nodes": [
+            |       {
+            |         "id": "ISSUE-1"
+            |       },
+            |       {
+            |         "id": "STORY-1"
+            |       },
+            |       {
+            |         "id": "TASK-1"
+            |       }
+            |     ]
+            |   }
+            | }
+            """.trimMargin(),
+            delayedResults = listOfJsonStrings(
+            ),
+        )
+}

--- a/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/execution/interfaceexpansion/allvisible/AllVisibleBareTypenameTestSnapshot.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/execution/interfaceexpansion/allvisible/AllVisibleBareTypenameTestSnapshot.kt
@@ -1,0 +1,113 @@
+// @formatter:off
+package graphql.nadel.tests.next.fixtures.execution.interfaceexpansion.allvisible
+
+import graphql.nadel.tests.next.ExpectedNadelResult
+import graphql.nadel.tests.next.ExpectedServiceCall
+import graphql.nadel.tests.next.TestSnapshot
+import graphql.nadel.tests.next.listOfJsonStrings
+import kotlin.Suppress
+import kotlin.collections.List
+import kotlin.collections.listOf
+
+private suspend fun main() {
+    graphql.nadel.tests.next.update<AllVisibleBareTypenameTest>()
+}
+
+/**
+ * This class is generated. Do NOT modify.
+ *
+ * Refer to [graphql.nadel.tests.next.UpdateTestSnapshots]
+ */
+@Suppress("unused")
+public class AllVisibleBareTypenameTestSnapshot : TestSnapshot() {
+    /**
+     * Query
+     *
+     * ```graphql
+     * query {
+     *   nodes {
+     *     __typename
+     *   }
+     * }
+     * ```
+     *
+     * Variables
+     *
+     * ```json
+     * {}
+     * ```
+     */
+    override val calls: List<ExpectedServiceCall> = listOf(
+            ExpectedServiceCall(
+                service = "data",
+                query = """
+                | {
+                |   nodes {
+                |     __typename
+                |   }
+                | }
+                """.trimMargin(),
+                variables = "{}",
+                result = """
+                | {
+                |   "data": {
+                |     "nodes": [
+                |       {
+                |         "__typename": "Issue"
+                |       },
+                |       {
+                |         "__typename": "Story"
+                |       },
+                |       {
+                |         "__typename": "Task"
+                |       }
+                |     ]
+                |   }
+                | }
+                """.trimMargin(),
+                delayedResults = listOfJsonStrings(
+                ),
+            ),
+        )
+
+    /**
+     * ```json
+     * {
+     *   "data": {
+     *     "nodes": [
+     *       {
+     *         "__typename": "Issue"
+     *       },
+     *       {
+     *         "__typename": "Story"
+     *       },
+     *       {
+     *         "__typename": "Task"
+     *       }
+     *     ]
+     *   }
+     * }
+     * ```
+     */
+    override val result: ExpectedNadelResult = ExpectedNadelResult(
+            result = """
+            | {
+            |   "data": {
+            |     "nodes": [
+            |       {
+            |         "__typename": "Issue"
+            |       },
+            |       {
+            |         "__typename": "Story"
+            |       },
+            |       {
+            |         "__typename": "Task"
+            |       }
+            |     ]
+            |   }
+            | }
+            """.trimMargin(),
+            delayedResults = listOfJsonStrings(
+            ),
+        )
+}

--- a/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/execution/interfaceexpansion/allvisible/AllVisibleRelaxedBareInterfaceFieldTestSnapshot.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/execution/interfaceexpansion/allvisible/AllVisibleRelaxedBareInterfaceFieldTestSnapshot.kt
@@ -1,0 +1,113 @@
+// @formatter:off
+package graphql.nadel.tests.next.fixtures.execution.interfaceexpansion.allvisible
+
+import graphql.nadel.tests.next.ExpectedNadelResult
+import graphql.nadel.tests.next.ExpectedServiceCall
+import graphql.nadel.tests.next.TestSnapshot
+import graphql.nadel.tests.next.listOfJsonStrings
+import kotlin.Suppress
+import kotlin.collections.List
+import kotlin.collections.listOf
+
+private suspend fun main() {
+    graphql.nadel.tests.next.update<AllVisibleRelaxedBareInterfaceFieldTest>()
+}
+
+/**
+ * This class is generated. Do NOT modify.
+ *
+ * Refer to [graphql.nadel.tests.next.UpdateTestSnapshots]
+ */
+@Suppress("unused")
+public class AllVisibleRelaxedBareInterfaceFieldTestSnapshot : TestSnapshot() {
+    /**
+     * Query
+     *
+     * ```graphql
+     * query {
+     *   nodes {
+     *     id
+     *   }
+     * }
+     * ```
+     *
+     * Variables
+     *
+     * ```json
+     * {}
+     * ```
+     */
+    override val calls: List<ExpectedServiceCall> = listOf(
+            ExpectedServiceCall(
+                service = "data",
+                query = """
+                | {
+                |   nodes {
+                |     id
+                |   }
+                | }
+                """.trimMargin(),
+                variables = "{}",
+                result = """
+                | {
+                |   "data": {
+                |     "nodes": [
+                |       {
+                |         "id": "ISSUE-1"
+                |       },
+                |       {
+                |         "id": "STORY-1"
+                |       },
+                |       {
+                |         "id": "TASK-1"
+                |       }
+                |     ]
+                |   }
+                | }
+                """.trimMargin(),
+                delayedResults = listOfJsonStrings(
+                ),
+            ),
+        )
+
+    /**
+     * ```json
+     * {
+     *   "data": {
+     *     "nodes": [
+     *       {
+     *         "id": "ISSUE-1"
+     *       },
+     *       {
+     *         "id": "STORY-1"
+     *       },
+     *       {
+     *         "id": "TASK-1"
+     *       }
+     *     ]
+     *   }
+     * }
+     * ```
+     */
+    override val result: ExpectedNadelResult = ExpectedNadelResult(
+            result = """
+            | {
+            |   "data": {
+            |     "nodes": [
+            |       {
+            |         "id": "ISSUE-1"
+            |       },
+            |       {
+            |         "id": "STORY-1"
+            |       },
+            |       {
+            |         "id": "TASK-1"
+            |       }
+            |     ]
+            |   }
+            | }
+            """.trimMargin(),
+            delayedResults = listOfJsonStrings(
+            ),
+        )
+}

--- a/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/execution/interfaceexpansion/allvisible/AllVisibleRelaxedBareTypenameTestSnapshot.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/execution/interfaceexpansion/allvisible/AllVisibleRelaxedBareTypenameTestSnapshot.kt
@@ -1,0 +1,113 @@
+// @formatter:off
+package graphql.nadel.tests.next.fixtures.execution.interfaceexpansion.allvisible
+
+import graphql.nadel.tests.next.ExpectedNadelResult
+import graphql.nadel.tests.next.ExpectedServiceCall
+import graphql.nadel.tests.next.TestSnapshot
+import graphql.nadel.tests.next.listOfJsonStrings
+import kotlin.Suppress
+import kotlin.collections.List
+import kotlin.collections.listOf
+
+private suspend fun main() {
+    graphql.nadel.tests.next.update<AllVisibleRelaxedBareTypenameTest>()
+}
+
+/**
+ * This class is generated. Do NOT modify.
+ *
+ * Refer to [graphql.nadel.tests.next.UpdateTestSnapshots]
+ */
+@Suppress("unused")
+public class AllVisibleRelaxedBareTypenameTestSnapshot : TestSnapshot() {
+    /**
+     * Query
+     *
+     * ```graphql
+     * query {
+     *   nodes {
+     *     __typename
+     *   }
+     * }
+     * ```
+     *
+     * Variables
+     *
+     * ```json
+     * {}
+     * ```
+     */
+    override val calls: List<ExpectedServiceCall> = listOf(
+            ExpectedServiceCall(
+                service = "data",
+                query = """
+                | {
+                |   nodes {
+                |     __typename
+                |   }
+                | }
+                """.trimMargin(),
+                variables = "{}",
+                result = """
+                | {
+                |   "data": {
+                |     "nodes": [
+                |       {
+                |         "__typename": "Issue"
+                |       },
+                |       {
+                |         "__typename": "Story"
+                |       },
+                |       {
+                |         "__typename": "Task"
+                |       }
+                |     ]
+                |   }
+                | }
+                """.trimMargin(),
+                delayedResults = listOfJsonStrings(
+                ),
+            ),
+        )
+
+    /**
+     * ```json
+     * {
+     *   "data": {
+     *     "nodes": [
+     *       {
+     *         "__typename": "Issue"
+     *       },
+     *       {
+     *         "__typename": "Story"
+     *       },
+     *       {
+     *         "__typename": "Task"
+     *       }
+     *     ]
+     *   }
+     * }
+     * ```
+     */
+    override val result: ExpectedNadelResult = ExpectedNadelResult(
+            result = """
+            | {
+            |   "data": {
+            |     "nodes": [
+            |       {
+            |         "__typename": "Issue"
+            |       },
+            |       {
+            |         "__typename": "Story"
+            |       },
+            |       {
+            |         "__typename": "Task"
+            |       }
+            |     ]
+            |   }
+            | }
+            """.trimMargin(),
+            delayedResults = listOfJsonStrings(
+            ),
+        )
+}

--- a/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/execution/interfaceexpansion/hiddenmembership/HiddenImplBareInterfaceFieldTestSnapshot.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/execution/interfaceexpansion/hiddenmembership/HiddenImplBareInterfaceFieldTestSnapshot.kt
@@ -1,0 +1,112 @@
+// @formatter:off
+package graphql.nadel.tests.next.fixtures.execution.interfaceexpansion.hiddenmembership
+
+import graphql.nadel.tests.next.ExpectedNadelResult
+import graphql.nadel.tests.next.ExpectedServiceCall
+import graphql.nadel.tests.next.TestSnapshot
+import graphql.nadel.tests.next.listOfJsonStrings
+import kotlin.Suppress
+import kotlin.collections.List
+import kotlin.collections.listOf
+
+private suspend fun main() {
+    graphql.nadel.tests.next.update<HiddenImplBareInterfaceFieldTest>()
+}
+
+/**
+ * This class is generated. Do NOT modify.
+ *
+ * Refer to [graphql.nadel.tests.next.UpdateTestSnapshots]
+ */
+@Suppress("unused")
+public class HiddenImplBareInterfaceFieldTestSnapshot : TestSnapshot() {
+    /**
+     * Query
+     *
+     * ```graphql
+     * query {
+     *   nodes {
+     *     id
+     *   }
+     * }
+     * ```
+     *
+     * Variables
+     *
+     * ```json
+     * {}
+     * ```
+     */
+    override val calls: List<ExpectedServiceCall> = listOf(
+            ExpectedServiceCall(
+                service = "data",
+                query = """
+                | {
+                |   nodes {
+                |     ... on Issue {
+                |       id
+                |     }
+                |     ... on Story {
+                |       id
+                |     }
+                |   }
+                | }
+                """.trimMargin(),
+                variables = "{}",
+                result = """
+                | {
+                |   "data": {
+                |     "nodes": [
+                |       {
+                |         "id": "ISSUE-1"
+                |       },
+                |       {
+                |         "id": "STORY-1"
+                |       },
+                |       {}
+                |     ]
+                |   }
+                | }
+                """.trimMargin(),
+                delayedResults = listOfJsonStrings(
+                ),
+            ),
+        )
+
+    /**
+     * ```json
+     * {
+     *   "data": {
+     *     "nodes": [
+     *       {
+     *         "id": "ISSUE-1"
+     *       },
+     *       {
+     *         "id": "STORY-1"
+     *       },
+     *       {}
+     *     ]
+     *   }
+     * }
+     * ```
+     */
+    override val result: ExpectedNadelResult = ExpectedNadelResult(
+            result = """
+            | {
+            |   "data": {
+            |     "nodes": [
+            |       {
+            |         "id": "ISSUE-1"
+            |       },
+            |       {
+            |         "id": "STORY-1"
+            |       },
+            |       {}
+            |     ]
+            |   }
+            | }
+            """.trimMargin(),
+            delayedResults = listOfJsonStrings(
+            ),
+        )
+}

--- a/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/execution/interfaceexpansion/hiddenmembership/HiddenImplBareTypenameTestSnapshot.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/execution/interfaceexpansion/hiddenmembership/HiddenImplBareTypenameTestSnapshot.kt
@@ -1,0 +1,112 @@
+// @formatter:off
+package graphql.nadel.tests.next.fixtures.execution.interfaceexpansion.hiddenmembership
+
+import graphql.nadel.tests.next.ExpectedNadelResult
+import graphql.nadel.tests.next.ExpectedServiceCall
+import graphql.nadel.tests.next.TestSnapshot
+import graphql.nadel.tests.next.listOfJsonStrings
+import kotlin.Suppress
+import kotlin.collections.List
+import kotlin.collections.listOf
+
+private suspend fun main() {
+    graphql.nadel.tests.next.update<HiddenImplBareTypenameTest>()
+}
+
+/**
+ * This class is generated. Do NOT modify.
+ *
+ * Refer to [graphql.nadel.tests.next.UpdateTestSnapshots]
+ */
+@Suppress("unused")
+public class HiddenImplBareTypenameTestSnapshot : TestSnapshot() {
+    /**
+     * Query
+     *
+     * ```graphql
+     * query {
+     *   nodes {
+     *     __typename
+     *   }
+     * }
+     * ```
+     *
+     * Variables
+     *
+     * ```json
+     * {}
+     * ```
+     */
+    override val calls: List<ExpectedServiceCall> = listOf(
+            ExpectedServiceCall(
+                service = "data",
+                query = """
+                | {
+                |   nodes {
+                |     ... on Issue {
+                |       __typename
+                |     }
+                |     ... on Story {
+                |       __typename
+                |     }
+                |   }
+                | }
+                """.trimMargin(),
+                variables = "{}",
+                result = """
+                | {
+                |   "data": {
+                |     "nodes": [
+                |       {
+                |         "__typename": "Issue"
+                |       },
+                |       {
+                |         "__typename": "Story"
+                |       },
+                |       {}
+                |     ]
+                |   }
+                | }
+                """.trimMargin(),
+                delayedResults = listOfJsonStrings(
+                ),
+            ),
+        )
+
+    /**
+     * ```json
+     * {
+     *   "data": {
+     *     "nodes": [
+     *       {
+     *         "__typename": "Issue"
+     *       },
+     *       {
+     *         "__typename": "Story"
+     *       },
+     *       {}
+     *     ]
+     *   }
+     * }
+     * ```
+     */
+    override val result: ExpectedNadelResult = ExpectedNadelResult(
+            result = """
+            | {
+            |   "data": {
+            |     "nodes": [
+            |       {
+            |         "__typename": "Issue"
+            |       },
+            |       {
+            |         "__typename": "Story"
+            |       },
+            |       {}
+            |     ]
+            |   }
+            | }
+            """.trimMargin(),
+            delayedResults = listOfJsonStrings(
+            ),
+        )
+}

--- a/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/execution/interfaceexpansion/hiddenmembership/HiddenImplExplicitAllExposedImplsTestSnapshot.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/execution/interfaceexpansion/hiddenmembership/HiddenImplExplicitAllExposedImplsTestSnapshot.kt
@@ -1,0 +1,117 @@
+// @formatter:off
+package graphql.nadel.tests.next.fixtures.execution.interfaceexpansion.hiddenmembership
+
+import graphql.nadel.tests.next.ExpectedNadelResult
+import graphql.nadel.tests.next.ExpectedServiceCall
+import graphql.nadel.tests.next.TestSnapshot
+import graphql.nadel.tests.next.listOfJsonStrings
+import kotlin.Suppress
+import kotlin.collections.List
+import kotlin.collections.listOf
+
+private suspend fun main() {
+    graphql.nadel.tests.next.update<HiddenImplExplicitAllExposedImplsTest>()
+}
+
+/**
+ * This class is generated. Do NOT modify.
+ *
+ * Refer to [graphql.nadel.tests.next.UpdateTestSnapshots]
+ */
+@Suppress("unused")
+public class HiddenImplExplicitAllExposedImplsTestSnapshot : TestSnapshot() {
+    /**
+     * Query
+     *
+     * ```graphql
+     * query {
+     *   nodes {
+     *     ... on Issue {
+     *       id
+     *     }
+     *     ... on Story {
+     *       id
+     *     }
+     *   }
+     * }
+     * ```
+     *
+     * Variables
+     *
+     * ```json
+     * {}
+     * ```
+     */
+    override val calls: List<ExpectedServiceCall> = listOf(
+            ExpectedServiceCall(
+                service = "data",
+                query = """
+                | {
+                |   nodes {
+                |     ... on Issue {
+                |       id
+                |     }
+                |     ... on Story {
+                |       id
+                |     }
+                |   }
+                | }
+                """.trimMargin(),
+                variables = "{}",
+                result = """
+                | {
+                |   "data": {
+                |     "nodes": [
+                |       {
+                |         "id": "ISSUE-1"
+                |       },
+                |       {
+                |         "id": "STORY-1"
+                |       },
+                |       {}
+                |     ]
+                |   }
+                | }
+                """.trimMargin(),
+                delayedResults = listOfJsonStrings(
+                ),
+            ),
+        )
+
+    /**
+     * ```json
+     * {
+     *   "data": {
+     *     "nodes": [
+     *       {
+     *         "id": "ISSUE-1"
+     *       },
+     *       {
+     *         "id": "STORY-1"
+     *       },
+     *       {}
+     *     ]
+     *   }
+     * }
+     * ```
+     */
+    override val result: ExpectedNadelResult = ExpectedNadelResult(
+            result = """
+            | {
+            |   "data": {
+            |     "nodes": [
+            |       {
+            |         "id": "ISSUE-1"
+            |       },
+            |       {
+            |         "id": "STORY-1"
+            |       },
+            |       {}
+            |     ]
+            |   }
+            | }
+            """.trimMargin(),
+            delayedResults = listOfJsonStrings(
+            ),
+        )
+}

--- a/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/execution/interfaceexpansion/hiddenmembership/HiddenImplExplicitExposedImplTestSnapshot.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/execution/interfaceexpansion/hiddenmembership/HiddenImplExplicitExposedImplTestSnapshot.kt
@@ -1,0 +1,105 @@
+// @formatter:off
+package graphql.nadel.tests.next.fixtures.execution.interfaceexpansion.hiddenmembership
+
+import graphql.nadel.tests.next.ExpectedNadelResult
+import graphql.nadel.tests.next.ExpectedServiceCall
+import graphql.nadel.tests.next.TestSnapshot
+import graphql.nadel.tests.next.listOfJsonStrings
+import kotlin.Suppress
+import kotlin.collections.List
+import kotlin.collections.listOf
+
+private suspend fun main() {
+    graphql.nadel.tests.next.update<HiddenImplExplicitExposedImplTest>()
+}
+
+/**
+ * This class is generated. Do NOT modify.
+ *
+ * Refer to [graphql.nadel.tests.next.UpdateTestSnapshots]
+ */
+@Suppress("unused")
+public class HiddenImplExplicitExposedImplTestSnapshot : TestSnapshot() {
+    /**
+     * Query
+     *
+     * ```graphql
+     * query {
+     *   nodes {
+     *     ... on Issue {
+     *       issueField
+     *     }
+     *   }
+     * }
+     * ```
+     *
+     * Variables
+     *
+     * ```json
+     * {}
+     * ```
+     */
+    override val calls: List<ExpectedServiceCall> = listOf(
+            ExpectedServiceCall(
+                service = "data",
+                query = """
+                | {
+                |   nodes {
+                |     ... on Issue {
+                |       issueField
+                |     }
+                |   }
+                | }
+                """.trimMargin(),
+                variables = "{}",
+                result = """
+                | {
+                |   "data": {
+                |     "nodes": [
+                |       {
+                |         "issueField": "i"
+                |       },
+                |       {},
+                |       {}
+                |     ]
+                |   }
+                | }
+                """.trimMargin(),
+                delayedResults = listOfJsonStrings(
+                ),
+            ),
+        )
+
+    /**
+     * ```json
+     * {
+     *   "data": {
+     *     "nodes": [
+     *       {
+     *         "issueField": "i"
+     *       },
+     *       {},
+     *       {}
+     *     ]
+     *   }
+     * }
+     * ```
+     */
+    override val result: ExpectedNadelResult = ExpectedNadelResult(
+            result = """
+            | {
+            |   "data": {
+            |     "nodes": [
+            |       {
+            |         "issueField": "i"
+            |       },
+            |       {},
+            |       {}
+            |     ]
+            |   }
+            | }
+            """.trimMargin(),
+            delayedResults = listOfJsonStrings(
+            ),
+        )
+}

--- a/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/execution/interfaceexpansion/hiddenmembership/HiddenImplRelaxedBareInterfaceFieldTestSnapshot.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/execution/interfaceexpansion/hiddenmembership/HiddenImplRelaxedBareInterfaceFieldTestSnapshot.kt
@@ -1,0 +1,113 @@
+// @formatter:off
+package graphql.nadel.tests.next.fixtures.execution.interfaceexpansion.hiddenmembership
+
+import graphql.nadel.tests.next.ExpectedNadelResult
+import graphql.nadel.tests.next.ExpectedServiceCall
+import graphql.nadel.tests.next.TestSnapshot
+import graphql.nadel.tests.next.listOfJsonStrings
+import kotlin.Suppress
+import kotlin.collections.List
+import kotlin.collections.listOf
+
+private suspend fun main() {
+    graphql.nadel.tests.next.update<HiddenImplRelaxedBareInterfaceFieldTest>()
+}
+
+/**
+ * This class is generated. Do NOT modify.
+ *
+ * Refer to [graphql.nadel.tests.next.UpdateTestSnapshots]
+ */
+@Suppress("unused")
+public class HiddenImplRelaxedBareInterfaceFieldTestSnapshot : TestSnapshot() {
+    /**
+     * Query
+     *
+     * ```graphql
+     * query {
+     *   nodes {
+     *     id
+     *   }
+     * }
+     * ```
+     *
+     * Variables
+     *
+     * ```json
+     * {}
+     * ```
+     */
+    override val calls: List<ExpectedServiceCall> = listOf(
+            ExpectedServiceCall(
+                service = "data",
+                query = """
+                | {
+                |   nodes {
+                |     __typename__abstract_member__nodes: __typename
+                |     id
+                |   }
+                | }
+                """.trimMargin(),
+                variables = "{}",
+                result = """
+                | {
+                |   "data": {
+                |     "nodes": [
+                |       {
+                |         "id": "ISSUE-1",
+                |         "__typename__abstract_member__nodes": "Issue"
+                |       },
+                |       {
+                |         "id": "STORY-1",
+                |         "__typename__abstract_member__nodes": "Story"
+                |       },
+                |       {
+                |         "id": "TASK-1",
+                |         "__typename__abstract_member__nodes": "Task"
+                |       }
+                |     ]
+                |   }
+                | }
+                """.trimMargin(),
+                delayedResults = listOfJsonStrings(
+                ),
+            ),
+        )
+
+    /**
+     * ```json
+     * {
+     *   "data": {
+     *     "nodes": [
+     *       {
+     *         "id": "ISSUE-1"
+     *       },
+     *       {
+     *         "id": "STORY-1"
+     *       },
+     *       {}
+     *     ]
+     *   }
+     * }
+     * ```
+     */
+    override val result: ExpectedNadelResult = ExpectedNadelResult(
+            result = """
+            | {
+            |   "data": {
+            |     "nodes": [
+            |       {
+            |         "id": "ISSUE-1"
+            |       },
+            |       {
+            |         "id": "STORY-1"
+            |       },
+            |       {}
+            |     ]
+            |   }
+            | }
+            """.trimMargin(),
+            delayedResults = listOfJsonStrings(
+            ),
+        )
+}

--- a/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/execution/interfaceexpansion/hiddenmembership/HiddenImplRelaxedBareTypenameTestSnapshot.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/execution/interfaceexpansion/hiddenmembership/HiddenImplRelaxedBareTypenameTestSnapshot.kt
@@ -1,0 +1,113 @@
+// @formatter:off
+package graphql.nadel.tests.next.fixtures.execution.interfaceexpansion.hiddenmembership
+
+import graphql.nadel.tests.next.ExpectedNadelResult
+import graphql.nadel.tests.next.ExpectedServiceCall
+import graphql.nadel.tests.next.TestSnapshot
+import graphql.nadel.tests.next.listOfJsonStrings
+import kotlin.Suppress
+import kotlin.collections.List
+import kotlin.collections.listOf
+
+private suspend fun main() {
+    graphql.nadel.tests.next.update<HiddenImplRelaxedBareTypenameTest>()
+}
+
+/**
+ * This class is generated. Do NOT modify.
+ *
+ * Refer to [graphql.nadel.tests.next.UpdateTestSnapshots]
+ */
+@Suppress("unused")
+public class HiddenImplRelaxedBareTypenameTestSnapshot : TestSnapshot() {
+    /**
+     * Query
+     *
+     * ```graphql
+     * query {
+     *   nodes {
+     *     __typename
+     *   }
+     * }
+     * ```
+     *
+     * Variables
+     *
+     * ```json
+     * {}
+     * ```
+     */
+    override val calls: List<ExpectedServiceCall> = listOf(
+            ExpectedServiceCall(
+                service = "data",
+                query = """
+                | {
+                |   nodes {
+                |     __typename
+                |     __typename__abstract_member__nodes: __typename
+                |   }
+                | }
+                """.trimMargin(),
+                variables = "{}",
+                result = """
+                | {
+                |   "data": {
+                |     "nodes": [
+                |       {
+                |         "__typename": "Issue",
+                |         "__typename__abstract_member__nodes": "Issue"
+                |       },
+                |       {
+                |         "__typename": "Story",
+                |         "__typename__abstract_member__nodes": "Story"
+                |       },
+                |       {
+                |         "__typename": "Task",
+                |         "__typename__abstract_member__nodes": "Task"
+                |       }
+                |     ]
+                |   }
+                | }
+                """.trimMargin(),
+                delayedResults = listOfJsonStrings(
+                ),
+            ),
+        )
+
+    /**
+     * ```json
+     * {
+     *   "data": {
+     *     "nodes": [
+     *       {
+     *         "__typename": "Issue"
+     *       },
+     *       {
+     *         "__typename": "Story"
+     *       },
+     *       {}
+     *     ]
+     *   }
+     * }
+     * ```
+     */
+    override val result: ExpectedNadelResult = ExpectedNadelResult(
+            result = """
+            | {
+            |   "data": {
+            |     "nodes": [
+            |       {
+            |         "__typename": "Issue"
+            |       },
+            |       {
+            |         "__typename": "Story"
+            |       },
+            |       {}
+            |     ]
+            |   }
+            | }
+            """.trimMargin(),
+            delayedResults = listOfJsonStrings(
+            ),
+        )
+}

--- a/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/execution/interfaceexpansion/hiddenmembership/HiddenImplRelaxedExplicitAllExposedImplsTestSnapshot.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/execution/interfaceexpansion/hiddenmembership/HiddenImplRelaxedExplicitAllExposedImplsTestSnapshot.kt
@@ -1,0 +1,118 @@
+// @formatter:off
+package graphql.nadel.tests.next.fixtures.execution.interfaceexpansion.hiddenmembership
+
+import graphql.nadel.tests.next.ExpectedNadelResult
+import graphql.nadel.tests.next.ExpectedServiceCall
+import graphql.nadel.tests.next.TestSnapshot
+import graphql.nadel.tests.next.listOfJsonStrings
+import kotlin.Suppress
+import kotlin.collections.List
+import kotlin.collections.listOf
+
+private suspend fun main() {
+    graphql.nadel.tests.next.update<HiddenImplRelaxedExplicitAllExposedImplsTest>()
+}
+
+/**
+ * This class is generated. Do NOT modify.
+ *
+ * Refer to [graphql.nadel.tests.next.UpdateTestSnapshots]
+ */
+@Suppress("unused")
+public class HiddenImplRelaxedExplicitAllExposedImplsTestSnapshot : TestSnapshot() {
+    /**
+     * Query
+     *
+     * ```graphql
+     * query {
+     *   nodes {
+     *     ... on Issue {
+     *       id
+     *     }
+     *     ... on Story {
+     *       id
+     *     }
+     *   }
+     * }
+     * ```
+     *
+     * Variables
+     *
+     * ```json
+     * {}
+     * ```
+     */
+    override val calls: List<ExpectedServiceCall> = listOf(
+            ExpectedServiceCall(
+                service = "data",
+                query = """
+                | {
+                |   nodes {
+                |     __typename__abstract_member__nodes: __typename
+                |     id
+                |   }
+                | }
+                """.trimMargin(),
+                variables = "{}",
+                result = """
+                | {
+                |   "data": {
+                |     "nodes": [
+                |       {
+                |         "id": "ISSUE-1",
+                |         "__typename__abstract_member__nodes": "Issue"
+                |       },
+                |       {
+                |         "id": "STORY-1",
+                |         "__typename__abstract_member__nodes": "Story"
+                |       },
+                |       {
+                |         "id": "TASK-1",
+                |         "__typename__abstract_member__nodes": "Task"
+                |       }
+                |     ]
+                |   }
+                | }
+                """.trimMargin(),
+                delayedResults = listOfJsonStrings(
+                ),
+            ),
+        )
+
+    /**
+     * ```json
+     * {
+     *   "data": {
+     *     "nodes": [
+     *       {
+     *         "id": "ISSUE-1"
+     *       },
+     *       {
+     *         "id": "STORY-1"
+     *       },
+     *       {}
+     *     ]
+     *   }
+     * }
+     * ```
+     */
+    override val result: ExpectedNadelResult = ExpectedNadelResult(
+            result = """
+            | {
+            |   "data": {
+            |     "nodes": [
+            |       {
+            |         "id": "ISSUE-1"
+            |       },
+            |       {
+            |         "id": "STORY-1"
+            |       },
+            |       {}
+            |     ]
+            |   }
+            | }
+            """.trimMargin(),
+            delayedResults = listOfJsonStrings(
+            ),
+        )
+}

--- a/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/execution/interfaceexpansion/hiddenmembership/HiddenImplRelaxedExplicitExposedImplTestSnapshot.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/execution/interfaceexpansion/hiddenmembership/HiddenImplRelaxedExplicitExposedImplTestSnapshot.kt
@@ -1,0 +1,105 @@
+// @formatter:off
+package graphql.nadel.tests.next.fixtures.execution.interfaceexpansion.hiddenmembership
+
+import graphql.nadel.tests.next.ExpectedNadelResult
+import graphql.nadel.tests.next.ExpectedServiceCall
+import graphql.nadel.tests.next.TestSnapshot
+import graphql.nadel.tests.next.listOfJsonStrings
+import kotlin.Suppress
+import kotlin.collections.List
+import kotlin.collections.listOf
+
+private suspend fun main() {
+    graphql.nadel.tests.next.update<HiddenImplRelaxedExplicitExposedImplTest>()
+}
+
+/**
+ * This class is generated. Do NOT modify.
+ *
+ * Refer to [graphql.nadel.tests.next.UpdateTestSnapshots]
+ */
+@Suppress("unused")
+public class HiddenImplRelaxedExplicitExposedImplTestSnapshot : TestSnapshot() {
+    /**
+     * Query
+     *
+     * ```graphql
+     * query {
+     *   nodes {
+     *     ... on Issue {
+     *       issueField
+     *     }
+     *   }
+     * }
+     * ```
+     *
+     * Variables
+     *
+     * ```json
+     * {}
+     * ```
+     */
+    override val calls: List<ExpectedServiceCall> = listOf(
+            ExpectedServiceCall(
+                service = "data",
+                query = """
+                | {
+                |   nodes {
+                |     ... on Issue {
+                |       issueField
+                |     }
+                |   }
+                | }
+                """.trimMargin(),
+                variables = "{}",
+                result = """
+                | {
+                |   "data": {
+                |     "nodes": [
+                |       {
+                |         "issueField": "i"
+                |       },
+                |       {},
+                |       {}
+                |     ]
+                |   }
+                | }
+                """.trimMargin(),
+                delayedResults = listOfJsonStrings(
+                ),
+            ),
+        )
+
+    /**
+     * ```json
+     * {
+     *   "data": {
+     *     "nodes": [
+     *       {
+     *         "issueField": "i"
+     *       },
+     *       {},
+     *       {}
+     *     ]
+     *   }
+     * }
+     * ```
+     */
+    override val result: ExpectedNadelResult = ExpectedNadelResult(
+            result = """
+            | {
+            |   "data": {
+            |     "nodes": [
+            |       {
+            |         "issueField": "i"
+            |       },
+            |       {},
+            |       {}
+            |     ]
+            |   }
+            | }
+            """.trimMargin(),
+            delayedResults = listOfJsonStrings(
+            ),
+        )
+}

--- a/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/execution/interfaceexpansion/hiddenmembership/HiddenImplRelaxedTest.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/execution/interfaceexpansion/hiddenmembership/HiddenImplRelaxedTest.kt
@@ -1,0 +1,76 @@
+package graphql.nadel.tests.next.fixtures.execution.interfaceexpansion.hiddenmembership
+
+import graphql.nadel.NadelExecutionHints
+
+/**
+ * The hiddenmembership scenario with the hint ON: same schema + queries as [HiddenImplementationTestBase], only
+ * the hint flipped, so the snapshot diff against the hint-OFF tests is the fix. Relaxed selections go bare
+ * downstream and non-exposed nodes are stripped to `{}`, so the client-facing result is unchanged.
+ */
+
+/** The fix: `nodes { id }` goes bare downstream; the hidden `Task` still reduces to `{}`. */
+class HiddenImplRelaxedBareInterfaceFieldTest : HiddenImplementationTestBase(
+    query = """
+        query {
+          nodes {
+            id
+          }
+        }
+    """.trimIndent(),
+) {
+    override fun makeExecutionHints(): NadelExecutionHints.Builder {
+        return super.makeExecutionHints().noInterfaceToObjectFragmentExpansion { _ -> true }
+    }
+}
+
+/** Naming every exposed impl normalizes to the bare selection, so it relaxes too (result-identical). */
+class HiddenImplRelaxedExplicitAllExposedImplsTest : HiddenImplementationTestBase(
+    query = """
+        query {
+          nodes {
+            ... on Issue {
+              id
+            }
+            ... on Story {
+              id
+            }
+          }
+        }
+    """.trimIndent(),
+) {
+    override fun makeExecutionHints(): NadelExecutionHints.Builder {
+        return super.makeExecutionHints().noInterfaceToObjectFragmentExpansion { _ -> true }
+    }
+}
+
+/** `__typename` is relaxed too; the hidden node is stripped after the type-rename transform (this runs last). */
+class HiddenImplRelaxedBareTypenameTest : HiddenImplementationTestBase(
+    query = """
+        query {
+          nodes {
+            __typename
+          }
+        }
+    """.trimIndent(),
+) {
+    override fun makeExecutionHints(): NadelExecutionHints.Builder {
+        return super.makeExecutionHints().noInterfaceToObjectFragmentExpansion { _ -> true }
+    }
+}
+
+/** Over-return protection: an explicit single-impl selection is not relaxed (would leak `Story` data). */
+class HiddenImplRelaxedExplicitExposedImplTest : HiddenImplementationTestBase(
+    query = """
+        query {
+          nodes {
+            ... on Issue {
+              issueField
+            }
+          }
+        }
+    """.trimIndent(),
+) {
+    override fun makeExecutionHints(): NadelExecutionHints.Builder {
+        return super.makeExecutionHints().noInterfaceToObjectFragmentExpansion { _ -> true }
+    }
+}

--- a/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/execution/interfaceexpansion/hiddenmembership/HiddenImplementationExpansionTest.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/execution/interfaceexpansion/hiddenmembership/HiddenImplementationExpansionTest.kt
@@ -1,0 +1,132 @@
+package graphql.nadel.tests.next.fixtures.execution.interfaceexpansion.hiddenmembership
+
+import graphql.nadel.tests.next.NadelIntegrationTest
+import org.intellij.lang.annotations.Language
+
+/**
+ * Characterises today's interface→object-fragment expansion. In the overall schema only `Issue`/`Story`
+ * implement `Node` (`Task` is a visible object type but not a member); in the underlying schema `Task` also
+ * implements `Node`. So the exposed set is a strict subset of the underlying impls, and graphql-java rewrites a
+ * bare interface selection into one `... on ExposedImpl` fragment per exposed type — how an undeployed sibling
+ * type ends up named in a query the client never wrote. The snapshots' `calls` block is the demonstration.
+ * (For a type absent from the overall schema entirely, see the underlyingonly fixtures.)
+ */
+abstract class HiddenImplementationTestBase(
+    @Language("GraphQL") query: String,
+) : NadelIntegrationTest(
+    query = query,
+    services = listOf(
+        Service(
+            name = "data",
+            overallSchema = """
+                type Query {
+                  nodes: [Node]
+                }
+                interface Node {
+                  id: ID
+                }
+                type Issue implements Node {
+                  id: ID
+                  issueField: String
+                }
+                type Story implements Node {
+                  id: ID
+                  storyField: String
+                }
+                type Task {
+                  id: ID
+                }
+            """.trimIndent(),
+            underlyingSchema = """
+                type Query {
+                  nodes: [Node]
+                }
+                interface Node {
+                  id: ID
+                }
+                type Issue implements Node {
+                  id: ID
+                  issueField: String
+                }
+                type Story implements Node {
+                  id: ID
+                  storyField: String
+                }
+                type Task implements Node {
+                  id: ID
+                }
+            """.trimIndent(),
+            runtimeWiring = { wiring ->
+                data class Issue(val id: String, val issueField: String)
+                data class Story(val id: String, val storyField: String)
+                data class Task(val id: String)
+
+                wiring
+                    .type("Node") { type ->
+                        type.typeResolver { env ->
+                            env.schema.getObjectType(env.getObject<Any>().javaClass.simpleName)
+                        }
+                    }
+                    .type("Query") { type ->
+                        type.dataFetcher("nodes") { _ ->
+                            listOf(
+                                Issue(id = "ISSUE-1", issueField = "i"),
+                                Story(id = "STORY-1", storyField = "s"),
+                                Task(id = "TASK-1"),
+                            )
+                        }
+                    }
+            },
+        ),
+    ),
+)
+
+/** The core case: bare `nodes { id }` is expanded into `... on Issue`/`... on Story` downstream. */
+class HiddenImplBareInterfaceFieldTest : HiddenImplementationTestBase(
+    query = """
+        query {
+          nodes {
+            id
+          }
+        }
+    """.trimIndent(),
+)
+
+class HiddenImplBareTypenameTest : HiddenImplementationTestBase(
+    query = """
+        query {
+          nodes {
+            __typename
+          }
+        }
+    """.trimIndent(),
+)
+
+/** Explicit `... on Issue` is honoured verbatim — the client opted into a concrete type. */
+class HiddenImplExplicitExposedImplTest : HiddenImplementationTestBase(
+    query = """
+        query {
+          nodes {
+            ... on Issue {
+              issueField
+            }
+          }
+        }
+    """.trimIndent(),
+)
+
+/** Naming every exposed impl normalizes to the same ENF as the bare selection — intent is lost by compile time. */
+class HiddenImplExplicitAllExposedImplsTest : HiddenImplementationTestBase(
+    query = """
+        query {
+          nodes {
+            ... on Issue {
+              id
+            }
+            ... on Story {
+              id
+            }
+          }
+        }
+    """.trimIndent(),
+)

--- a/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/execution/interfaceexpansion/multiinterface/MultiInterfaceHiddenImplBareInterfaceFieldTestSnapshot.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/execution/interfaceexpansion/multiinterface/MultiInterfaceHiddenImplBareInterfaceFieldTestSnapshot.kt
@@ -1,0 +1,125 @@
+// @formatter:off
+package graphql.nadel.tests.next.fixtures.execution.interfaceexpansion.multiinterface
+
+import graphql.nadel.tests.next.ExpectedNadelResult
+import graphql.nadel.tests.next.ExpectedServiceCall
+import graphql.nadel.tests.next.TestSnapshot
+import graphql.nadel.tests.next.listOfJsonStrings
+import kotlin.Suppress
+import kotlin.collections.List
+import kotlin.collections.listOf
+
+private suspend fun main() {
+    graphql.nadel.tests.next.update<MultiInterfaceHiddenImplBareInterfaceFieldTest>()
+}
+
+/**
+ * This class is generated. Do NOT modify.
+ *
+ * Refer to [graphql.nadel.tests.next.UpdateTestSnapshots]
+ */
+@Suppress("unused")
+public class MultiInterfaceHiddenImplBareInterfaceFieldTestSnapshot : TestSnapshot() {
+    /**
+     * Query
+     *
+     * ```graphql
+     * query {
+     *   containers {
+     *     item {
+     *       id
+     *     }
+     *   }
+     * }
+     * ```
+     *
+     * Variables
+     *
+     * ```json
+     * {}
+     * ```
+     */
+    override val calls: List<ExpectedServiceCall> = listOf(
+            ExpectedServiceCall(
+                service = "data",
+                query = """
+                | {
+                |   containers {
+                |     item {
+                |       ... on Post {
+                |         id
+                |       }
+                |       ... on Wiki {
+                |         id
+                |       }
+                |     }
+                |   }
+                | }
+                """.trimMargin(),
+                variables = "{}",
+                result = """
+                | {
+                |   "data": {
+                |     "containers": [
+                |       {
+                |         "item": {
+                |           "id": "WIKI-1"
+                |         }
+                |       },
+                |       {
+                |         "item": {
+                |           "id": "POST-1"
+                |         }
+                |       }
+                |     ]
+                |   }
+                | }
+                """.trimMargin(),
+                delayedResults = listOfJsonStrings(
+                ),
+            ),
+        )
+
+    /**
+     * ```json
+     * {
+     *   "data": {
+     *     "containers": [
+     *       {
+     *         "item": {
+     *           "id": "WIKI-1"
+     *         }
+     *       },
+     *       {
+     *         "item": {
+     *           "id": "POST-1"
+     *         }
+     *       }
+     *     ]
+     *   }
+     * }
+     * ```
+     */
+    override val result: ExpectedNadelResult = ExpectedNadelResult(
+            result = """
+            | {
+            |   "data": {
+            |     "containers": [
+            |       {
+            |         "item": {
+            |           "id": "WIKI-1"
+            |         }
+            |       },
+            |       {
+            |         "item": {
+            |           "id": "POST-1"
+            |         }
+            |       }
+            |     ]
+            |   }
+            | }
+            """.trimMargin(),
+            delayedResults = listOfJsonStrings(
+            ),
+        )
+}

--- a/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/execution/interfaceexpansion/multiinterface/MultiInterfaceHiddenImplRelaxedBareInterfaceFieldTestSnapshot.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/execution/interfaceexpansion/multiinterface/MultiInterfaceHiddenImplRelaxedBareInterfaceFieldTestSnapshot.kt
@@ -1,0 +1,123 @@
+// @formatter:off
+package graphql.nadel.tests.next.fixtures.execution.interfaceexpansion.multiinterface
+
+import graphql.nadel.tests.next.ExpectedNadelResult
+import graphql.nadel.tests.next.ExpectedServiceCall
+import graphql.nadel.tests.next.TestSnapshot
+import graphql.nadel.tests.next.listOfJsonStrings
+import kotlin.Suppress
+import kotlin.collections.List
+import kotlin.collections.listOf
+
+private suspend fun main() {
+    graphql.nadel.tests.next.update<MultiInterfaceHiddenImplRelaxedBareInterfaceFieldTest>()
+}
+
+/**
+ * This class is generated. Do NOT modify.
+ *
+ * Refer to [graphql.nadel.tests.next.UpdateTestSnapshots]
+ */
+@Suppress("unused")
+public class MultiInterfaceHiddenImplRelaxedBareInterfaceFieldTestSnapshot : TestSnapshot() {
+    /**
+     * Query
+     *
+     * ```graphql
+     * query {
+     *   containers {
+     *     item {
+     *       id
+     *     }
+     *   }
+     * }
+     * ```
+     *
+     * Variables
+     *
+     * ```json
+     * {}
+     * ```
+     */
+    override val calls: List<ExpectedServiceCall> = listOf(
+            ExpectedServiceCall(
+                service = "data",
+                query = """
+                | {
+                |   containers {
+                |     item {
+                |       __typename__abstract_member__item: __typename
+                |       id
+                |     }
+                |   }
+                | }
+                """.trimMargin(),
+                variables = "{}",
+                result = """
+                | {
+                |   "data": {
+                |     "containers": [
+                |       {
+                |         "item": {
+                |           "id": "WIKI-1",
+                |           "__typename__abstract_member__item": "Wiki"
+                |         }
+                |       },
+                |       {
+                |         "item": {
+                |           "id": "POST-1",
+                |           "__typename__abstract_member__item": "Post"
+                |         }
+                |       }
+                |     ]
+                |   }
+                | }
+                """.trimMargin(),
+                delayedResults = listOfJsonStrings(
+                ),
+            ),
+        )
+
+    /**
+     * ```json
+     * {
+     *   "data": {
+     *     "containers": [
+     *       {
+     *         "item": {
+     *           "id": "WIKI-1"
+     *         }
+     *       },
+     *       {
+     *         "item": {
+     *           "id": "POST-1"
+     *         }
+     *       }
+     *     ]
+     *   }
+     * }
+     * ```
+     */
+    override val result: ExpectedNadelResult = ExpectedNadelResult(
+            result = """
+            | {
+            |   "data": {
+            |     "containers": [
+            |       {
+            |         "item": {
+            |           "id": "WIKI-1"
+            |         }
+            |       },
+            |       {
+            |         "item": {
+            |           "id": "POST-1"
+            |         }
+            |       }
+            |     ]
+            |   }
+            | }
+            """.trimMargin(),
+            delayedResults = listOfJsonStrings(
+            ),
+        )
+}

--- a/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/execution/interfaceexpansion/multiinterface/MultiInterfaceHiddenImplRelaxedTest.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/execution/interfaceexpansion/multiinterface/MultiInterfaceHiddenImplRelaxedTest.kt
@@ -1,0 +1,24 @@
+package graphql.nadel.tests.next.fixtures.execution.interfaceexpansion.multiinterface
+
+import graphql.nadel.NadelExecutionHints
+
+/**
+ * The multi-interface scenario with the hint ON: same schema + query as [MultiInterfaceHiddenImplTestBase], hint
+ * flipped. Confirms the relaxation check accepts a field whose parent resolves to multiple interfaces - the
+ * `containers { item { id } }` selection goes bare downstream instead of expanding per exposed impl.
+ */
+class MultiInterfaceHiddenImplRelaxedBareInterfaceFieldTest : MultiInterfaceHiddenImplTestBase(
+    query = """
+        query {
+          containers {
+            item {
+              id
+            }
+          }
+        }
+    """.trimIndent(),
+) {
+    override fun makeExecutionHints(): NadelExecutionHints.Builder {
+        return super.makeExecutionHints().noInterfaceToObjectFragmentExpansion { _ -> true }
+    }
+}

--- a/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/execution/interfaceexpansion/multiinterface/MultiInterfaceHiddenImplTest.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/execution/interfaceexpansion/multiinterface/MultiInterfaceHiddenImplTest.kt
@@ -1,0 +1,135 @@
+package graphql.nadel.tests.next.fixtures.execution.interfaceexpansion.multiinterface
+
+import graphql.nadel.tests.next.NadelIntegrationTest
+import org.intellij.lang.annotations.Language
+
+/**
+ * The relaxed field's parent resolves to MORE THAN ONE interface. `Container.item` is declared as `FeedItem`,
+ * but `PageContainer.item` narrows it to `PageItem` and `BlogContainer.item` to `BlogItem` (both implement
+ * `FeedItem`). So under a bare `containers { item { id } }` the `id` field's parent output types are
+ * `{PageItem, BlogItem}` - two interfaces - and `id` exists on both. Each underlying interface has a hidden impl
+ * (`SecretPage`/`SecretBlog`), so a bare selection would otherwise expand into per-exposed-type fragments. This
+ * exercises the multi-interface branch of the relaxation check.
+ */
+abstract class MultiInterfaceHiddenImplTestBase(
+    @Language("GraphQL") query: String,
+) : NadelIntegrationTest(
+    query = query,
+    services = listOf(
+        Service(
+            name = "data",
+            overallSchema = """
+                type Query {
+                  containers: [Container]
+                }
+                interface Container {
+                  item: FeedItem
+                }
+                type PageContainer implements Container {
+                  item: PageItem
+                }
+                type BlogContainer implements Container {
+                  item: BlogItem
+                }
+                interface FeedItem {
+                  id: ID
+                }
+                interface PageItem implements FeedItem {
+                  id: ID
+                }
+                interface BlogItem implements FeedItem {
+                  id: ID
+                }
+                type Wiki implements PageItem & FeedItem {
+                  id: ID
+                }
+                type Post implements BlogItem & FeedItem {
+                  id: ID
+                }
+            """.trimIndent(),
+            underlyingSchema = """
+                type Query {
+                  containers: [Container]
+                }
+                interface Container {
+                  item: FeedItem
+                }
+                type PageContainer implements Container {
+                  item: PageItem
+                }
+                type BlogContainer implements Container {
+                  item: BlogItem
+                }
+                interface FeedItem {
+                  id: ID
+                }
+                interface PageItem implements FeedItem {
+                  id: ID
+                }
+                interface BlogItem implements FeedItem {
+                  id: ID
+                }
+                type Wiki implements PageItem & FeedItem {
+                  id: ID
+                }
+                type Post implements BlogItem & FeedItem {
+                  id: ID
+                }
+                type SecretPage implements PageItem & FeedItem {
+                  id: ID
+                }
+                type SecretBlog implements BlogItem & FeedItem {
+                  id: ID
+                }
+            """.trimIndent(),
+            runtimeWiring = { wiring ->
+                data class Wiki(val id: String)
+                data class Post(val id: String)
+                data class PageContainer(val item: Any)
+                data class BlogContainer(val item: Any)
+
+                wiring
+                    .type("Container") { type ->
+                        type.typeResolver { env ->
+                            env.schema.getObjectType(env.getObject<Any>().javaClass.simpleName)
+                        }
+                    }
+                    .type("FeedItem") { type ->
+                        type.typeResolver { env ->
+                            env.schema.getObjectType(env.getObject<Any>().javaClass.simpleName)
+                        }
+                    }
+                    .type("PageItem") { type ->
+                        type.typeResolver { env ->
+                            env.schema.getObjectType(env.getObject<Any>().javaClass.simpleName)
+                        }
+                    }
+                    .type("BlogItem") { type ->
+                        type.typeResolver { env ->
+                            env.schema.getObjectType(env.getObject<Any>().javaClass.simpleName)
+                        }
+                    }
+                    .type("Query") { type ->
+                        type.dataFetcher("containers") { _ ->
+                            listOf(
+                                PageContainer(item = Wiki(id = "WIKI-1")),
+                                BlogContainer(item = Post(id = "POST-1")),
+                            )
+                        }
+                    }
+            },
+        ),
+    ),
+)
+
+class MultiInterfaceHiddenImplBareInterfaceFieldTest : MultiInterfaceHiddenImplTestBase(
+    query = """
+        query {
+          containers {
+            item {
+              id
+            }
+          }
+        }
+    """.trimIndent(),
+)

--- a/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/execution/interfaceexpansion/renames/RenamedAncestorBareInterfaceFieldTestSnapshot.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/execution/interfaceexpansion/renames/RenamedAncestorBareInterfaceFieldTestSnapshot.kt
@@ -1,0 +1,124 @@
+// @formatter:off
+package graphql.nadel.tests.next.fixtures.execution.interfaceexpansion.renames
+
+import graphql.nadel.tests.next.ExpectedNadelResult
+import graphql.nadel.tests.next.ExpectedServiceCall
+import graphql.nadel.tests.next.TestSnapshot
+import graphql.nadel.tests.next.listOfJsonStrings
+import kotlin.Suppress
+import kotlin.collections.List
+import kotlin.collections.listOf
+
+private suspend fun main() {
+    graphql.nadel.tests.next.update<RenamedAncestorBareInterfaceFieldTest>()
+}
+
+/**
+ * This class is generated. Do NOT modify.
+ *
+ * Refer to [graphql.nadel.tests.next.UpdateTestSnapshots]
+ */
+@Suppress("unused")
+public class RenamedAncestorBareInterfaceFieldTestSnapshot : TestSnapshot() {
+    /**
+     * Query
+     *
+     * ```graphql
+     * query {
+     *   container {
+     *     things {
+     *       id
+     *     }
+     *   }
+     * }
+     * ```
+     *
+     * Variables
+     *
+     * ```json
+     * {}
+     * ```
+     */
+    override val calls: List<ExpectedServiceCall> = listOf(
+            ExpectedServiceCall(
+                service = "data",
+                query = """
+                | {
+                |   container {
+                |     __typename__rename__things: __typename
+                |     rename__things__nodes: nodes {
+                |       ... on Issue {
+                |         id
+                |       }
+                |       ... on Story {
+                |         id
+                |       }
+                |     }
+                |   }
+                | }
+                """.trimMargin(),
+                variables = "{}",
+                result = """
+                | {
+                |   "data": {
+                |     "container": {
+                |       "rename__things__nodes": [
+                |         {
+                |           "id": "ISSUE-1"
+                |         },
+                |         {
+                |           "id": "STORY-1"
+                |         },
+                |         {}
+                |       ],
+                |       "__typename__rename__things": "Container"
+                |     }
+                |   }
+                | }
+                """.trimMargin(),
+                delayedResults = listOfJsonStrings(
+                ),
+            ),
+        )
+
+    /**
+     * ```json
+     * {
+     *   "data": {
+     *     "container": {
+     *       "things": [
+     *         {
+     *           "id": "ISSUE-1"
+     *         },
+     *         {
+     *           "id": "STORY-1"
+     *         },
+     *         {}
+     *       ]
+     *     }
+     *   }
+     * }
+     * ```
+     */
+    override val result: ExpectedNadelResult = ExpectedNadelResult(
+            result = """
+            | {
+            |   "data": {
+            |     "container": {
+            |       "things": [
+            |         {
+            |           "id": "ISSUE-1"
+            |         },
+            |         {
+            |           "id": "STORY-1"
+            |         },
+            |         {}
+            |       ]
+            |     }
+            |   }
+            | }
+            """.trimMargin(),
+            delayedResults = listOfJsonStrings(
+            ),
+        )
+}

--- a/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/execution/interfaceexpansion/renames/RenamedAncestorBareTypenameTestSnapshot.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/execution/interfaceexpansion/renames/RenamedAncestorBareTypenameTestSnapshot.kt
@@ -1,0 +1,124 @@
+// @formatter:off
+package graphql.nadel.tests.next.fixtures.execution.interfaceexpansion.renames
+
+import graphql.nadel.tests.next.ExpectedNadelResult
+import graphql.nadel.tests.next.ExpectedServiceCall
+import graphql.nadel.tests.next.TestSnapshot
+import graphql.nadel.tests.next.listOfJsonStrings
+import kotlin.Suppress
+import kotlin.collections.List
+import kotlin.collections.listOf
+
+private suspend fun main() {
+    graphql.nadel.tests.next.update<RenamedAncestorBareTypenameTest>()
+}
+
+/**
+ * This class is generated. Do NOT modify.
+ *
+ * Refer to [graphql.nadel.tests.next.UpdateTestSnapshots]
+ */
+@Suppress("unused")
+public class RenamedAncestorBareTypenameTestSnapshot : TestSnapshot() {
+    /**
+     * Query
+     *
+     * ```graphql
+     * query {
+     *   container {
+     *     things {
+     *       __typename
+     *     }
+     *   }
+     * }
+     * ```
+     *
+     * Variables
+     *
+     * ```json
+     * {}
+     * ```
+     */
+    override val calls: List<ExpectedServiceCall> = listOf(
+            ExpectedServiceCall(
+                service = "data",
+                query = """
+                | {
+                |   container {
+                |     __typename__rename__things: __typename
+                |     rename__things__nodes: nodes {
+                |       ... on Issue {
+                |         __typename
+                |       }
+                |       ... on Story {
+                |         __typename
+                |       }
+                |     }
+                |   }
+                | }
+                """.trimMargin(),
+                variables = "{}",
+                result = """
+                | {
+                |   "data": {
+                |     "container": {
+                |       "rename__things__nodes": [
+                |         {
+                |           "__typename": "Issue"
+                |         },
+                |         {
+                |           "__typename": "Story"
+                |         },
+                |         {}
+                |       ],
+                |       "__typename__rename__things": "Container"
+                |     }
+                |   }
+                | }
+                """.trimMargin(),
+                delayedResults = listOfJsonStrings(
+                ),
+            ),
+        )
+
+    /**
+     * ```json
+     * {
+     *   "data": {
+     *     "container": {
+     *       "things": [
+     *         {
+     *           "__typename": "Issue"
+     *         },
+     *         {
+     *           "__typename": "Story"
+     *         },
+     *         {}
+     *       ]
+     *     }
+     *   }
+     * }
+     * ```
+     */
+    override val result: ExpectedNadelResult = ExpectedNadelResult(
+            result = """
+            | {
+            |   "data": {
+            |     "container": {
+            |       "things": [
+            |         {
+            |           "__typename": "Issue"
+            |         },
+            |         {
+            |           "__typename": "Story"
+            |         },
+            |         {}
+            |       ]
+            |     }
+            |   }
+            | }
+            """.trimMargin(),
+            delayedResults = listOfJsonStrings(
+            ),
+        )
+}

--- a/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/execution/interfaceexpansion/renames/RenamedAncestorRelaxedBareInterfaceFieldTestSnapshot.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/execution/interfaceexpansion/renames/RenamedAncestorRelaxedBareInterfaceFieldTestSnapshot.kt
@@ -1,0 +1,125 @@
+// @formatter:off
+package graphql.nadel.tests.next.fixtures.execution.interfaceexpansion.renames
+
+import graphql.nadel.tests.next.ExpectedNadelResult
+import graphql.nadel.tests.next.ExpectedServiceCall
+import graphql.nadel.tests.next.TestSnapshot
+import graphql.nadel.tests.next.listOfJsonStrings
+import kotlin.Suppress
+import kotlin.collections.List
+import kotlin.collections.listOf
+
+private suspend fun main() {
+    graphql.nadel.tests.next.update<RenamedAncestorRelaxedBareInterfaceFieldTest>()
+}
+
+/**
+ * This class is generated. Do NOT modify.
+ *
+ * Refer to [graphql.nadel.tests.next.UpdateTestSnapshots]
+ */
+@Suppress("unused")
+public class RenamedAncestorRelaxedBareInterfaceFieldTestSnapshot : TestSnapshot() {
+    /**
+     * Query
+     *
+     * ```graphql
+     * query {
+     *   container {
+     *     things {
+     *       id
+     *     }
+     *   }
+     * }
+     * ```
+     *
+     * Variables
+     *
+     * ```json
+     * {}
+     * ```
+     */
+    override val calls: List<ExpectedServiceCall> = listOf(
+            ExpectedServiceCall(
+                service = "data",
+                query = """
+                | {
+                |   container {
+                |     __typename__rename__things: __typename
+                |     rename__things__nodes: nodes {
+                |       __typename__abstract_member__things: __typename
+                |       id
+                |     }
+                |   }
+                | }
+                """.trimMargin(),
+                variables = "{}",
+                result = """
+                | {
+                |   "data": {
+                |     "container": {
+                |       "rename__things__nodes": [
+                |         {
+                |           "id": "ISSUE-1",
+                |           "__typename__abstract_member__things": "Issue"
+                |         },
+                |         {
+                |           "id": "STORY-1",
+                |           "__typename__abstract_member__things": "Story"
+                |         },
+                |         {
+                |           "id": "SECRET-1",
+                |           "__typename__abstract_member__things": "Secret"
+                |         }
+                |       ],
+                |       "__typename__rename__things": "Container"
+                |     }
+                |   }
+                | }
+                """.trimMargin(),
+                delayedResults = listOfJsonStrings(
+                ),
+            ),
+        )
+
+    /**
+     * ```json
+     * {
+     *   "data": {
+     *     "container": {
+     *       "things": [
+     *         {
+     *           "id": "ISSUE-1"
+     *         },
+     *         {
+     *           "id": "STORY-1"
+     *         },
+     *         {}
+     *       ]
+     *     }
+     *   }
+     * }
+     * ```
+     */
+    override val result: ExpectedNadelResult = ExpectedNadelResult(
+            result = """
+            | {
+            |   "data": {
+            |     "container": {
+            |       "things": [
+            |         {
+            |           "id": "ISSUE-1"
+            |         },
+            |         {
+            |           "id": "STORY-1"
+            |         },
+            |         {}
+            |       ]
+            |     }
+            |   }
+            | }
+            """.trimMargin(),
+            delayedResults = listOfJsonStrings(
+            ),
+        )
+}

--- a/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/execution/interfaceexpansion/renames/RenamedAncestorRelaxedBareTypenameTestSnapshot.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/execution/interfaceexpansion/renames/RenamedAncestorRelaxedBareTypenameTestSnapshot.kt
@@ -1,0 +1,125 @@
+// @formatter:off
+package graphql.nadel.tests.next.fixtures.execution.interfaceexpansion.renames
+
+import graphql.nadel.tests.next.ExpectedNadelResult
+import graphql.nadel.tests.next.ExpectedServiceCall
+import graphql.nadel.tests.next.TestSnapshot
+import graphql.nadel.tests.next.listOfJsonStrings
+import kotlin.Suppress
+import kotlin.collections.List
+import kotlin.collections.listOf
+
+private suspend fun main() {
+    graphql.nadel.tests.next.update<RenamedAncestorRelaxedBareTypenameTest>()
+}
+
+/**
+ * This class is generated. Do NOT modify.
+ *
+ * Refer to [graphql.nadel.tests.next.UpdateTestSnapshots]
+ */
+@Suppress("unused")
+public class RenamedAncestorRelaxedBareTypenameTestSnapshot : TestSnapshot() {
+    /**
+     * Query
+     *
+     * ```graphql
+     * query {
+     *   container {
+     *     things {
+     *       __typename
+     *     }
+     *   }
+     * }
+     * ```
+     *
+     * Variables
+     *
+     * ```json
+     * {}
+     * ```
+     */
+    override val calls: List<ExpectedServiceCall> = listOf(
+            ExpectedServiceCall(
+                service = "data",
+                query = """
+                | {
+                |   container {
+                |     __typename__rename__things: __typename
+                |     rename__things__nodes: nodes {
+                |       __typename
+                |       __typename__abstract_member__things: __typename
+                |     }
+                |   }
+                | }
+                """.trimMargin(),
+                variables = "{}",
+                result = """
+                | {
+                |   "data": {
+                |     "container": {
+                |       "rename__things__nodes": [
+                |         {
+                |           "__typename": "Issue",
+                |           "__typename__abstract_member__things": "Issue"
+                |         },
+                |         {
+                |           "__typename": "Story",
+                |           "__typename__abstract_member__things": "Story"
+                |         },
+                |         {
+                |           "__typename": "Secret",
+                |           "__typename__abstract_member__things": "Secret"
+                |         }
+                |       ],
+                |       "__typename__rename__things": "Container"
+                |     }
+                |   }
+                | }
+                """.trimMargin(),
+                delayedResults = listOfJsonStrings(
+                ),
+            ),
+        )
+
+    /**
+     * ```json
+     * {
+     *   "data": {
+     *     "container": {
+     *       "things": [
+     *         {
+     *           "__typename": "Issue"
+     *         },
+     *         {
+     *           "__typename": "Story"
+     *         },
+     *         {}
+     *       ]
+     *     }
+     *   }
+     * }
+     * ```
+     */
+    override val result: ExpectedNadelResult = ExpectedNadelResult(
+            result = """
+            | {
+            |   "data": {
+            |     "container": {
+            |       "things": [
+            |         {
+            |           "__typename": "Issue"
+            |         },
+            |         {
+            |           "__typename": "Story"
+            |         },
+            |         {}
+            |       ]
+            |     }
+            |   }
+            | }
+            """.trimMargin(),
+            delayedResults = listOfJsonStrings(
+            ),
+        )
+}

--- a/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/execution/interfaceexpansion/renames/RenamedAncestorRelaxedTest.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/execution/interfaceexpansion/renames/RenamedAncestorRelaxedTest.kt
@@ -1,0 +1,41 @@
+package graphql.nadel.tests.next.fixtures.execution.interfaceexpansion.renames
+
+import graphql.nadel.NadelExecutionHints
+
+/**
+ * The renamed-ancestor scenario with the hint ON: same schema + queries as [RenamedAncestorTestBase], hint
+ * flipped. Confirms the field is emitted bare even though a renamed ancestor makes its overall and underlying
+ * query paths differ, and the underlying-only `Secret` is stripped to `{}`.
+ */
+
+class RenamedAncestorRelaxedBareInterfaceFieldTest : RenamedAncestorTestBase(
+    query = """
+        query {
+          container {
+            things {
+              id
+            }
+          }
+        }
+    """.trimIndent(),
+) {
+    override fun makeExecutionHints(): NadelExecutionHints.Builder {
+        return super.makeExecutionHints().noInterfaceToObjectFragmentExpansion { _ -> true }
+    }
+}
+
+class RenamedAncestorRelaxedBareTypenameTest : RenamedAncestorTestBase(
+    query = """
+        query {
+          container {
+            things {
+              __typename
+            }
+          }
+        }
+    """.trimIndent(),
+) {
+    override fun makeExecutionHints(): NadelExecutionHints.Builder {
+        return super.makeExecutionHints().noInterfaceToObjectFragmentExpansion { _ -> true }
+    }
+}

--- a/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/execution/interfaceexpansion/renames/RenamedAncestorTest.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/execution/interfaceexpansion/renames/RenamedAncestorTest.kt
@@ -1,0 +1,107 @@
+package graphql.nadel.tests.next.fixtures.execution.interfaceexpansion.renames
+
+import graphql.nadel.tests.next.NadelIntegrationTest
+import org.intellij.lang.annotations.Language
+
+/**
+ * The relaxable interface selection sits UNDER a renamed ancestor: `Container.things` is renamed from the
+ * underlying `nodes`. Renames emit an artificial alias for the ancestor downstream, so the relaxed field's
+ * overall query path differs from its underlying query path. This is the case a query-path-keyed bare signal
+ * would silently miss; the identity-keyed signal must still emit the field bare. `Node` has a hidden
+ * underlying-only impl (`Secret`) so relaxation applies.
+ */
+abstract class RenamedAncestorTestBase(
+    @Language("GraphQL") query: String,
+) : NadelIntegrationTest(
+    query = query,
+    services = listOf(
+        Service(
+            name = "data",
+            overallSchema = """
+                type Query {
+                  container: Container
+                }
+                type Container {
+                  things: [Node] @renamed(from: "nodes")
+                }
+                interface Node {
+                  id: ID
+                }
+                type Issue implements Node {
+                  id: ID
+                }
+                type Story implements Node {
+                  id: ID
+                }
+            """.trimIndent(),
+            underlyingSchema = """
+                type Query {
+                  container: Container
+                }
+                type Container {
+                  nodes: [Node]
+                }
+                interface Node {
+                  id: ID
+                }
+                type Issue implements Node {
+                  id: ID
+                }
+                type Story implements Node {
+                  id: ID
+                }
+                type Secret implements Node {
+                  id: ID
+                }
+            """.trimIndent(),
+            runtimeWiring = { wiring ->
+                data class Issue(val id: String)
+                data class Story(val id: String)
+                data class Secret(val id: String)
+
+                wiring
+                    .type("Node") { type ->
+                        type.typeResolver { env ->
+                            env.schema.getObjectType(env.getObject<Any>().javaClass.simpleName)
+                        }
+                    }
+                    .type("Container") { type ->
+                        type.dataFetcher("nodes") { _ ->
+                            listOf(
+                                Issue(id = "ISSUE-1"),
+                                Story(id = "STORY-1"),
+                                Secret(id = "SECRET-1"),
+                            )
+                        }
+                    }
+                    .type("Query") { type ->
+                        type.dataFetcher("container") { _ -> Any() }
+                    }
+            },
+        ),
+    ),
+)
+
+class RenamedAncestorBareInterfaceFieldTest : RenamedAncestorTestBase(
+    query = """
+        query {
+          container {
+            things {
+              id
+            }
+          }
+        }
+    """.trimIndent(),
+)
+
+class RenamedAncestorBareTypenameTest : RenamedAncestorTestBase(
+    query = """
+        query {
+          container {
+            things {
+              __typename
+            }
+          }
+        }
+    """.trimIndent(),
+)

--- a/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/execution/interfaceexpansion/renames/RenamedHiddenImplBareInterfaceFieldTestSnapshot.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/execution/interfaceexpansion/renames/RenamedHiddenImplBareInterfaceFieldTestSnapshot.kt
@@ -1,0 +1,112 @@
+// @formatter:off
+package graphql.nadel.tests.next.fixtures.execution.interfaceexpansion.renames
+
+import graphql.nadel.tests.next.ExpectedNadelResult
+import graphql.nadel.tests.next.ExpectedServiceCall
+import graphql.nadel.tests.next.TestSnapshot
+import graphql.nadel.tests.next.listOfJsonStrings
+import kotlin.Suppress
+import kotlin.collections.List
+import kotlin.collections.listOf
+
+private suspend fun main() {
+    graphql.nadel.tests.next.update<RenamedHiddenImplBareInterfaceFieldTest>()
+}
+
+/**
+ * This class is generated. Do NOT modify.
+ *
+ * Refer to [graphql.nadel.tests.next.UpdateTestSnapshots]
+ */
+@Suppress("unused")
+public class RenamedHiddenImplBareInterfaceFieldTestSnapshot : TestSnapshot() {
+    /**
+     * Query
+     *
+     * ```graphql
+     * query {
+     *   nodes {
+     *     id
+     *   }
+     * }
+     * ```
+     *
+     * Variables
+     *
+     * ```json
+     * {}
+     * ```
+     */
+    override val calls: List<ExpectedServiceCall> = listOf(
+            ExpectedServiceCall(
+                service = "data",
+                query = """
+                | {
+                |   nodes {
+                |     ... on Issue {
+                |       id
+                |     }
+                |     ... on Story {
+                |       id
+                |     }
+                |   }
+                | }
+                """.trimMargin(),
+                variables = "{}",
+                result = """
+                | {
+                |   "data": {
+                |     "nodes": [
+                |       {
+                |         "id": "ISSUE-1"
+                |       },
+                |       {
+                |         "id": "STORY-1"
+                |       },
+                |       {}
+                |     ]
+                |   }
+                | }
+                """.trimMargin(),
+                delayedResults = listOfJsonStrings(
+                ),
+            ),
+        )
+
+    /**
+     * ```json
+     * {
+     *   "data": {
+     *     "nodes": [
+     *       {
+     *         "id": "ISSUE-1"
+     *       },
+     *       {
+     *         "id": "STORY-1"
+     *       },
+     *       {}
+     *     ]
+     *   }
+     * }
+     * ```
+     */
+    override val result: ExpectedNadelResult = ExpectedNadelResult(
+            result = """
+            | {
+            |   "data": {
+            |     "nodes": [
+            |       {
+            |         "id": "ISSUE-1"
+            |       },
+            |       {
+            |         "id": "STORY-1"
+            |       },
+            |       {}
+            |     ]
+            |   }
+            | }
+            """.trimMargin(),
+            delayedResults = listOfJsonStrings(
+            ),
+        )
+}

--- a/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/execution/interfaceexpansion/renames/RenamedHiddenImplBareTypenameTestSnapshot.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/execution/interfaceexpansion/renames/RenamedHiddenImplBareTypenameTestSnapshot.kt
@@ -1,0 +1,112 @@
+// @formatter:off
+package graphql.nadel.tests.next.fixtures.execution.interfaceexpansion.renames
+
+import graphql.nadel.tests.next.ExpectedNadelResult
+import graphql.nadel.tests.next.ExpectedServiceCall
+import graphql.nadel.tests.next.TestSnapshot
+import graphql.nadel.tests.next.listOfJsonStrings
+import kotlin.Suppress
+import kotlin.collections.List
+import kotlin.collections.listOf
+
+private suspend fun main() {
+    graphql.nadel.tests.next.update<RenamedHiddenImplBareTypenameTest>()
+}
+
+/**
+ * This class is generated. Do NOT modify.
+ *
+ * Refer to [graphql.nadel.tests.next.UpdateTestSnapshots]
+ */
+@Suppress("unused")
+public class RenamedHiddenImplBareTypenameTestSnapshot : TestSnapshot() {
+    /**
+     * Query
+     *
+     * ```graphql
+     * query {
+     *   nodes {
+     *     __typename
+     *   }
+     * }
+     * ```
+     *
+     * Variables
+     *
+     * ```json
+     * {}
+     * ```
+     */
+    override val calls: List<ExpectedServiceCall> = listOf(
+            ExpectedServiceCall(
+                service = "data",
+                query = """
+                | {
+                |   nodes {
+                |     ... on Issue {
+                |       __typename
+                |     }
+                |     ... on Story {
+                |       __typename
+                |     }
+                |   }
+                | }
+                """.trimMargin(),
+                variables = "{}",
+                result = """
+                | {
+                |   "data": {
+                |     "nodes": [
+                |       {
+                |         "__typename": "Issue"
+                |       },
+                |       {
+                |         "__typename": "Story"
+                |       },
+                |       {}
+                |     ]
+                |   }
+                | }
+                """.trimMargin(),
+                delayedResults = listOfJsonStrings(
+                ),
+            ),
+        )
+
+    /**
+     * ```json
+     * {
+     *   "data": {
+     *     "nodes": [
+     *       {
+     *         "__typename": "JiraIssue"
+     *       },
+     *       {
+     *         "__typename": "Story"
+     *       },
+     *       {}
+     *     ]
+     *   }
+     * }
+     * ```
+     */
+    override val result: ExpectedNadelResult = ExpectedNadelResult(
+            result = """
+            | {
+            |   "data": {
+            |     "nodes": [
+            |       {
+            |         "__typename": "JiraIssue"
+            |       },
+            |       {
+            |         "__typename": "Story"
+            |       },
+            |       {}
+            |     ]
+            |   }
+            | }
+            """.trimMargin(),
+            delayedResults = listOfJsonStrings(
+            ),
+        )
+}

--- a/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/execution/interfaceexpansion/renames/RenamedHiddenImplRelaxedBareInterfaceFieldTestSnapshot.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/execution/interfaceexpansion/renames/RenamedHiddenImplRelaxedBareInterfaceFieldTestSnapshot.kt
@@ -1,0 +1,113 @@
+// @formatter:off
+package graphql.nadel.tests.next.fixtures.execution.interfaceexpansion.renames
+
+import graphql.nadel.tests.next.ExpectedNadelResult
+import graphql.nadel.tests.next.ExpectedServiceCall
+import graphql.nadel.tests.next.TestSnapshot
+import graphql.nadel.tests.next.listOfJsonStrings
+import kotlin.Suppress
+import kotlin.collections.List
+import kotlin.collections.listOf
+
+private suspend fun main() {
+    graphql.nadel.tests.next.update<RenamedHiddenImplRelaxedBareInterfaceFieldTest>()
+}
+
+/**
+ * This class is generated. Do NOT modify.
+ *
+ * Refer to [graphql.nadel.tests.next.UpdateTestSnapshots]
+ */
+@Suppress("unused")
+public class RenamedHiddenImplRelaxedBareInterfaceFieldTestSnapshot : TestSnapshot() {
+    /**
+     * Query
+     *
+     * ```graphql
+     * query {
+     *   nodes {
+     *     id
+     *   }
+     * }
+     * ```
+     *
+     * Variables
+     *
+     * ```json
+     * {}
+     * ```
+     */
+    override val calls: List<ExpectedServiceCall> = listOf(
+            ExpectedServiceCall(
+                service = "data",
+                query = """
+                | {
+                |   nodes {
+                |     __typename__abstract_member__nodes: __typename
+                |     id
+                |   }
+                | }
+                """.trimMargin(),
+                variables = "{}",
+                result = """
+                | {
+                |   "data": {
+                |     "nodes": [
+                |       {
+                |         "id": "ISSUE-1",
+                |         "__typename__abstract_member__nodes": "Issue"
+                |       },
+                |       {
+                |         "id": "STORY-1",
+                |         "__typename__abstract_member__nodes": "Story"
+                |       },
+                |       {
+                |         "id": "SECRET-1",
+                |         "__typename__abstract_member__nodes": "Secret"
+                |       }
+                |     ]
+                |   }
+                | }
+                """.trimMargin(),
+                delayedResults = listOfJsonStrings(
+                ),
+            ),
+        )
+
+    /**
+     * ```json
+     * {
+     *   "data": {
+     *     "nodes": [
+     *       {
+     *         "id": "ISSUE-1"
+     *       },
+     *       {
+     *         "id": "STORY-1"
+     *       },
+     *       {}
+     *     ]
+     *   }
+     * }
+     * ```
+     */
+    override val result: ExpectedNadelResult = ExpectedNadelResult(
+            result = """
+            | {
+            |   "data": {
+            |     "nodes": [
+            |       {
+            |         "id": "ISSUE-1"
+            |       },
+            |       {
+            |         "id": "STORY-1"
+            |       },
+            |       {}
+            |     ]
+            |   }
+            | }
+            """.trimMargin(),
+            delayedResults = listOfJsonStrings(
+            ),
+        )
+}

--- a/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/execution/interfaceexpansion/renames/RenamedHiddenImplRelaxedBareTypenameTestSnapshot.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/execution/interfaceexpansion/renames/RenamedHiddenImplRelaxedBareTypenameTestSnapshot.kt
@@ -1,0 +1,113 @@
+// @formatter:off
+package graphql.nadel.tests.next.fixtures.execution.interfaceexpansion.renames
+
+import graphql.nadel.tests.next.ExpectedNadelResult
+import graphql.nadel.tests.next.ExpectedServiceCall
+import graphql.nadel.tests.next.TestSnapshot
+import graphql.nadel.tests.next.listOfJsonStrings
+import kotlin.Suppress
+import kotlin.collections.List
+import kotlin.collections.listOf
+
+private suspend fun main() {
+    graphql.nadel.tests.next.update<RenamedHiddenImplRelaxedBareTypenameTest>()
+}
+
+/**
+ * This class is generated. Do NOT modify.
+ *
+ * Refer to [graphql.nadel.tests.next.UpdateTestSnapshots]
+ */
+@Suppress("unused")
+public class RenamedHiddenImplRelaxedBareTypenameTestSnapshot : TestSnapshot() {
+    /**
+     * Query
+     *
+     * ```graphql
+     * query {
+     *   nodes {
+     *     __typename
+     *   }
+     * }
+     * ```
+     *
+     * Variables
+     *
+     * ```json
+     * {}
+     * ```
+     */
+    override val calls: List<ExpectedServiceCall> = listOf(
+            ExpectedServiceCall(
+                service = "data",
+                query = """
+                | {
+                |   nodes {
+                |     __typename
+                |     __typename__abstract_member__nodes: __typename
+                |   }
+                | }
+                """.trimMargin(),
+                variables = "{}",
+                result = """
+                | {
+                |   "data": {
+                |     "nodes": [
+                |       {
+                |         "__typename": "Issue",
+                |         "__typename__abstract_member__nodes": "Issue"
+                |       },
+                |       {
+                |         "__typename": "Story",
+                |         "__typename__abstract_member__nodes": "Story"
+                |       },
+                |       {
+                |         "__typename": "Secret",
+                |         "__typename__abstract_member__nodes": "Secret"
+                |       }
+                |     ]
+                |   }
+                | }
+                """.trimMargin(),
+                delayedResults = listOfJsonStrings(
+                ),
+            ),
+        )
+
+    /**
+     * ```json
+     * {
+     *   "data": {
+     *     "nodes": [
+     *       {
+     *         "__typename": "JiraIssue"
+     *       },
+     *       {
+     *         "__typename": "Story"
+     *       },
+     *       {}
+     *     ]
+     *   }
+     * }
+     * ```
+     */
+    override val result: ExpectedNadelResult = ExpectedNadelResult(
+            result = """
+            | {
+            |   "data": {
+            |     "nodes": [
+            |       {
+            |         "__typename": "JiraIssue"
+            |       },
+            |       {
+            |         "__typename": "Story"
+            |       },
+            |       {}
+            |     ]
+            |   }
+            | }
+            """.trimMargin(),
+            delayedResults = listOfJsonStrings(
+            ),
+        )
+}

--- a/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/execution/interfaceexpansion/renames/RenamedHiddenImplRelaxedTest.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/execution/interfaceexpansion/renames/RenamedHiddenImplRelaxedTest.kt
@@ -1,0 +1,37 @@
+package graphql.nadel.tests.next.fixtures.execution.interfaceexpansion.renames
+
+import graphql.nadel.NadelExecutionHints
+
+/**
+ * The renamed-impl scenario with the hint ON: same schema + queries as [RenamedHiddenImplTestBase], hint flipped.
+ * The selection goes bare downstream; the underlying-only `Secret` is stripped to `{}`, and the exposed
+ * `Issue` node comes back as the overall type name `JiraIssue`.
+ */
+
+class RenamedHiddenImplRelaxedBareInterfaceFieldTest : RenamedHiddenImplTestBase(
+    query = """
+        query {
+          nodes {
+            id
+          }
+        }
+    """.trimIndent(),
+) {
+    override fun makeExecutionHints(): NadelExecutionHints.Builder {
+        return super.makeExecutionHints().noInterfaceToObjectFragmentExpansion { _ -> true }
+    }
+}
+
+class RenamedHiddenImplRelaxedBareTypenameTest : RenamedHiddenImplTestBase(
+    query = """
+        query {
+          nodes {
+            __typename
+          }
+        }
+    """.trimIndent(),
+) {
+    override fun makeExecutionHints(): NadelExecutionHints.Builder {
+        return super.makeExecutionHints().noInterfaceToObjectFragmentExpansion { _ -> true }
+    }
+}

--- a/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/execution/interfaceexpansion/renames/RenamedHiddenImplTest.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/execution/interfaceexpansion/renames/RenamedHiddenImplTest.kt
@@ -1,0 +1,96 @@
+package graphql.nadel.tests.next.fixtures.execution.interfaceexpansion.renames
+
+import graphql.nadel.tests.next.NadelIntegrationTest
+import org.intellij.lang.annotations.Language
+
+/**
+ * Relaxation combined with a RENAMED exposed implementation. `Node` is implemented overall by `JiraIssue`
+ * (renamed from underlying `Issue`) and `Story`; the underlying schema additionally has `Secret`, which is not
+ * exposed. So a bare `Node` selection resolves to `{JiraIssue, Story}`, a strict subset of the underlying
+ * `{Issue, Story, Secret}` - the hiding condition - while an exposed member is also type-renamed. The other
+ * interfaceexpansion fixtures use only plain (un-renamed) types; this exercises the underlying<->overall type
+ * mapping on both the query side (bare emission) and the result side (hiding + the `__typename` the client
+ * gets back is the overall name `JiraIssue`).
+ */
+abstract class RenamedHiddenImplTestBase(
+    @Language("GraphQL") query: String,
+) : NadelIntegrationTest(
+    query = query,
+    services = listOf(
+        Service(
+            name = "data",
+            overallSchema = """
+                type Query {
+                  nodes: [Node]
+                }
+                interface Node {
+                  id: ID
+                }
+                type JiraIssue implements Node @renamed(from: "Issue") {
+                  id: ID
+                }
+                type Story implements Node {
+                  id: ID
+                }
+            """.trimIndent(),
+            underlyingSchema = """
+                type Query {
+                  nodes: [Node]
+                }
+                interface Node {
+                  id: ID
+                }
+                type Issue implements Node {
+                  id: ID
+                }
+                type Story implements Node {
+                  id: ID
+                }
+                type Secret implements Node {
+                  id: ID
+                }
+            """.trimIndent(),
+            runtimeWiring = { wiring ->
+                data class Issue(val id: String)
+                data class Story(val id: String)
+                data class Secret(val id: String)
+
+                wiring
+                    .type("Node") { type ->
+                        type.typeResolver { env ->
+                            env.schema.getObjectType(env.getObject<Any>().javaClass.simpleName)
+                        }
+                    }
+                    .type("Query") { type ->
+                        type.dataFetcher("nodes") { _ ->
+                            listOf(
+                                Issue(id = "ISSUE-1"),
+                                Story(id = "STORY-1"),
+                                Secret(id = "SECRET-1"),
+                            )
+                        }
+                    }
+            },
+        ),
+    ),
+)
+
+class RenamedHiddenImplBareInterfaceFieldTest : RenamedHiddenImplTestBase(
+    query = """
+        query {
+          nodes {
+            id
+          }
+        }
+    """.trimIndent(),
+)
+
+class RenamedHiddenImplBareTypenameTest : RenamedHiddenImplTestBase(
+    query = """
+        query {
+          nodes {
+            __typename
+          }
+        }
+    """.trimIndent(),
+)

--- a/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/execution/interfaceexpansion/underlyingonly/UnderlyingOnlyImplBareInterfaceFieldTestSnapshot.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/execution/interfaceexpansion/underlyingonly/UnderlyingOnlyImplBareInterfaceFieldTestSnapshot.kt
@@ -1,0 +1,112 @@
+// @formatter:off
+package graphql.nadel.tests.next.fixtures.execution.interfaceexpansion.underlyingonly
+
+import graphql.nadel.tests.next.ExpectedNadelResult
+import graphql.nadel.tests.next.ExpectedServiceCall
+import graphql.nadel.tests.next.TestSnapshot
+import graphql.nadel.tests.next.listOfJsonStrings
+import kotlin.Suppress
+import kotlin.collections.List
+import kotlin.collections.listOf
+
+private suspend fun main() {
+    graphql.nadel.tests.next.update<UnderlyingOnlyImplBareInterfaceFieldTest>()
+}
+
+/**
+ * This class is generated. Do NOT modify.
+ *
+ * Refer to [graphql.nadel.tests.next.UpdateTestSnapshots]
+ */
+@Suppress("unused")
+public class UnderlyingOnlyImplBareInterfaceFieldTestSnapshot : TestSnapshot() {
+    /**
+     * Query
+     *
+     * ```graphql
+     * query {
+     *   nodes {
+     *     id
+     *   }
+     * }
+     * ```
+     *
+     * Variables
+     *
+     * ```json
+     * {}
+     * ```
+     */
+    override val calls: List<ExpectedServiceCall> = listOf(
+            ExpectedServiceCall(
+                service = "data",
+                query = """
+                | {
+                |   nodes {
+                |     ... on Issue {
+                |       id
+                |     }
+                |     ... on Story {
+                |       id
+                |     }
+                |   }
+                | }
+                """.trimMargin(),
+                variables = "{}",
+                result = """
+                | {
+                |   "data": {
+                |     "nodes": [
+                |       {
+                |         "id": "ISSUE-1"
+                |       },
+                |       {
+                |         "id": "STORY-1"
+                |       },
+                |       {}
+                |     ]
+                |   }
+                | }
+                """.trimMargin(),
+                delayedResults = listOfJsonStrings(
+                ),
+            ),
+        )
+
+    /**
+     * ```json
+     * {
+     *   "data": {
+     *     "nodes": [
+     *       {
+     *         "id": "ISSUE-1"
+     *       },
+     *       {
+     *         "id": "STORY-1"
+     *       },
+     *       {}
+     *     ]
+     *   }
+     * }
+     * ```
+     */
+    override val result: ExpectedNadelResult = ExpectedNadelResult(
+            result = """
+            | {
+            |   "data": {
+            |     "nodes": [
+            |       {
+            |         "id": "ISSUE-1"
+            |       },
+            |       {
+            |         "id": "STORY-1"
+            |       },
+            |       {}
+            |     ]
+            |   }
+            | }
+            """.trimMargin(),
+            delayedResults = listOfJsonStrings(
+            ),
+        )
+}

--- a/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/execution/interfaceexpansion/underlyingonly/UnderlyingOnlyImplBareTypenameTestSnapshot.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/execution/interfaceexpansion/underlyingonly/UnderlyingOnlyImplBareTypenameTestSnapshot.kt
@@ -1,0 +1,112 @@
+// @formatter:off
+package graphql.nadel.tests.next.fixtures.execution.interfaceexpansion.underlyingonly
+
+import graphql.nadel.tests.next.ExpectedNadelResult
+import graphql.nadel.tests.next.ExpectedServiceCall
+import graphql.nadel.tests.next.TestSnapshot
+import graphql.nadel.tests.next.listOfJsonStrings
+import kotlin.Suppress
+import kotlin.collections.List
+import kotlin.collections.listOf
+
+private suspend fun main() {
+    graphql.nadel.tests.next.update<UnderlyingOnlyImplBareTypenameTest>()
+}
+
+/**
+ * This class is generated. Do NOT modify.
+ *
+ * Refer to [graphql.nadel.tests.next.UpdateTestSnapshots]
+ */
+@Suppress("unused")
+public class UnderlyingOnlyImplBareTypenameTestSnapshot : TestSnapshot() {
+    /**
+     * Query
+     *
+     * ```graphql
+     * query {
+     *   nodes {
+     *     __typename
+     *   }
+     * }
+     * ```
+     *
+     * Variables
+     *
+     * ```json
+     * {}
+     * ```
+     */
+    override val calls: List<ExpectedServiceCall> = listOf(
+            ExpectedServiceCall(
+                service = "data",
+                query = """
+                | {
+                |   nodes {
+                |     ... on Issue {
+                |       __typename
+                |     }
+                |     ... on Story {
+                |       __typename
+                |     }
+                |   }
+                | }
+                """.trimMargin(),
+                variables = "{}",
+                result = """
+                | {
+                |   "data": {
+                |     "nodes": [
+                |       {
+                |         "__typename": "Issue"
+                |       },
+                |       {
+                |         "__typename": "Story"
+                |       },
+                |       {}
+                |     ]
+                |   }
+                | }
+                """.trimMargin(),
+                delayedResults = listOfJsonStrings(
+                ),
+            ),
+        )
+
+    /**
+     * ```json
+     * {
+     *   "data": {
+     *     "nodes": [
+     *       {
+     *         "__typename": "Issue"
+     *       },
+     *       {
+     *         "__typename": "Story"
+     *       },
+     *       {}
+     *     ]
+     *   }
+     * }
+     * ```
+     */
+    override val result: ExpectedNadelResult = ExpectedNadelResult(
+            result = """
+            | {
+            |   "data": {
+            |     "nodes": [
+            |       {
+            |         "__typename": "Issue"
+            |       },
+            |       {
+            |         "__typename": "Story"
+            |       },
+            |       {}
+            |     ]
+            |   }
+            | }
+            """.trimMargin(),
+            delayedResults = listOfJsonStrings(
+            ),
+        )
+}

--- a/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/execution/interfaceexpansion/underlyingonly/UnderlyingOnlyImplRelaxedBareInterfaceFieldTestSnapshot.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/execution/interfaceexpansion/underlyingonly/UnderlyingOnlyImplRelaxedBareInterfaceFieldTestSnapshot.kt
@@ -1,0 +1,113 @@
+// @formatter:off
+package graphql.nadel.tests.next.fixtures.execution.interfaceexpansion.underlyingonly
+
+import graphql.nadel.tests.next.ExpectedNadelResult
+import graphql.nadel.tests.next.ExpectedServiceCall
+import graphql.nadel.tests.next.TestSnapshot
+import graphql.nadel.tests.next.listOfJsonStrings
+import kotlin.Suppress
+import kotlin.collections.List
+import kotlin.collections.listOf
+
+private suspend fun main() {
+    graphql.nadel.tests.next.update<UnderlyingOnlyImplRelaxedBareInterfaceFieldTest>()
+}
+
+/**
+ * This class is generated. Do NOT modify.
+ *
+ * Refer to [graphql.nadel.tests.next.UpdateTestSnapshots]
+ */
+@Suppress("unused")
+public class UnderlyingOnlyImplRelaxedBareInterfaceFieldTestSnapshot : TestSnapshot() {
+    /**
+     * Query
+     *
+     * ```graphql
+     * query {
+     *   nodes {
+     *     id
+     *   }
+     * }
+     * ```
+     *
+     * Variables
+     *
+     * ```json
+     * {}
+     * ```
+     */
+    override val calls: List<ExpectedServiceCall> = listOf(
+            ExpectedServiceCall(
+                service = "data",
+                query = """
+                | {
+                |   nodes {
+                |     __typename__abstract_member__nodes: __typename
+                |     id
+                |   }
+                | }
+                """.trimMargin(),
+                variables = "{}",
+                result = """
+                | {
+                |   "data": {
+                |     "nodes": [
+                |       {
+                |         "id": "ISSUE-1",
+                |         "__typename__abstract_member__nodes": "Issue"
+                |       },
+                |       {
+                |         "id": "STORY-1",
+                |         "__typename__abstract_member__nodes": "Story"
+                |       },
+                |       {
+                |         "id": "SECRET-1",
+                |         "__typename__abstract_member__nodes": "Secret"
+                |       }
+                |     ]
+                |   }
+                | }
+                """.trimMargin(),
+                delayedResults = listOfJsonStrings(
+                ),
+            ),
+        )
+
+    /**
+     * ```json
+     * {
+     *   "data": {
+     *     "nodes": [
+     *       {
+     *         "id": "ISSUE-1"
+     *       },
+     *       {
+     *         "id": "STORY-1"
+     *       },
+     *       {}
+     *     ]
+     *   }
+     * }
+     * ```
+     */
+    override val result: ExpectedNadelResult = ExpectedNadelResult(
+            result = """
+            | {
+            |   "data": {
+            |     "nodes": [
+            |       {
+            |         "id": "ISSUE-1"
+            |       },
+            |       {
+            |         "id": "STORY-1"
+            |       },
+            |       {}
+            |     ]
+            |   }
+            | }
+            """.trimMargin(),
+            delayedResults = listOfJsonStrings(
+            ),
+        )
+}

--- a/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/execution/interfaceexpansion/underlyingonly/UnderlyingOnlyImplRelaxedBareTypenameTestSnapshot.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/execution/interfaceexpansion/underlyingonly/UnderlyingOnlyImplRelaxedBareTypenameTestSnapshot.kt
@@ -1,0 +1,113 @@
+// @formatter:off
+package graphql.nadel.tests.next.fixtures.execution.interfaceexpansion.underlyingonly
+
+import graphql.nadel.tests.next.ExpectedNadelResult
+import graphql.nadel.tests.next.ExpectedServiceCall
+import graphql.nadel.tests.next.TestSnapshot
+import graphql.nadel.tests.next.listOfJsonStrings
+import kotlin.Suppress
+import kotlin.collections.List
+import kotlin.collections.listOf
+
+private suspend fun main() {
+    graphql.nadel.tests.next.update<UnderlyingOnlyImplRelaxedBareTypenameTest>()
+}
+
+/**
+ * This class is generated. Do NOT modify.
+ *
+ * Refer to [graphql.nadel.tests.next.UpdateTestSnapshots]
+ */
+@Suppress("unused")
+public class UnderlyingOnlyImplRelaxedBareTypenameTestSnapshot : TestSnapshot() {
+    /**
+     * Query
+     *
+     * ```graphql
+     * query {
+     *   nodes {
+     *     __typename
+     *   }
+     * }
+     * ```
+     *
+     * Variables
+     *
+     * ```json
+     * {}
+     * ```
+     */
+    override val calls: List<ExpectedServiceCall> = listOf(
+            ExpectedServiceCall(
+                service = "data",
+                query = """
+                | {
+                |   nodes {
+                |     __typename
+                |     __typename__abstract_member__nodes: __typename
+                |   }
+                | }
+                """.trimMargin(),
+                variables = "{}",
+                result = """
+                | {
+                |   "data": {
+                |     "nodes": [
+                |       {
+                |         "__typename": "Issue",
+                |         "__typename__abstract_member__nodes": "Issue"
+                |       },
+                |       {
+                |         "__typename": "Story",
+                |         "__typename__abstract_member__nodes": "Story"
+                |       },
+                |       {
+                |         "__typename": "Secret",
+                |         "__typename__abstract_member__nodes": "Secret"
+                |       }
+                |     ]
+                |   }
+                | }
+                """.trimMargin(),
+                delayedResults = listOfJsonStrings(
+                ),
+            ),
+        )
+
+    /**
+     * ```json
+     * {
+     *   "data": {
+     *     "nodes": [
+     *       {
+     *         "__typename": "Issue"
+     *       },
+     *       {
+     *         "__typename": "Story"
+     *       },
+     *       {}
+     *     ]
+     *   }
+     * }
+     * ```
+     */
+    override val result: ExpectedNadelResult = ExpectedNadelResult(
+            result = """
+            | {
+            |   "data": {
+            |     "nodes": [
+            |       {
+            |         "__typename": "Issue"
+            |       },
+            |       {
+            |         "__typename": "Story"
+            |       },
+            |       {}
+            |     ]
+            |   }
+            | }
+            """.trimMargin(),
+            delayedResults = listOfJsonStrings(
+            ),
+        )
+}

--- a/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/execution/interfaceexpansion/underlyingonly/UnderlyingOnlyImplRelaxedTest.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/execution/interfaceexpansion/underlyingonly/UnderlyingOnlyImplRelaxedTest.kt
@@ -1,0 +1,37 @@
+package graphql.nadel.tests.next.fixtures.execution.interfaceexpansion.underlyingonly
+
+import graphql.nadel.NadelExecutionHints
+
+/**
+ * The underlyingonly scenario with the hint ON: same schema + queries as [UnderlyingOnlyImplementationTestBase],
+ * only the hint flipped.
+ */
+
+/** The fix: `nodes { id }` goes bare downstream; the underlying-only `Secret` is stripped to `{}`. */
+class UnderlyingOnlyImplRelaxedBareInterfaceFieldTest : UnderlyingOnlyImplementationTestBase(
+    query = """
+        query {
+          nodes {
+            id
+          }
+        }
+    """.trimIndent(),
+) {
+    override fun makeExecutionHints(): NadelExecutionHints.Builder {
+        return super.makeExecutionHints().noInterfaceToObjectFragmentExpansion { _ -> true }
+    }
+}
+
+class UnderlyingOnlyImplRelaxedBareTypenameTest : UnderlyingOnlyImplementationTestBase(
+    query = """
+        query {
+          nodes {
+            __typename
+          }
+        }
+    """.trimIndent(),
+) {
+    override fun makeExecutionHints(): NadelExecutionHints.Builder {
+        return super.makeExecutionHints().noInterfaceToObjectFragmentExpansion { _ -> true }
+    }
+}

--- a/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/execution/interfaceexpansion/underlyingonly/UnderlyingOnlyImplementationTest.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/execution/interfaceexpansion/underlyingonly/UnderlyingOnlyImplementationTest.kt
@@ -1,0 +1,97 @@
+package graphql.nadel.tests.next.fixtures.execution.interfaceexpansion.underlyingonly
+
+import graphql.nadel.tests.next.NadelIntegrationTest
+import org.intellij.lang.annotations.Language
+
+/**
+ * Like hiddenmembership, but `Secret` implements `Node` only in the underlying schema and is absent from the
+ * overall schema entirely — the strongest form of hiding. The underlying `nodes` resolver returns a `Secret`,
+ * so these characterise what a client receives for a node whose concrete type has no overall counterpart.
+ */
+abstract class UnderlyingOnlyImplementationTestBase(
+    @Language("GraphQL") query: String,
+) : NadelIntegrationTest(
+    query = query,
+    services = listOf(
+        Service(
+            name = "data",
+            overallSchema = """
+                type Query {
+                  nodes: [Node]
+                }
+                interface Node {
+                  id: ID
+                }
+                type Issue implements Node {
+                  id: ID
+                  issueField: String
+                }
+                type Story implements Node {
+                  id: ID
+                  storyField: String
+                }
+            """.trimIndent(),
+            underlyingSchema = """
+                type Query {
+                  nodes: [Node]
+                }
+                interface Node {
+                  id: ID
+                }
+                type Issue implements Node {
+                  id: ID
+                  issueField: String
+                }
+                type Story implements Node {
+                  id: ID
+                  storyField: String
+                }
+                type Secret implements Node {
+                  id: ID
+                  secretField: String
+                }
+            """.trimIndent(),
+            runtimeWiring = { wiring ->
+                data class Issue(val id: String, val issueField: String)
+                data class Story(val id: String, val storyField: String)
+                data class Secret(val id: String, val secretField: String)
+
+                wiring
+                    .type("Node") { type ->
+                        type.typeResolver { env ->
+                            env.schema.getObjectType(env.getObject<Any>().javaClass.simpleName)
+                        }
+                    }
+                    .type("Query") { type ->
+                        type.dataFetcher("nodes") { _ ->
+                            listOf(
+                                Issue(id = "ISSUE-1", issueField = "i"),
+                                Story(id = "STORY-1", storyField = "s"),
+                                Secret(id = "SECRET-1", secretField = "shhh"),
+                            )
+                        }
+                    }
+            },
+        ),
+    ),
+)
+
+class UnderlyingOnlyImplBareInterfaceFieldTest : UnderlyingOnlyImplementationTestBase(
+    query = """
+        query {
+          nodes {
+            id
+          }
+        }
+    """.trimIndent(),
+)
+
+class UnderlyingOnlyImplBareTypenameTest : UnderlyingOnlyImplementationTestBase(
+    query = """
+        query {
+          nodes {
+            __typename
+          }
+        }
+    """.trimIndent(),
+)

--- a/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/execution/interfaceexpansion/union/UnionHiddenMemberBareTypenameTestSnapshot.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/execution/interfaceexpansion/union/UnionHiddenMemberBareTypenameTestSnapshot.kt
@@ -1,0 +1,103 @@
+// @formatter:off
+package graphql.nadel.tests.next.fixtures.execution.interfaceexpansion.union
+
+import graphql.nadel.tests.next.ExpectedNadelResult
+import graphql.nadel.tests.next.ExpectedServiceCall
+import graphql.nadel.tests.next.TestSnapshot
+import graphql.nadel.tests.next.listOfJsonStrings
+import kotlin.Suppress
+import kotlin.collections.List
+import kotlin.collections.listOf
+
+private suspend fun main() {
+    graphql.nadel.tests.next.update<UnionHiddenMemberBareTypenameTest>()
+}
+
+/**
+ * This class is generated. Do NOT modify.
+ *
+ * Refer to [graphql.nadel.tests.next.UpdateTestSnapshots]
+ */
+@Suppress("unused")
+public class UnionHiddenMemberBareTypenameTestSnapshot : TestSnapshot() {
+    /**
+     * Query
+     *
+     * ```graphql
+     * query {
+     *   actors {
+     *     __typename
+     *   }
+     * }
+     * ```
+     *
+     * Variables
+     *
+     * ```json
+     * {}
+     * ```
+     */
+    override val calls: List<ExpectedServiceCall> = listOf(
+            ExpectedServiceCall(
+                service = "data",
+                query = """
+                | {
+                |   actors {
+                |     ... on Issue {
+                |       __typename
+                |     }
+                |     ... on User {
+                |       __typename
+                |     }
+                |   }
+                | }
+                """.trimMargin(),
+                variables = "{}",
+                result = """
+                | {
+                |   "data": {
+                |     "actors": [
+                |       {
+                |         "__typename": "User"
+                |       },
+                |       {}
+                |     ]
+                |   }
+                | }
+                """.trimMargin(),
+                delayedResults = listOfJsonStrings(
+                ),
+            ),
+        )
+
+    /**
+     * ```json
+     * {
+     *   "data": {
+     *     "actors": [
+     *       {
+     *         "__typename": "User"
+     *       },
+     *       {}
+     *     ]
+     *   }
+     * }
+     * ```
+     */
+    override val result: ExpectedNadelResult = ExpectedNadelResult(
+            result = """
+            | {
+            |   "data": {
+            |     "actors": [
+            |       {
+            |         "__typename": "User"
+            |       },
+            |       {}
+            |     ]
+            |   }
+            | }
+            """.trimMargin(),
+            delayedResults = listOfJsonStrings(
+            ),
+        )
+}

--- a/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/execution/interfaceexpansion/union/UnionHiddenMemberExpansionTest.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/execution/interfaceexpansion/union/UnionHiddenMemberExpansionTest.kt
@@ -1,0 +1,90 @@
+package graphql.nadel.tests.next.fixtures.execution.interfaceexpansion.union
+
+import graphql.nadel.tests.next.NadelIntegrationTest
+import org.intellij.lang.annotations.Language
+
+/**
+ * Union analogue: the expansion isn't interface-specific. `Actor` is `{User, Issue}` overall but
+ * `{User, Issue, Bot}` underlying (`Bot` hidden). A union's only abstract-level selection is `__typename`, so a
+ * bare `actors { __typename }` is expanded into `... on User`/`... on Issue`, naming the exposed members; the
+ * hidden `Bot` comes back as `{}`. The hint relaxes this — see the `*RelaxedTest` counterpart.
+ */
+abstract class UnionHiddenMemberTestBase(
+    @Language("GraphQL") query: String,
+) : NadelIntegrationTest(
+    query = query,
+    services = listOf(
+        Service(
+            name = "data",
+            overallSchema = """
+                type Query {
+                  actors: [Actor]
+                }
+                union Actor = User | Issue
+                type User {
+                  id: ID
+                }
+                type Issue {
+                  id: ID
+                }
+            """.trimIndent(),
+            underlyingSchema = """
+                type Query {
+                  actors: [Actor]
+                }
+                union Actor = User | Issue | Bot
+                type User {
+                  id: ID
+                }
+                type Issue {
+                  id: ID
+                }
+                type Bot {
+                  id: ID
+                }
+            """.trimIndent(),
+            runtimeWiring = { wiring ->
+                data class User(val id: String)
+                data class Bot(val id: String)
+
+                wiring
+                    .type("Actor") { type ->
+                        type.typeResolver { env ->
+                            env.schema.getObjectType(env.getObject<Any>().javaClass.simpleName)
+                        }
+                    }
+                    .type("Query") { type ->
+                        type.dataFetcher("actors") { _ ->
+                            listOf(
+                                User(id = "USER-1"),
+                                Bot(id = "BOT-1"),
+                            )
+                        }
+                    }
+            },
+        ),
+    ),
+)
+
+class UnionHiddenMemberBareTypenameTest : UnionHiddenMemberTestBase(
+    query = """
+        query {
+          actors {
+            __typename
+          }
+        }
+    """.trimIndent(),
+)
+
+/** Explicit `... on User` is honoured verbatim; the hidden `Bot` (matching no fragment) comes back as `{}`. */
+class UnionHiddenMemberExplicitMemberTest : UnionHiddenMemberTestBase(
+    query = """
+        query {
+          actors {
+            ... on User {
+              id
+            }
+          }
+        }
+    """.trimIndent(),
+)

--- a/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/execution/interfaceexpansion/union/UnionHiddenMemberExplicitMemberTestSnapshot.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/execution/interfaceexpansion/union/UnionHiddenMemberExplicitMemberTestSnapshot.kt
@@ -1,0 +1,102 @@
+// @formatter:off
+package graphql.nadel.tests.next.fixtures.execution.interfaceexpansion.union
+
+import graphql.nadel.tests.next.ExpectedNadelResult
+import graphql.nadel.tests.next.ExpectedServiceCall
+import graphql.nadel.tests.next.TestSnapshot
+import graphql.nadel.tests.next.listOfJsonStrings
+import kotlin.Suppress
+import kotlin.collections.List
+import kotlin.collections.listOf
+
+private suspend fun main() {
+    graphql.nadel.tests.next.update<UnionHiddenMemberExplicitMemberTest>()
+}
+
+/**
+ * This class is generated. Do NOT modify.
+ *
+ * Refer to [graphql.nadel.tests.next.UpdateTestSnapshots]
+ */
+@Suppress("unused")
+public class UnionHiddenMemberExplicitMemberTestSnapshot : TestSnapshot() {
+    /**
+     * Query
+     *
+     * ```graphql
+     * query {
+     *   actors {
+     *     ... on User {
+     *       id
+     *     }
+     *   }
+     * }
+     * ```
+     *
+     * Variables
+     *
+     * ```json
+     * {}
+     * ```
+     */
+    override val calls: List<ExpectedServiceCall> = listOf(
+            ExpectedServiceCall(
+                service = "data",
+                query = """
+                | {
+                |   actors {
+                |     ... on User {
+                |       id
+                |     }
+                |   }
+                | }
+                """.trimMargin(),
+                variables = "{}",
+                result = """
+                | {
+                |   "data": {
+                |     "actors": [
+                |       {
+                |         "id": "USER-1"
+                |       },
+                |       {}
+                |     ]
+                |   }
+                | }
+                """.trimMargin(),
+                delayedResults = listOfJsonStrings(
+                ),
+            ),
+        )
+
+    /**
+     * ```json
+     * {
+     *   "data": {
+     *     "actors": [
+     *       {
+     *         "id": "USER-1"
+     *       },
+     *       {}
+     *     ]
+     *   }
+     * }
+     * ```
+     */
+    override val result: ExpectedNadelResult = ExpectedNadelResult(
+            result = """
+            | {
+            |   "data": {
+            |     "actors": [
+            |       {
+            |         "id": "USER-1"
+            |       },
+            |       {}
+            |     ]
+            |   }
+            | }
+            """.trimMargin(),
+            delayedResults = listOfJsonStrings(
+            ),
+        )
+}

--- a/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/execution/interfaceexpansion/union/UnionHiddenMemberRelaxedBareTypenameTestSnapshot.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/execution/interfaceexpansion/union/UnionHiddenMemberRelaxedBareTypenameTestSnapshot.kt
@@ -1,0 +1,103 @@
+// @formatter:off
+package graphql.nadel.tests.next.fixtures.execution.interfaceexpansion.union
+
+import graphql.nadel.tests.next.ExpectedNadelResult
+import graphql.nadel.tests.next.ExpectedServiceCall
+import graphql.nadel.tests.next.TestSnapshot
+import graphql.nadel.tests.next.listOfJsonStrings
+import kotlin.Suppress
+import kotlin.collections.List
+import kotlin.collections.listOf
+
+private suspend fun main() {
+    graphql.nadel.tests.next.update<UnionHiddenMemberRelaxedBareTypenameTest>()
+}
+
+/**
+ * This class is generated. Do NOT modify.
+ *
+ * Refer to [graphql.nadel.tests.next.UpdateTestSnapshots]
+ */
+@Suppress("unused")
+public class UnionHiddenMemberRelaxedBareTypenameTestSnapshot : TestSnapshot() {
+    /**
+     * Query
+     *
+     * ```graphql
+     * query {
+     *   actors {
+     *     __typename
+     *   }
+     * }
+     * ```
+     *
+     * Variables
+     *
+     * ```json
+     * {}
+     * ```
+     */
+    override val calls: List<ExpectedServiceCall> = listOf(
+            ExpectedServiceCall(
+                service = "data",
+                query = """
+                | {
+                |   actors {
+                |     __typename
+                |     __typename__abstract_member__actors: __typename
+                |   }
+                | }
+                """.trimMargin(),
+                variables = "{}",
+                result = """
+                | {
+                |   "data": {
+                |     "actors": [
+                |       {
+                |         "__typename": "User",
+                |         "__typename__abstract_member__actors": "User"
+                |       },
+                |       {
+                |         "__typename": "Bot",
+                |         "__typename__abstract_member__actors": "Bot"
+                |       }
+                |     ]
+                |   }
+                | }
+                """.trimMargin(),
+                delayedResults = listOfJsonStrings(
+                ),
+            ),
+        )
+
+    /**
+     * ```json
+     * {
+     *   "data": {
+     *     "actors": [
+     *       {
+     *         "__typename": "User"
+     *       },
+     *       {}
+     *     ]
+     *   }
+     * }
+     * ```
+     */
+    override val result: ExpectedNadelResult = ExpectedNadelResult(
+            result = """
+            | {
+            |   "data": {
+            |     "actors": [
+            |       {
+            |         "__typename": "User"
+            |       },
+            |       {}
+            |     ]
+            |   }
+            | }
+            """.trimMargin(),
+            delayedResults = listOfJsonStrings(
+            ),
+        )
+}

--- a/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/execution/interfaceexpansion/union/UnionHiddenMemberRelaxedExplicitMemberTestSnapshot.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/execution/interfaceexpansion/union/UnionHiddenMemberRelaxedExplicitMemberTestSnapshot.kt
@@ -1,0 +1,102 @@
+// @formatter:off
+package graphql.nadel.tests.next.fixtures.execution.interfaceexpansion.union
+
+import graphql.nadel.tests.next.ExpectedNadelResult
+import graphql.nadel.tests.next.ExpectedServiceCall
+import graphql.nadel.tests.next.TestSnapshot
+import graphql.nadel.tests.next.listOfJsonStrings
+import kotlin.Suppress
+import kotlin.collections.List
+import kotlin.collections.listOf
+
+private suspend fun main() {
+    graphql.nadel.tests.next.update<UnionHiddenMemberRelaxedExplicitMemberTest>()
+}
+
+/**
+ * This class is generated. Do NOT modify.
+ *
+ * Refer to [graphql.nadel.tests.next.UpdateTestSnapshots]
+ */
+@Suppress("unused")
+public class UnionHiddenMemberRelaxedExplicitMemberTestSnapshot : TestSnapshot() {
+    /**
+     * Query
+     *
+     * ```graphql
+     * query {
+     *   actors {
+     *     ... on User {
+     *       id
+     *     }
+     *   }
+     * }
+     * ```
+     *
+     * Variables
+     *
+     * ```json
+     * {}
+     * ```
+     */
+    override val calls: List<ExpectedServiceCall> = listOf(
+            ExpectedServiceCall(
+                service = "data",
+                query = """
+                | {
+                |   actors {
+                |     ... on User {
+                |       id
+                |     }
+                |   }
+                | }
+                """.trimMargin(),
+                variables = "{}",
+                result = """
+                | {
+                |   "data": {
+                |     "actors": [
+                |       {
+                |         "id": "USER-1"
+                |       },
+                |       {}
+                |     ]
+                |   }
+                | }
+                """.trimMargin(),
+                delayedResults = listOfJsonStrings(
+                ),
+            ),
+        )
+
+    /**
+     * ```json
+     * {
+     *   "data": {
+     *     "actors": [
+     *       {
+     *         "id": "USER-1"
+     *       },
+     *       {}
+     *     ]
+     *   }
+     * }
+     * ```
+     */
+    override val result: ExpectedNadelResult = ExpectedNadelResult(
+            result = """
+            | {
+            |   "data": {
+            |     "actors": [
+            |       {
+            |         "id": "USER-1"
+            |       },
+            |       {}
+            |     ]
+            |   }
+            | }
+            """.trimMargin(),
+            delayedResults = listOfJsonStrings(
+            ),
+        )
+}

--- a/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/execution/interfaceexpansion/union/UnionHiddenMemberRelaxedTest.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/execution/interfaceexpansion/union/UnionHiddenMemberRelaxedTest.kt
@@ -1,0 +1,41 @@
+package graphql.nadel.tests.next.fixtures.execution.interfaceexpansion.union
+
+import graphql.nadel.NadelExecutionHints
+
+/**
+ * The union scenario with the hint ON. `__typename` at the union level is relaxed (sent bare) just like on an
+ * interface, and a hidden member's node is stripped to `{}`. Anything else on a union needs an explicit
+ * `... on Member` fragment and is never relaxed.
+ */
+
+/** `actors { __typename }` goes bare; the hidden `Bot` is stripped to `{}` (result identical to hint-OFF). */
+class UnionHiddenMemberRelaxedBareTypenameTest : UnionHiddenMemberTestBase(
+    query = """
+        query {
+          actors {
+            __typename
+          }
+        }
+    """.trimIndent(),
+) {
+    override fun makeExecutionHints(): NadelExecutionHints.Builder {
+        return super.makeExecutionHints().noInterfaceToObjectFragmentExpansion { _ -> true }
+    }
+}
+
+/** `... on User { id }`: explicit member fragment, unchanged (honoured verbatim); the hidden `Bot` node → `{}`. */
+class UnionHiddenMemberRelaxedExplicitMemberTest : UnionHiddenMemberTestBase(
+    query = """
+        query {
+          actors {
+            ... on User {
+              id
+            }
+          }
+        }
+    """.trimIndent(),
+) {
+    override fun makeExecutionHints(): NadelExecutionHints.Builder {
+        return super.makeExecutionHints().noInterfaceToObjectFragmentExpansion { _ -> true }
+    }
+}


### PR DESCRIPTION
Please make sure you consider the following:

- [x] Add tests that use __typename in queries
- [x] Does this change work with all nadel transformations (rename, type rename, hydration, etc)? Add tests for this.
- [x] Is it worth using hints for this change in order to be able to enable a percentage rollout?
- [x] Do we need to add integration tests for this change in the graphql gateway?
- [x] Do we need a pollinator check for this?
