### PR TITLE
Batching of Root Fields in AGG

### DIFF
--- a/lib/src/main/java/graphql/nadel/NadelExecutionHints.kt
+++ b/lib/src/main/java/graphql/nadel/NadelExecutionHints.kt
@@ -2,6 +2,7 @@ package graphql.nadel
 
 import graphql.nadel.hints.AllDocumentVariablesHint
 import graphql.nadel.hints.LegacyOperationNamesHint
+import graphql.nadel.hints.NadelBatchRootFieldsHint
 import graphql.nadel.hints.NadelDeferSupportHint
 import graphql.nadel.hints.NadelDisableSharedTypesHint
 import graphql.nadel.hints.NadelExecuteOnEngineSchemaHint
@@ -28,6 +29,7 @@ data class NadelExecutionHints(
     val shadowUnderlyingTypeNameInvestigation: NadelShadowUnderlyingTypeNameInvestigation,
     val disableSharedTypes: NadelDisableSharedTypesHint,
     val useReachableUnderlyingServiceTypes: NadelReachableUnderlyingServiceTypesHint,
+    val batchRootFields: NadelBatchRootFieldsHint,
 ) {
     /**
      * Returns a builder with the same field values as this object.
@@ -53,6 +55,7 @@ data class NadelExecutionHints(
         private var shadowUnderlyingTypeNameInvestigation = NadelShadowUnderlyingTypeNameInvestigation { false }
         private var disableSharedTypes = NadelDisableSharedTypesHint { false }
         private var useReachableUnderlyingServiceTypes = NadelReachableUnderlyingServiceTypesHint { false }
+        private var batchRootFields = NadelBatchRootFieldsHint { false }
 
         constructor()
 
@@ -70,6 +73,7 @@ data class NadelExecutionHints(
             shadowUnderlyingTypeNameInvestigation = nadelExecutionHints.shadowUnderlyingTypeNameInvestigation
             disableSharedTypes = nadelExecutionHints.disableSharedTypes
             useReachableUnderlyingServiceTypes = nadelExecutionHints.useReachableUnderlyingServiceTypes
+            batchRootFields = nadelExecutionHints.batchRootFields
         }
 
         fun legacyOperationNames(flag: LegacyOperationNamesHint): Builder {
@@ -137,6 +141,11 @@ data class NadelExecutionHints(
             return this
         }
 
+        fun batchRootFields(flag: NadelBatchRootFieldsHint): Builder {
+            batchRootFields = flag
+            return this
+        }
+
         fun build(): NadelExecutionHints {
             return NadelExecutionHints(
                 legacyOperationNames,
@@ -152,6 +161,7 @@ data class NadelExecutionHints(
                 shadowUnderlyingTypeNameInvestigation,
                 disableSharedTypes,
                 useReachableUnderlyingServiceTypes,
+                batchRootFields,
             )
         }
     }

--- a/lib/src/main/java/graphql/nadel/NextgenEngine.kt
+++ b/lib/src/main/java/graphql/nadel/NextgenEngine.kt
@@ -201,18 +201,18 @@ internal class NextgenEngine(
                 val fields = fieldToService.getServicesForTopLevelFields(operation, executionHints)
                 val results = coroutineScope {
                     fields
-                        .map { (field, service) ->
+                        .map { (fields, service) ->
                             async {
                                 try {
-                                    val resolvedService = fieldToService.resolveDynamicService(field, service)
+                                    val resolvedService = fieldToService.resolveDynamicService(fields, service)
                                     executeTopLevelField(
-                                        topLevelField = field,
+                                        topLevelField = fields,
                                         service = resolvedService,
                                         executionContext = executionContext,
                                     )
                                 } catch (e: Throwable) {
                                     when (e) {
-                                        is GraphQLError -> newServiceExecutionErrorResult(field, error = e)
+                                        is GraphQLError -> newServiceExecutionErrorResult(fields.first(), error = e)
                                         else -> throw e
                                     }
                                 }
@@ -260,7 +260,7 @@ internal class NextgenEngine(
     ): ServiceExecutionResult {
         return try {
             executeTopLevelField(
-                topLevelField = topLevelField,
+                topLevelField = listOf(topLevelField),
                 service = service,
                 executionContext = executionContext.copy(
                     hydrationDetails = hydrationDetails,
@@ -283,7 +283,7 @@ internal class NextgenEngine(
         executionContext: NadelExecutionContext,
     ): ServiceExecutionResult {
         return executeTopLevelField(
-            topLevelField = topLevelField,
+            topLevelField = listOf(topLevelField),
             service = service,
             executionContext = executionContext.copy(
                 isPartitionedCall = true,
@@ -292,7 +292,7 @@ internal class NextgenEngine(
     }
 
     private suspend fun executeTopLevelField(
-        topLevelField: ExecutableNormalizedField,
+        topLevelField: List<ExecutableNormalizedField>,
         service: Service,
         executionContext: NadelExecutionContext,
     ): ServiceExecutionResult {
@@ -315,7 +315,8 @@ internal class NextgenEngine(
                 executionContext = executionContext,
                 serviceExecutionContext = serviceExecutionContext,
                 executionPlan = executionPlan,
-                field = topLevelField
+                // TODO(batch-root-fields): transform every field once a list can hold >1 root field
+                field = topLevelField.first()
             )
         }
         val result: ServiceExecutionResult = timer.time(step = RootStep.ServiceExecution.child(service.name)) {
@@ -352,7 +353,8 @@ internal class NextgenEngine(
             )
         }
         val transformedResult: ServiceExecutionResult = when {
-            topLevelField.name.startsWith("__") -> result
+            // TODO(batch-root-fields): assumes a single root field; revisit when batching >1 root field
+            topLevelField.first().name.startsWith("__") -> result
             else -> timer.time(step = RootStep.ResultTransforming) {
                 resultTransformer.transform(
                     executionContext = executionContext,

--- a/lib/src/main/java/graphql/nadel/NextgenEngine.kt
+++ b/lib/src/main/java/graphql/nadel/NextgenEngine.kt
@@ -206,7 +206,7 @@ internal class NextgenEngine(
                                 try {
                                     val resolvedService = fieldToService.resolveDynamicService(fields, service)
                                     executeTopLevelField(
-                                        topLevelField = fields,
+                                        topLevelFields = fields,
                                         service = resolvedService,
                                         executionContext = executionContext,
                                     )
@@ -221,7 +221,7 @@ internal class NextgenEngine(
                 }.awaitAll()
 
                 if (executionHints.newResultMergerAndNamespacedTypename()) {
-                    NadelResultMerger.mergeResults(fields, engineSchema, results)
+                    NadelResultMerger.mergeResults(operation.topLevelFields, engineSchema, results)
                 } else {
                     graphql.nadel.engine.util.mergeResults(results)
                 }
@@ -260,7 +260,7 @@ internal class NextgenEngine(
     ): ServiceExecutionResult {
         return try {
             executeTopLevelField(
-                topLevelField = listOf(topLevelField),
+                topLevelFields = listOf(topLevelField),
                 service = service,
                 executionContext = executionContext.copy(
                     hydrationDetails = hydrationDetails,
@@ -283,7 +283,7 @@ internal class NextgenEngine(
         executionContext: NadelExecutionContext,
     ): ServiceExecutionResult {
         return executeTopLevelField(
-            topLevelField = listOf(topLevelField),
+            topLevelFields = listOf(topLevelField),
             service = service,
             executionContext = executionContext.copy(
                 isPartitionedCall = true,
@@ -292,7 +292,7 @@ internal class NextgenEngine(
     }
 
     private suspend fun executeTopLevelField(
-        topLevelField: List<ExecutableNormalizedField>,
+        topLevelFields: List<ExecutableNormalizedField>,
         service: Service,
         executionContext: NadelExecutionContext,
     ): ServiceExecutionResult {
@@ -305,7 +305,7 @@ internal class NextgenEngine(
                 serviceExecutionContext = serviceExecutionContext,
                 services = services,
                 service = service,
-                rootField = topLevelField,
+                rootFields = topLevelFields,
                 serviceHydrationDetails = executionContext.hydrationDetails,
             )
         }
@@ -315,7 +315,7 @@ internal class NextgenEngine(
                 executionContext = executionContext,
                 serviceExecutionContext = serviceExecutionContext,
                 executionPlan = executionPlan,
-                fields = topLevelField
+                fields = topLevelFields
             )
         }
         val result: ServiceExecutionResult = timer.time(step = RootStep.ServiceExecution.child(service.name)) {
@@ -354,7 +354,7 @@ internal class NextgenEngine(
         val transformedResult: ServiceExecutionResult = when {
             // Introspection fields are never batched with other fields (see NadelFieldToService),
             // so an all-introspection batch needs no result transformation.
-            topLevelField.all { it.name.startsWith("__") } -> result
+            topLevelFields.all { it.name.startsWith("__") } -> result
             else -> timer.time(step = RootStep.ResultTransforming) {
                 resultTransformer.transform(
                     executionContext = executionContext,

--- a/lib/src/main/java/graphql/nadel/NextgenEngine.kt
+++ b/lib/src/main/java/graphql/nadel/NextgenEngine.kt
@@ -212,7 +212,7 @@ internal class NextgenEngine(
                                     )
                                 } catch (e: Throwable) {
                                     when (e) {
-                                        is GraphQLError -> newServiceExecutionErrorResult(fields.first(), error = e)
+                                        is GraphQLError -> newServiceExecutionErrorResult(fields, error = e)
                                         else -> throw e
                                     }
                                 }
@@ -315,8 +315,7 @@ internal class NextgenEngine(
                 executionContext = executionContext,
                 serviceExecutionContext = serviceExecutionContext,
                 executionPlan = executionPlan,
-                // TODO(batch-root-fields): transform every field once a list can hold >1 root field
-                field = topLevelField.first()
+                fields = topLevelField
             )
         }
         val result: ServiceExecutionResult = timer.time(step = RootStep.ServiceExecution.child(service.name)) {
@@ -353,8 +352,9 @@ internal class NextgenEngine(
             )
         }
         val transformedResult: ServiceExecutionResult = when {
-            // TODO(batch-root-fields): assumes a single root field; revisit when batching >1 root field
-            topLevelField.first().name.startsWith("__") -> result
+            // Introspection fields are never batched with other fields (see NadelFieldToService),
+            // so an all-introspection batch needs no result transformation.
+            topLevelField.all { it.name.startsWith("__") } -> result
             else -> timer.time(step = RootStep.ResultTransforming) {
                 resultTransformer.transform(
                     executionContext = executionContext,
@@ -517,7 +517,7 @@ internal class NextgenEngine(
         executionContext: NadelExecutionContext,
         serviceExecutionContext: NadelServiceExecutionContext,
         executionPlan: NadelExecutionPlan,
-        field: ExecutableNormalizedField,
+        fields: List<ExecutableNormalizedField>,
     ): NadelQueryTransformer.TransformResult {
         return NadelQueryTransformer.transformQuery(
             overallExecutionBlueprint,
@@ -525,7 +525,7 @@ internal class NextgenEngine(
             executionContext,
             serviceExecutionContext,
             executionPlan,
-            field,
+            fields,
         )
     }
 

--- a/lib/src/main/java/graphql/nadel/engine/plan/NadelExecutionPlanFactory.kt
+++ b/lib/src/main/java/graphql/nadel/engine/plan/NadelExecutionPlanFactory.kt
@@ -68,8 +68,9 @@ internal class NadelExecutionPlanFactory(
         val transformContexts: MutableMap<NadelTransform<Any>, NadelTransformServiceExecutionContext?> =
             mutableMapOf()
         executionContext.timer.batch { timer ->
-            // TODO(batch-root-fields): plan every root field once a list can hold >1 root field
-            traverseQuery(rootField.first()) { field ->
+            // Plan across every root field: batched root fields (see NadelBatchRootFieldsHint) share
+            // one service call, so all their transform steps belong to this single execution plan.
+            traverseQuery(rootField) { field ->
                 val steps = transformsWithTimingStepInfo.mapNotNull { transformWithTimingInfo ->
                     val transform = transformWithTimingInfo.transform
                     // This is a patch to prevent errors
@@ -88,7 +89,8 @@ internal class NadelExecutionPlanFactory(
                                     executionBlueprint,
                                     services,
                                     service,
-                                    // TODO(batch-root-fields): pass all root fields when batching >1 root field
+                                    // buildContext is memoized once per service call; the first root
+                                    // field is passed as the representative root field of the batch.
                                     rootField.first(),
                                     serviceHydrationDetails
                                 )
@@ -135,14 +137,16 @@ internal class NadelExecutionPlanFactory(
     }
 
     private inline fun traverseQuery(
-        root: ExecutableNormalizedField,
+        roots: List<ExecutableNormalizedField>,
         consumer: (ExecutableNormalizedField) -> Unit,
     ) {
-        dfs(
-            root = root,
-            getChildren = ExecutableNormalizedField::getChildren,
-            consumer = consumer,
-        )
+        for (root in roots) {
+            dfs(
+                root = root,
+                getChildren = ExecutableNormalizedField::getChildren,
+                consumer = consumer,
+            )
+        }
     }
 
     companion object {

--- a/lib/src/main/java/graphql/nadel/engine/plan/NadelExecutionPlanFactory.kt
+++ b/lib/src/main/java/graphql/nadel/engine/plan/NadelExecutionPlanFactory.kt
@@ -60,7 +60,7 @@ internal class NadelExecutionPlanFactory(
         serviceExecutionContext: NadelServiceExecutionContext,
         services: Map<String, Service>,
         service: Service,
-        rootField: ExecutableNormalizedField,
+        rootField: List<ExecutableNormalizedField>,
         serviceHydrationDetails: ServiceExecutionHydrationDetails?,
     ): NadelExecutionPlan {
         val executionSteps: MutableMap<ExecutableNormalizedField, List<NadelExecutionPlan.Step<Any>>> =
@@ -68,7 +68,8 @@ internal class NadelExecutionPlanFactory(
         val transformContexts: MutableMap<NadelTransform<Any>, NadelTransformServiceExecutionContext?> =
             mutableMapOf()
         executionContext.timer.batch { timer ->
-            traverseQuery(rootField) { field ->
+            // TODO(batch-root-fields): plan every root field once a list can hold >1 root field
+            traverseQuery(rootField.first()) { field ->
                 val steps = transformsWithTimingStepInfo.mapNotNull { transformWithTimingInfo ->
                     val transform = transformWithTimingInfo.transform
                     // This is a patch to prevent errors
@@ -87,7 +88,8 @@ internal class NadelExecutionPlanFactory(
                                     executionBlueprint,
                                     services,
                                     service,
-                                    rootField,
+                                    // TODO(batch-root-fields): pass all root fields when batching >1 root field
+                                    rootField.first(),
                                     serviceHydrationDetails
                                 )
                             }

--- a/lib/src/main/java/graphql/nadel/engine/plan/NadelExecutionPlanFactory.kt
+++ b/lib/src/main/java/graphql/nadel/engine/plan/NadelExecutionPlanFactory.kt
@@ -53,14 +53,14 @@ internal class NadelExecutionPlanFactory(
 
     /**
      * This derives an execution plan from with the main input parameters being the
-     * [rootField] and [executionBlueprint].
+     * [rootFields] and [executionBlueprint].
      */
     suspend fun create(
         executionContext: NadelExecutionContext,
         serviceExecutionContext: NadelServiceExecutionContext,
         services: Map<String, Service>,
         service: Service,
-        rootField: List<ExecutableNormalizedField>,
+        rootFields: List<ExecutableNormalizedField>,
         serviceHydrationDetails: ServiceExecutionHydrationDetails?,
     ): NadelExecutionPlan {
         val executionSteps: MutableMap<ExecutableNormalizedField, List<NadelExecutionPlan.Step<Any>>> =
@@ -68,9 +68,7 @@ internal class NadelExecutionPlanFactory(
         val transformContexts: MutableMap<NadelTransform<Any>, NadelTransformServiceExecutionContext?> =
             mutableMapOf()
         executionContext.timer.batch { timer ->
-            // Plan across every root field: batched root fields (see NadelBatchRootFieldsHint) share
-            // one service call, so all their transform steps belong to this single execution plan.
-            traverseQuery(rootField) { field ->
+            traverseQuery(rootFields) { field ->
                 val steps = transformsWithTimingStepInfo.mapNotNull { transformWithTimingInfo ->
                     val transform = transformWithTimingInfo.transform
                     // This is a patch to prevent errors
@@ -89,9 +87,7 @@ internal class NadelExecutionPlanFactory(
                                     executionBlueprint,
                                     services,
                                     service,
-                                    // buildContext is memoized once per service call; the first root
-                                    // field is passed as the representative root field of the batch.
-                                    rootField.first(),
+                                    rootFields,
                                     serviceHydrationDetails
                                 )
                             }

--- a/lib/src/main/java/graphql/nadel/engine/transform/NadelTransform.kt
+++ b/lib/src/main/java/graphql/nadel/engine/transform/NadelTransform.kt
@@ -25,7 +25,8 @@ interface NadelTransform<State : Any> {
      * of the transform on all the fields.
      *
      * @param executionBlueprint the [NadelOverallExecutionBlueprint] of the Nadel instance being operated on
-     * @param rootField the root [ExecutableNormalizedField] of the operation this [NadelTransform] runs on
+     * @param rootFields the root [ExecutableNormalizedField]s of the operation this [NadelTransform] runs on.
+     * There is more than one when sibling root fields are batched into a single service call.
      * @param hydrationDetails the [ServiceExecutionHydrationDetails] when the [NadelTransform] is applied to fields inside
      * hydrations, `null` otherwise
      *
@@ -39,7 +40,7 @@ interface NadelTransform<State : Any> {
         executionBlueprint: NadelOverallExecutionBlueprint,
         services: Map<String, Service>,
         service: Service,
-        rootField: ExecutableNormalizedField,
+        rootFields: List<ExecutableNormalizedField>,
         hydrationDetails: ServiceExecutionHydrationDetails?,
     ): NadelTransformServiceExecutionContext? {
         return null

--- a/lib/src/main/java/graphql/nadel/engine/transform/NadelTransformJavaCompat.kt
+++ b/lib/src/main/java/graphql/nadel/engine/transform/NadelTransformJavaCompat.kt
@@ -113,7 +113,7 @@ interface NadelTransformJavaCompat<State : Any> {
                     executionBlueprint: NadelOverallExecutionBlueprint,
                     services: Map<String, Service>,
                     service: Service,
-                    rootField: ExecutableNormalizedField,
+                    rootFields: List<ExecutableNormalizedField>,
                     hydrationDetails: ServiceExecutionHydrationDetails?,
                 ): NadelTransformServiceExecutionContext? {
                     return compat.buildContext(
@@ -122,7 +122,8 @@ interface NadelTransformJavaCompat<State : Any> {
                         executionBlueprint,
                         services,
                         service,
-                        rootField,
+                        // The Java compat API predates root-field batching and takes a single root field.
+                        rootFields.first(),
                         hydrationDetails
                     ).asDeferred().await()
                 }

--- a/lib/src/main/java/graphql/nadel/engine/transform/NadelTransformJavaCompat.kt
+++ b/lib/src/main/java/graphql/nadel/engine/transform/NadelTransformJavaCompat.kt
@@ -31,7 +31,7 @@ interface NadelTransformJavaCompat<State : Any> {
         executionBlueprint: NadelOverallExecutionBlueprint,
         services: Map<String, Service>,
         service: Service,
-        rootField: ExecutableNormalizedField,
+        rootFields: List<ExecutableNormalizedField>,
         hydrationDetails: ServiceExecutionHydrationDetails?,
     ): CompletableFuture<NadelTransformServiceExecutionContext?> {
         return CompletableFuture.completedFuture(null)
@@ -122,8 +122,7 @@ interface NadelTransformJavaCompat<State : Any> {
                         executionBlueprint,
                         services,
                         service,
-                        // The Java compat API predates root-field batching and takes a single root field.
-                        rootFields.first(),
+                        rootFields,
                         hydrationDetails
                     ).asDeferred().await()
                 }

--- a/lib/src/main/java/graphql/nadel/engine/transform/query/NadelFieldToService.kt
+++ b/lib/src/main/java/graphql/nadel/engine/transform/query/NadelFieldToService.kt
@@ -34,7 +34,7 @@ internal class NadelFieldToService(
                 if (isNamespacedField(topLevelField)) {
                     getServicePairsForNamespacedFields(topLevelField, executionHints)
                 } else {
-                    listOf(NadelFieldAndService(field = listOf(topLevelField), service = getService(topLevelField)))
+                    listOf(NadelFieldAndService(fields = listOf(topLevelField), service = getService(topLevelField)))
                 }
             }
         }
@@ -52,12 +52,12 @@ internal class NadelFieldToService(
             if (canBatchRootField(topLevelField, service, executionHints)) {
                 batchedByService.getOrPut(service) { mutableListOf() }.add(topLevelField)
             } else {
-                result += NadelFieldAndService(field = listOf(topLevelField), service = service)
+                result += NadelFieldAndService(fields = listOf(topLevelField), service = service)
             }
         }
 
         batchedByService.forEach { (service, batchedFields) ->
-            result += NadelFieldAndService(field = batchedFields, service = service)
+            result += NadelFieldAndService(fields = batchedFields, service = service)
         }
 
         return result
@@ -86,11 +86,11 @@ internal class NadelFieldToService(
      * otherwise returns the originalService.
      */
     fun resolveDynamicService(
-        field: List<ExecutableNormalizedField>,
+        fields: List<ExecutableNormalizedField>,
         originalService: Service,
     ): Service {
-        return if (dynamicServiceResolution.needsDynamicServiceResolution(field.first())) {
-            dynamicServiceResolution.resolveServiceForField(field.first())
+        return if (dynamicServiceResolution.needsDynamicServiceResolution(fields.first())) {
+            dynamicServiceResolution.resolveServiceForField(fields.first())
         } else {
             originalService
         }
@@ -106,7 +106,7 @@ internal class NadelFieldToService(
             }
             .map { (service, childTopLevelFields) ->
                 NadelFieldAndService(
-                    field = listOf(topLevelField.copyWithChildren(childTopLevelFields)),
+                    fields = listOf(topLevelField.copyWithChildren(childTopLevelFields)),
                     service = service,
                 )
             }
@@ -148,7 +148,7 @@ internal class NadelFieldToService(
 }
 
 data class NadelFieldAndService(
-    val field: List<ExecutableNormalizedField>,
+    val fields: List<ExecutableNormalizedField>,
     val service: Service,
 )
 

--- a/lib/src/main/java/graphql/nadel/engine/transform/query/NadelFieldToService.kt
+++ b/lib/src/main/java/graphql/nadel/engine/transform/query/NadelFieldToService.kt
@@ -27,43 +27,37 @@ internal class NadelFieldToService(
         query: ExecutableNormalizedOperation,
         executionHints: NadelExecutionHints,
     ): List<NadelFieldAndService> {
-        val topLevelFields = query.topLevelFields
-
-        // Resolve the owning service for each non-namespaced root field, and bucket the ones that
-        // are eligible for batching by service. LinkedHashMap preserves first-occurrence order.
-        val fieldToService = HashMap<ExecutableNormalizedField, Service>()
-        val batchedByService = LinkedHashMap<Service, MutableList<ExecutableNormalizedField>>()
-        for (topLevelField in topLevelFields) {
-            if (isNamespacedField(topLevelField)) {
-                continue
-            }
-            val service = getService(topLevelField)
-            fieldToService[topLevelField] = service
-            if (canBatchRootField(topLevelField, service, executionHints)) {
-                batchedByService.getOrPut(service) { mutableListOf() }.add(topLevelField)
+        // Feature flag: when root-field batching is globally disabled, keep the original behaviour
+        // of one entry (i.e. one service call) per root field.
+        if (!executionHints.batchRootFields()) {
+            return query.topLevelFields.flatMap { topLevelField ->
+                if (isNamespacedField(topLevelField)) {
+                    getServicePairsForNamespacedFields(topLevelField, executionHints)
+                } else {
+                    listOf(NadelFieldAndService(field = listOf(topLevelField), service = getService(topLevelField)))
+                }
             }
         }
 
-        // Emit entries in query order. A batched service's root fields are emitted as a single
-        // entry (one service call) at the position of the service's first batchable root field;
-        // everything else keeps its own single-field entry, exactly as before.
+        // Group batch-eligible root fields per service into a single entry (one service call).
         val result = mutableListOf<NadelFieldAndService>()
-        val emittedBatches = HashSet<Service>()
-        for (topLevelField in topLevelFields) {
+        val batchedByService = LinkedHashMap<Service, MutableList<ExecutableNormalizedField>>()
+        for (topLevelField in query.topLevelFields) {
             if (isNamespacedField(topLevelField)) {
                 result += getServicePairsForNamespacedFields(topLevelField, executionHints)
                 continue
             }
 
-            val service = fieldToService.getValue(topLevelField)
-            val batchedFields = batchedByService[service]
-            if (batchedFields != null && topLevelField in batchedFields) {
-                if (emittedBatches.add(service)) {
-                    result += NadelFieldAndService(field = batchedFields, service = service)
-                }
+            val service = getService(topLevelField)
+            if (canBatchRootField(topLevelField, service, executionHints)) {
+                batchedByService.getOrPut(service) { mutableListOf() }.add(topLevelField)
             } else {
                 result += NadelFieldAndService(field = listOf(topLevelField), service = service)
             }
+        }
+
+        batchedByService.forEach { (service, batchedFields) ->
+            result += NadelFieldAndService(field = batchedFields, service = service)
         }
 
         return result

--- a/lib/src/main/java/graphql/nadel/engine/transform/query/NadelFieldToService.kt
+++ b/lib/src/main/java/graphql/nadel/engine/transform/query/NadelFieldToService.kt
@@ -27,13 +27,64 @@ internal class NadelFieldToService(
         query: ExecutableNormalizedOperation,
         executionHints: NadelExecutionHints,
     ): List<NadelFieldAndService> {
-        return query.topLevelFields.flatMap { topLevelField ->
+        val topLevelFields = query.topLevelFields
+
+        // Resolve the owning service for each non-namespaced root field, and bucket the ones that
+        // are eligible for batching by service. LinkedHashMap preserves first-occurrence order.
+        val fieldToService = HashMap<ExecutableNormalizedField, Service>()
+        val batchedByService = LinkedHashMap<Service, MutableList<ExecutableNormalizedField>>()
+        for (topLevelField in topLevelFields) {
             if (isNamespacedField(topLevelField)) {
-                getServicePairsForNamespacedFields(topLevelField, executionHints)
-            } else {
-                listOf(getServicePairFor(field = topLevelField))
+                continue
+            }
+            val service = getService(topLevelField)
+            fieldToService[topLevelField] = service
+            if (canBatchRootField(topLevelField, service, executionHints)) {
+                batchedByService.getOrPut(service) { mutableListOf() }.add(topLevelField)
             }
         }
+
+        // Emit entries in query order. A batched service's root fields are emitted as a single
+        // entry (one service call) at the position of the service's first batchable root field;
+        // everything else keeps its own single-field entry, exactly as before.
+        val result = mutableListOf<NadelFieldAndService>()
+        val emittedBatches = HashSet<Service>()
+        for (topLevelField in topLevelFields) {
+            if (isNamespacedField(topLevelField)) {
+                result += getServicePairsForNamespacedFields(topLevelField, executionHints)
+                continue
+            }
+
+            val service = fieldToService.getValue(topLevelField)
+            val batchedFields = batchedByService[service]
+            if (batchedFields != null && topLevelField in batchedFields) {
+                if (emittedBatches.add(service)) {
+                    result += NadelFieldAndService(field = batchedFields, service = service)
+                }
+            } else {
+                result += NadelFieldAndService(field = listOf(topLevelField), service = service)
+            }
+        }
+
+        return result
+    }
+
+    /**
+     * Root fields are only batched into a single service call when the service opts in via
+     * [NadelExecutionHints.batchRootFields].
+     */
+    private fun canBatchRootField(
+        field: ExecutableNormalizedField,
+        service: Service,
+        executionHints: NadelExecutionHints,
+    ): Boolean {
+        if (!executionHints.batchRootFields(service)) {
+            return false
+        }
+        if (field.name.startsWith("__")) {
+            return false
+        }
+        return !dynamicServiceResolution.needsDynamicServiceResolution(field)
     }
 
     /**
@@ -65,13 +116,6 @@ internal class NadelFieldToService(
                     service = service,
                 )
             }
-    }
-
-    private fun getServicePairFor(field: ExecutableNormalizedField): NadelFieldAndService {
-        return NadelFieldAndService(
-            field = listOf(field),
-            service = getService(field),
-        )
     }
 
     private fun getServiceForNamespacedField(

--- a/lib/src/main/java/graphql/nadel/engine/transform/query/NadelFieldToService.kt
+++ b/lib/src/main/java/graphql/nadel/engine/transform/query/NadelFieldToService.kt
@@ -41,11 +41,11 @@ internal class NadelFieldToService(
      * otherwise returns the originalService.
      */
     fun resolveDynamicService(
-        field: ExecutableNormalizedField,
+        field: List<ExecutableNormalizedField>,
         originalService: Service,
     ): Service {
-        return if (dynamicServiceResolution.needsDynamicServiceResolution(field)) {
-            dynamicServiceResolution.resolveServiceForField(field)
+        return if (dynamicServiceResolution.needsDynamicServiceResolution(field.first())) {
+            dynamicServiceResolution.resolveServiceForField(field.first())
         } else {
             originalService
         }
@@ -61,7 +61,7 @@ internal class NadelFieldToService(
             }
             .map { (service, childTopLevelFields) ->
                 NadelFieldAndService(
-                    field = topLevelField.copyWithChildren(childTopLevelFields),
+                    field = listOf(topLevelField.copyWithChildren(childTopLevelFields)),
                     service = service,
                 )
             }
@@ -69,7 +69,7 @@ internal class NadelFieldToService(
 
     private fun getServicePairFor(field: ExecutableNormalizedField): NadelFieldAndService {
         return NadelFieldAndService(
-            field = field,
+            field = listOf(field),
             service = getService(field),
         )
     }
@@ -110,7 +110,7 @@ internal class NadelFieldToService(
 }
 
 data class NadelFieldAndService(
-    val field: ExecutableNormalizedField,
+    val field: List<ExecutableNormalizedField>,
     val service: Service,
 )
 

--- a/lib/src/main/java/graphql/nadel/engine/transform/query/NadelFieldToService.kt
+++ b/lib/src/main/java/graphql/nadel/engine/transform/query/NadelFieldToService.kt
@@ -89,8 +89,11 @@ internal class NadelFieldToService(
         fields: List<ExecutableNormalizedField>,
         originalService: Service,
     ): Service {
-        return if (dynamicServiceResolution.needsDynamicServiceResolution(fields.first())) {
-            dynamicServiceResolution.resolveServiceForField(fields.first())
+        // Dynamically-resolved fields are never batched (see canBatchRootField), so dynamic
+        // resolution only applies to single-field entries; batched entries keep the original service.
+        val field = fields.singleOrNull() ?: return originalService
+        return if (dynamicServiceResolution.needsDynamicServiceResolution(field)) {
+            dynamicServiceResolution.resolveServiceForField(field)
         } else {
             originalService
         }

--- a/lib/src/main/java/graphql/nadel/engine/transform/query/NadelQueryTransformer.kt
+++ b/lib/src/main/java/graphql/nadel/engine/transform/query/NadelQueryTransformer.kt
@@ -27,7 +27,7 @@ class NadelQueryTransformer private constructor(
             executionContext: NadelExecutionContext,
             serviceExecutionContext: NadelServiceExecutionContext,
             executionPlan: NadelExecutionPlan,
-            field: ExecutableNormalizedField,
+            fields: List<ExecutableNormalizedField>,
         ): TransformResult {
             val transformContext = TransformContext()
 
@@ -41,7 +41,10 @@ class NadelQueryTransformer private constructor(
                     transformContext,
                     timer,
                 )
-                val result = transformer.transform(field)
+                // Transform every root field. The shared transformContext accumulates the artificial
+                // fields and overall->underlying mapping across all of them, so a batch of root fields
+                // destined for one service becomes a single combined TransformResult (one document).
+                val result = transformer.transform(fields)
                     .also { rootFields ->
                         transformer.fixParentRefs(parent = null, rootFields)
                     }

--- a/lib/src/main/java/graphql/nadel/engine/util/GraphQLUtil.kt
+++ b/lib/src/main/java/graphql/nadel/engine/util/GraphQLUtil.kt
@@ -448,10 +448,19 @@ fun newServiceExecutionErrorResult(
     field: ExecutableNormalizedField,
     error: GraphQLError,
 ): ServiceExecutionResult {
+    return newServiceExecutionErrorResult(fields = listOf(field), error = error)
+}
+
+fun newServiceExecutionErrorResult(
+    fields: List<ExecutableNormalizedField>,
+    error: GraphQLError,
+): ServiceExecutionResult {
+    val data: MutableMap<String, Any?> = mutableMapOf()
+    for (field in fields) {
+        data[field.resultKey] = null
+    }
     return NadelServiceExecutionResultImpl(
-        data = mutableMapOf(
-            field.resultKey to null,
-        ),
+        data = data,
         errors = mutableListOf(
             error.toSpecification(),
         ),

--- a/lib/src/main/java/graphql/nadel/hints/NadelBatchRootFieldsHint.kt
+++ b/lib/src/main/java/graphql/nadel/hints/NadelBatchRootFieldsHint.kt
@@ -1,0 +1,17 @@
+package graphql.nadel.hints
+
+import graphql.nadel.Service
+
+fun interface NadelBatchRootFieldsHint {
+    /**
+     * Determines whether multiple top level (root) fields destined for the same service should be
+     * combined into a single service call (i.e. one request), rather than one call per root field.
+     *
+     * This only affects sibling root fields with no shared namespace wrapper (e.g. the prefixed
+     * `jira_foo`, `jira_bar` form). Namespaced fields are already batched per service regardless.
+     *
+     * @param service the service the root fields would be sent to
+     * @return true to batch this service's root fields into a single call
+     */
+    operator fun invoke(service: Service): Boolean
+}

--- a/lib/src/main/java/graphql/nadel/hints/NadelBatchRootFieldsHint.kt
+++ b/lib/src/main/java/graphql/nadel/hints/NadelBatchRootFieldsHint.kt
@@ -4,14 +4,19 @@ import graphql.nadel.Service
 
 fun interface NadelBatchRootFieldsHint {
     /**
-     * Determines whether multiple top level (root) fields destined for the same service should be
-     * combined into a single service call (i.e. one request), rather than one call per root field.
+     * Global feature flag for root-field batching. When false, Nadel keeps its original behaviour
+     * of making one service call per root field. Use this to feature flag the whole feature.
+     */
+    operator fun invoke(): Boolean
+
+    /**
+     * Per-service opt-in for root-field batching. Defaults to the global flag [invoke].
      *
-     * This only affects sibling root fields with no shared namespace wrapper (e.g. the prefixed
+     * Only affects sibling root fields with no shared namespace wrapper (e.g. the prefixed
      * `jira_foo`, `jira_bar` form). Namespaced fields are already batched per service regardless.
      *
      * @param service the service the root fields would be sent to
      * @return true to batch this service's root fields into a single call
      */
-    operator fun invoke(service: Service): Boolean
+    operator fun invoke(service: Service): Boolean = invoke()
 }

--- a/lib/src/main/java/graphql/nadel/result/NadelResultMerger.kt
+++ b/lib/src/main/java/graphql/nadel/result/NadelResultMerger.kt
@@ -55,11 +55,10 @@ internal object NadelResultMerger {
 
         for ((topLevelResultKey, children) in requiredFieldMap) {
             val topLevelFieldDef by lazy {
-                // TODO(batch-root-fields): assumes each entry holds a single root field; revisit when batching >1
                 fields
-                    .first { it.field.first().resultKey == topLevelResultKey.value }
-                    .field
-                    .first()
+                    .asSequence()
+                    .flatMap { it.field }
+                    .first { it.resultKey == topLevelResultKey.value }
                     .getFieldDefinitions(engineSchema)
                     .single() // This is under Query, Mutation etc. so there is only one field
             }
@@ -124,9 +123,7 @@ internal object NadelResultMerger {
 
         // NOTE: please ensure all fields are from object types and will NOT have multiple field defs
         // Other code in this file relies on this contract
-        for ((fieldList) in fields) {
-            // TODO(batch-root-fields): iterate all fields once a list can hold >1 root field
-            val field = fieldList.first()
+        for (field in fields.flatMap { it.field }) {
             val requiredChildFields = requiredFields
                 .computeIfAbsent(NadelResultKey(field.resultKey)) {
                     mutableListOf()

--- a/lib/src/main/java/graphql/nadel/result/NadelResultMerger.kt
+++ b/lib/src/main/java/graphql/nadel/result/NadelResultMerger.kt
@@ -55,9 +55,11 @@ internal object NadelResultMerger {
 
         for ((topLevelResultKey, children) in requiredFieldMap) {
             val topLevelFieldDef by lazy {
+                // TODO(batch-root-fields): assumes each entry holds a single root field; revisit when batching >1
                 fields
-                    .first { (field) -> field.resultKey == topLevelResultKey.value }
+                    .first { it.field.first().resultKey == topLevelResultKey.value }
                     .field
+                    .first()
                     .getFieldDefinitions(engineSchema)
                     .single() // This is under Query, Mutation etc. so there is only one field
             }
@@ -122,7 +124,9 @@ internal object NadelResultMerger {
 
         // NOTE: please ensure all fields are from object types and will NOT have multiple field defs
         // Other code in this file relies on this contract
-        for ((field) in fields) {
+        for ((fieldList) in fields) {
+            // TODO(batch-root-fields): iterate all fields once a list can hold >1 root field
+            val field = fieldList.first()
             val requiredChildFields = requiredFields
                 .computeIfAbsent(NadelResultKey(field.resultKey)) {
                     mutableListOf()

--- a/lib/src/main/java/graphql/nadel/result/NadelResultMerger.kt
+++ b/lib/src/main/java/graphql/nadel/result/NadelResultMerger.kt
@@ -5,7 +5,6 @@ import graphql.ExecutionResultImpl
 import graphql.GraphQLError
 import graphql.introspection.Introspection
 import graphql.nadel.ServiceExecutionResult
-import graphql.nadel.engine.transform.query.NadelFieldAndService
 import graphql.nadel.engine.transform.result.NadelResultKey
 import graphql.nadel.engine.util.AnyMap
 import graphql.nadel.engine.util.JsonMap
@@ -20,7 +19,7 @@ import graphql.schema.GraphQLSchema
 
 internal object NadelResultMerger {
     fun mergeResults(
-        fields: List<NadelFieldAndService>,
+        topLevelFields: List<ExecutableNormalizedField>,
         engineSchema: GraphQLSchema,
         results: List<ServiceExecutionResult>,
     ): ExecutionResult {
@@ -35,7 +34,7 @@ internal object NadelResultMerger {
         }
 
         return ExecutionResultImpl.newExecutionResult()
-            .data(fixData(fields, engineSchema, data))
+            .data(fixData(topLevelFields, engineSchema, data))
             .extensions(extensions.let {
                 @Suppress("UNCHECKED_CAST") // .extensions should take in a Map<*, *> instead of strictly Map<Any?, Any?>
                 it as Map<Any?, Any?>
@@ -47,17 +46,15 @@ internal object NadelResultMerger {
     }
 
     private fun fixData(
-        fields: List<NadelFieldAndService>,
+        topLevelFields: List<ExecutableNormalizedField>,
         engineSchema: GraphQLSchema,
         data: MutableJsonMap,
     ): MutableJsonMap? {
-        val requiredFieldMap = buildRequiredFieldMap(fields, engineSchema)
+        val requiredFieldMap = buildRequiredFieldMap(topLevelFields, engineSchema)
 
         for ((topLevelResultKey, children) in requiredFieldMap) {
             val topLevelFieldDef by lazy {
-                fields
-                    .asSequence()
-                    .flatMap { it.field }
+                topLevelFields
                     .first { it.resultKey == topLevelResultKey.value }
                     .getFieldDefinitions(engineSchema)
                     .single() // This is under Query, Mutation etc. so there is only one field
@@ -116,14 +113,14 @@ internal object NadelResultMerger {
     }
 
     private fun buildRequiredFieldMap(
-        fields: List<NadelFieldAndService>,
+        topLevelFields: List<ExecutableNormalizedField>,
         engineSchema: GraphQLSchema,
     ): MutableMap<NadelResultKey, MutableList<ExecutableNormalizedField>> {
         val requiredFields = mutableMapOf<NadelResultKey, MutableList<ExecutableNormalizedField>>()
 
         // NOTE: please ensure all fields are from object types and will NOT have multiple field defs
         // Other code in this file relies on this contract
-        for (field in fields.flatMap { it.field }) {
+        for (field in topLevelFields) {
             val requiredChildFields = requiredFields
                 .computeIfAbsent(NadelResultKey(field.resultKey)) {
                     mutableListOf()

--- a/lib/src/test/kotlin/graphql/nadel/transform/NadelTransformJavaCompatTest.kt
+++ b/lib/src/test/kotlin/graphql/nadel/transform/NadelTransformJavaCompatTest.kt
@@ -86,7 +86,7 @@ class NadelTransformJavaCompatTest : DescribeSpec({
                 executionBlueprint,
                 services,
                 service,
-                overallField,
+                listOf(overallField),
                 hydrationDetails = hydrationDetails,
             )
 

--- a/lib/src/test/kotlin/graphql/nadel/transform/NadelTransformJavaCompatTest.kt
+++ b/lib/src/test/kotlin/graphql/nadel/transform/NadelTransformJavaCompatTest.kt
@@ -62,7 +62,7 @@ class NadelTransformJavaCompatTest : DescribeSpec({
                     executionBlueprint: NadelOverallExecutionBlueprint,
                     services: Map<String, Service>,
                     service: Service,
-                    rootField: ExecutableNormalizedField,
+                    rootFields: List<ExecutableNormalizedField>,
                     hydrationDetails: ServiceExecutionHydrationDetails?,
                 ): CompletableFuture<NadelTransformServiceExecutionContext?> {
                     return CompletableFuture.completedFuture(Prop("something"))
@@ -100,7 +100,7 @@ class NadelTransformJavaCompatTest : DescribeSpec({
                     executionBlueprint,
                     services,
                     service,
-                    overallField,
+                    listOf(overallField),
                     hydrationDetails,
                 )
             }

--- a/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/batching/BatchRootFieldsPerServiceTest.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/batching/BatchRootFieldsPerServiceTest.kt
@@ -1,6 +1,7 @@
 package graphql.nadel.tests.next.fixtures.batching
 
 import graphql.nadel.NadelExecutionHints
+import graphql.nadel.hints.NadelBatchRootFieldsHint
 import graphql.nadel.tests.next.NadelIntegrationTest
 
 /**
@@ -58,6 +59,9 @@ class BatchRootFieldsPerServiceTest : NadelIntegrationTest(
 ) {
     override fun makeExecutionHints(): NadelExecutionHints.Builder {
         return super.makeExecutionHints()
-            .batchRootFields { service -> service.name == "batched" }
+            .batchRootFields(object : NadelBatchRootFieldsHint {
+                override fun invoke(): Boolean = true
+                override fun invoke(service: graphql.nadel.Service): Boolean = service.name == "batched"
+            })
     }
 }

--- a/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/batching/BatchRootFieldsPerServiceTest.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/batching/BatchRootFieldsPerServiceTest.kt
@@ -1,0 +1,63 @@
+package graphql.nadel.tests.next.fixtures.batching
+
+import graphql.nadel.NadelExecutionHints
+import graphql.nadel.tests.next.NadelIntegrationTest
+
+/**
+ * Root-field batching is opt-in per service. Here it is enabled for "batched" but not "unbatched".
+ *
+ * The snapshot should record:
+ *  - a single call to "batched" containing batchedFoo and batchedBar, and
+ *  - two separate calls to "unbatched" (one per root field), preserving today's behaviour.
+ */
+class BatchRootFieldsPerServiceTest : NadelIntegrationTest(
+    query = """
+        query {
+          batchedFoo
+          batchedBar
+          unbatchedFoo
+          unbatchedBar
+        }
+    """.trimIndent(),
+    services = listOf(
+        Service(
+            name = "batched",
+            overallSchema = """
+                type Query {
+                  batchedFoo: String
+                  batchedBar: String
+                }
+            """.trimIndent(),
+            runtimeWiring = { wiring ->
+                wiring
+                    .type("Query") { type ->
+                        type
+                            .dataFetcher("batchedFoo") { "batchedFoo-value" }
+                            .dataFetcher("batchedBar") { "batchedBar-value" }
+                    }
+            },
+        ),
+        Service(
+            name = "unbatched",
+            overallSchema = """
+                type Query {
+                  unbatchedFoo: String
+                  unbatchedBar: String
+                }
+            """.trimIndent(),
+            runtimeWiring = { wiring ->
+                wiring
+                    .type("Query") { type ->
+                        type
+                            .dataFetcher("unbatchedFoo") { "unbatchedFoo-value" }
+                            .dataFetcher("unbatchedBar") { "unbatchedBar-value" }
+                    }
+            },
+        ),
+    ),
+) {
+    override fun makeExecutionHints(): NadelExecutionHints.Builder {
+        return super.makeExecutionHints()
+            .batchRootFields { service -> service.name == "batched" }
+    }
+}

--- a/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/batching/BatchRootFieldsPerServiceTestSnapshot.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/batching/BatchRootFieldsPerServiceTestSnapshot.kt
@@ -1,0 +1,108 @@
+// @formatter:off
+package graphql.nadel.tests.next.fixtures.batching
+
+import graphql.nadel.tests.next.ExpectedNadelResult
+import graphql.nadel.tests.next.ExpectedServiceCall
+import graphql.nadel.tests.next.TestSnapshot
+import graphql.nadel.tests.next.listOfJsonStrings
+import kotlin.Suppress
+import kotlin.collections.List
+import kotlin.collections.listOf
+
+private suspend fun main() {
+    graphql.nadel.tests.next.update<BatchRootFieldsPerServiceTest>()
+}
+
+/**
+ * This class is generated. Do NOT modify.
+ *
+ * Refer to [graphql.nadel.tests.next.UpdateTestSnapshots]
+ */
+@Suppress("unused")
+public class BatchRootFieldsPerServiceTestSnapshot : TestSnapshot() {
+    override val calls: List<ExpectedServiceCall> = listOf(
+            ExpectedServiceCall(
+                service = "batched",
+                query = """
+                | {
+                |   batchedBar
+                |   batchedFoo
+                | }
+                """.trimMargin(),
+                variables = "{}",
+                result = """
+                | {
+                |   "data": {
+                |     "batchedFoo": "batchedFoo-value",
+                |     "batchedBar": "batchedBar-value"
+                |   }
+                | }
+                """.trimMargin(),
+                delayedResults = listOfJsonStrings(
+                ),
+            ),
+            ExpectedServiceCall(
+                service = "unbatched",
+                query = """
+                | {
+                |   unbatchedBar
+                | }
+                """.trimMargin(),
+                variables = "{}",
+                result = """
+                | {
+                |   "data": {
+                |     "unbatchedBar": "unbatchedBar-value"
+                |   }
+                | }
+                """.trimMargin(),
+                delayedResults = listOfJsonStrings(
+                ),
+            ),
+            ExpectedServiceCall(
+                service = "unbatched",
+                query = """
+                | {
+                |   unbatchedFoo
+                | }
+                """.trimMargin(),
+                variables = "{}",
+                result = """
+                | {
+                |   "data": {
+                |     "unbatchedFoo": "unbatchedFoo-value"
+                |   }
+                | }
+                """.trimMargin(),
+                delayedResults = listOfJsonStrings(
+                ),
+            ),
+        )
+
+    /**
+     * ```json
+     * {
+     *   "data": {
+     *     "batchedFoo": "batchedFoo-value",
+     *     "batchedBar": "batchedBar-value",
+     *     "unbatchedFoo": "unbatchedFoo-value",
+     *     "unbatchedBar": "unbatchedBar-value"
+     *   }
+     * }
+     * ```
+     */
+    override val result: ExpectedNadelResult = ExpectedNadelResult(
+            result = """
+            | {
+            |   "data": {
+            |     "batchedFoo": "batchedFoo-value",
+            |     "batchedBar": "batchedBar-value",
+            |     "unbatchedFoo": "unbatchedFoo-value",
+            |     "unbatchedBar": "unbatchedBar-value"
+            |   }
+            | }
+            """.trimMargin(),
+            delayedResults = listOfJsonStrings(
+            ),
+        )
+}

--- a/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/batching/BatchedRootFieldsTest.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/batching/BatchedRootFieldsTest.kt
@@ -1,0 +1,46 @@
+package graphql.nadel.tests.next.fixtures.batching
+
+import graphql.nadel.NadelExecutionHints
+import graphql.nadel.tests.next.NadelIntegrationTest
+
+/**
+ * Multiple sibling root fields destined for the same service are combined into a single service
+ * call when [NadelExecutionHints.batchRootFields] is enabled for that service.
+ *
+ * The snapshot should record a single call to "monolith" containing foo, bar and baz.
+ */
+class BatchedRootFieldsTest : NadelIntegrationTest(
+    query = """
+        query {
+          foo
+          bar
+          baz
+        }
+    """.trimIndent(),
+    services = listOf(
+        Service(
+            name = "monolith",
+            overallSchema = """
+                type Query {
+                  foo: String
+                  bar: String
+                  baz: String
+                }
+            """.trimIndent(),
+            runtimeWiring = { wiring ->
+                wiring
+                    .type("Query") { type ->
+                        type
+                            .dataFetcher("foo") { "foo-value" }
+                            .dataFetcher("bar") { "bar-value" }
+                            .dataFetcher("baz") { "baz-value" }
+                    }
+            },
+        ),
+    ),
+) {
+    override fun makeExecutionHints(): NadelExecutionHints.Builder {
+        return super.makeExecutionHints()
+            .batchRootFields { true }
+    }
+}

--- a/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/batching/BatchedRootFieldsTestSnapshot.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/batching/BatchedRootFieldsTestSnapshot.kt
@@ -1,0 +1,72 @@
+// @formatter:off
+package graphql.nadel.tests.next.fixtures.batching
+
+import graphql.nadel.tests.next.ExpectedNadelResult
+import graphql.nadel.tests.next.ExpectedServiceCall
+import graphql.nadel.tests.next.TestSnapshot
+import graphql.nadel.tests.next.listOfJsonStrings
+import kotlin.Suppress
+import kotlin.collections.List
+import kotlin.collections.listOf
+
+private suspend fun main() {
+    graphql.nadel.tests.next.update<BatchedRootFieldsTest>()
+}
+
+/**
+ * This class is generated. Do NOT modify.
+ *
+ * Refer to [graphql.nadel.tests.next.UpdateTestSnapshots]
+ */
+@Suppress("unused")
+public class BatchedRootFieldsTestSnapshot : TestSnapshot() {
+    override val calls: List<ExpectedServiceCall> = listOf(
+            ExpectedServiceCall(
+                service = "monolith",
+                query = """
+                | {
+                |   bar
+                |   baz
+                |   foo
+                | }
+                """.trimMargin(),
+                variables = "{}",
+                result = """
+                | {
+                |   "data": {
+                |     "foo": "foo-value",
+                |     "bar": "bar-value",
+                |     "baz": "baz-value"
+                |   }
+                | }
+                """.trimMargin(),
+                delayedResults = listOfJsonStrings(
+                ),
+            ),
+        )
+
+    /**
+     * ```json
+     * {
+     *   "data": {
+     *     "foo": "foo-value",
+     *     "bar": "bar-value",
+     *     "baz": "baz-value"
+     *   }
+     * }
+     * ```
+     */
+    override val result: ExpectedNadelResult = ExpectedNadelResult(
+            result = """
+            | {
+            |   "data": {
+            |     "foo": "foo-value",
+            |     "bar": "bar-value",
+            |     "baz": "baz-value"
+            |   }
+            | }
+            """.trimMargin(),
+            delayedResults = listOfJsonStrings(
+            ),
+        )
+}

--- a/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/execution/ServiceExecutionContextTest.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/execution/ServiceExecutionContextTest.kt
@@ -158,11 +158,11 @@ class ServiceExecutionContextTest : NadelIntegrationTest(
                             executionBlueprint: NadelOverallExecutionBlueprint,
                             services: Map<String, graphql.nadel.Service>,
                             service: graphql.nadel.Service,
-                            rootField: ExecutableNormalizedField,
+                            rootFields: List<ExecutableNormalizedField>,
                             hydrationDetails: ServiceExecutionHydrationDetails?,
                         ): NadelTransformServiceExecutionContext? {
                             val testTransformServiceExecutionContext =
-                                TestTransformServiceExecutionContext(rootField.toExecutionString())
+                                TestTransformServiceExecutionContext(rootFields.single().toExecutionString())
                             transformServiceExecutionContexts.add(testTransformServiceExecutionContext)
                             return testTransformServiceExecutionContext
                         }


### PR DESCRIPTION
Please make sure you consider the following:

- [ ] Add tests that use __typename in queries
- [ ] Does this change work with all nadel transformations (rename, type rename, hydration, etc)? Add tests for this.
- [ ] Is it worth using hints for this change in order to be able to enable a percentage rollout?
- [ ] Do we need to add integration tests for this change in the graphql gateway?
- [ ] Do we need a pollinator check for this?
