### PR TITLE
Support Boolean fields in conditional hydration

### DIFF
--- a/lib/src/main/java/graphql/nadel/engine/blueprint/hydration/NadelHydrationCondition.kt
+++ b/lib/src/main/java/graphql/nadel/engine/blueprint/hydration/NadelHydrationCondition.kt
@@ -34,6 +34,15 @@ sealed class NadelHydrationCondition {
         }
     }
 
+    data class BooleanResultEquals(
+        override val fieldPath: NadelQueryPath,
+        val value: Boolean,
+    ) : NadelHydrationCondition() {
+        override fun evaluate(fieldValue: Any?): Boolean {
+            return fieldValue is Boolean && fieldValue == value
+        }
+    }
+
     data class StringResultMatches(
         override val fieldPath: NadelQueryPath,
         val regex: Regex,

--- a/lib/src/main/java/graphql/nadel/validation/NadelSchemaHydrationValidationError.kt
+++ b/lib/src/main/java/graphql/nadel/validation/NadelSchemaHydrationValidationError.kt
@@ -553,13 +553,14 @@ data class NadelHydrationResultConditionUnsupportedFieldTypeError(
         val str = Scalars.GraphQLString.name
         val int = Scalars.GraphQLInt.name
         val id = Scalars.GraphQLID.name
+        val boolean = Scalars.GraphQLBoolean.name
         val parentTypeName = parentType.overall.name
 
         getHydrationErrorMessage(
             parentType,
             virtualField,
             hydration,
-            reason = "condition field $parentTypeName.$conditionField must be of type $str, $int, $id or enum but is $conditionFieldType",
+            reason = "condition field $parentTypeName.$conditionField must be of type $str, $int, $id, $boolean or enum but is $conditionFieldType",
         )
     }
 

--- a/lib/src/main/java/graphql/nadel/validation/hydration/NadelHydrationConditionValidation.kt
+++ b/lib/src/main/java/graphql/nadel/validation/hydration/NadelHydrationConditionValidation.kt
@@ -1,5 +1,6 @@
 package graphql.nadel.validation.hydration
 
+import graphql.Scalars.GraphQLBoolean
 import graphql.Scalars.GraphQLID
 import graphql.Scalars.GraphQLInt
 import graphql.Scalars.GraphQLString
@@ -55,6 +56,10 @@ private sealed class NadelConditionFieldType {
 
     object IdType : NadelConditionFieldType() {
         override val graphQLType = GraphQLID
+    }
+
+    object BooleanType : NadelConditionFieldType() {
+        override val graphQLType = GraphQLBoolean
     }
 
     data class EnumType(
@@ -134,6 +139,7 @@ internal class NadelHydrationConditionValidation {
             GraphQLString -> NadelConditionFieldType.StringType
             GraphQLInt -> NadelConditionFieldType.IntType
             GraphQLID -> NadelConditionFieldType.IdType
+            GraphQLBoolean -> NadelConditionFieldType.BooleanType
             is GraphQLEnumType -> NadelConditionFieldType.EnumType(conditionFieldOutputType)
             else -> null
         } ?: return NadelHydrationResultConditionUnsupportedFieldTypeError(
@@ -303,6 +309,11 @@ internal class NadelHydrationConditionValidation {
             return NadelHydrationCondition.LongResultEquals(
                 fieldPath = NadelQueryPath(resultCondition.pathToSourceField),
                 value = expectedValue.toLong(),
+            ).asInterimSuccess()
+        } else if (expectedValue is Boolean && conditionFieldType == NadelConditionFieldType.BooleanType) {
+            return NadelHydrationCondition.BooleanResultEquals(
+                fieldPath = NadelQueryPath(resultCondition.pathToSourceField),
+                value = expectedValue,
             ).asInterimSuccess()
         } else {
             return NadelHydrationConditionIncompatibleValueError(

--- a/lib/src/test/kotlin/graphql/nadel/validation/NadelHydrationWhenConditionValidationTest.kt
+++ b/lib/src/test/kotlin/graphql/nadel/validation/NadelHydrationWhenConditionValidationTest.kt
@@ -10,146 +10,150 @@ private const val argument = "$" + "argument"
 
 class NadelHydrationWhenConditionValidationTest {
     private fun booleanConditionFixture(
-        conditionFieldType: String = "Boolean",
-        underlyingConditionFieldType: String = "Boolean!",
-        predicate: String = "equals: true",
+        conditionFieldType: String,
+        underlyingConditionFieldType: String,
+        predicate: String,
     ): NadelValidationTestFixture {
         return NadelValidationTestFixture(
             overallSchema = mapOf(
                 "issues" to """
-                        type Query {
-                            issue: JiraIssue
-                        }
-                        type JiraIssue @renamed(from: "Issue") {
-                            id: ID!
-                        }
-                    """.trimIndent(),
+                    type Query {
+                        issue: JiraIssue
+                    }
+                    type JiraIssue @renamed(from: "Issue") {
+                        id: ID!
+                    }
+                """.trimIndent(),
                 "users" to """
-                        type Query {
-                            users(id: [ID!]!): [User]
-                        }
-                        type User {
-                            id: ID!
-                            name: String!
-                        }
-                        extend type JiraIssue {
-                            shouldHydrate: $conditionFieldType
-                            collaborators: [User] @hydrated(
-                                service: "users"
-                                field: "users"
-                                arguments: [
-                                    {name: "id", value: "$source.collaboratorIds"}
-                                ]
-                                when: {
-                                    result: {
-                                        sourceField: "shouldHydrate"
-                                        predicate: { $predicate }
-                                    }
+                    type Query {
+                        users(id: [ID!]!): [User]
+                    }
+                    type User {
+                        id: ID!
+                        name: String!
+                    }
+                    extend type JiraIssue {
+                        shouldHydrate: $conditionFieldType
+                        collaborators: [User] @hydrated(
+                            service: "users"
+                            field: "users"
+                            arguments: [
+                                {name: "id", value: "$source.collaboratorIds"}
+                            ]
+                            when: {
+                                result: {
+                                    sourceField: "shouldHydrate"
+                                    predicate: { $predicate }
                                 }
-                            )
-                        }
-                    """.trimIndent(),
+                            }
+                        )
+                    }
+                """.trimIndent(),
             ),
             underlyingSchema = mapOf(
                 "issues" to """
-                        type Query {
-                            issue: Issue
-                        }
-                        type Issue {
-                            id: ID!
-                            collaboratorIds: [ID!]
-                            shouldHydrate: $underlyingConditionFieldType
-                        }
-                    """.trimIndent(),
+                    type Query {
+                        issue: Issue
+                    }
+                    type Issue {
+                        id: ID!
+                        collaboratorIds: [ID!]
+                        shouldHydrate: $underlyingConditionFieldType
+                    }
+                """.trimIndent(),
                 "users" to """
-                        type Query {
-                            users(id: [ID!]!): [User]
-                        }
-                        type User {
-                            id: ID!
-                            name: String!
-                        }
-                    """.trimIndent(),
+                    type Query {
+                        users(id: [ID!]!): [User]
+                    }
+                    type User {
+                        id: ID!
+                        name: String!
+                    }
+                """.trimIndent(),
             ),
         )
     }
 
     private fun enumConditionFixture(
-        conditionFieldType: String = "IssueType",
-        underlyingConditionFieldType: String = "IssueType!",
-        predicate: String = "equals: \"BUG\"",
+        conditionFieldType: String,
+        underlyingConditionFieldType: String,
+        predicate: String,
     ): NadelValidationTestFixture {
         return NadelValidationTestFixture(
             overallSchema = mapOf(
                 "issues" to """
-                        type Query {
-                            issue: JiraIssue
-                        }
-                        type JiraIssue @renamed(from: "Issue") {
-                            id: ID!
-                        }
-                        enum IssueType {
-                            BUG
-                            STORY
-                        }
-                    """.trimIndent(),
+                type Query {
+                        issue: JiraIssue
+                    }
+                    type JiraIssue @renamed(from: "Issue") {
+                        id: ID!
+                    }
+                    enum IssueType {
+                        BUG
+                        STORY
+                    }
+                """.trimIndent(),
                 "users" to """
-                        type Query {
-                            users(id: [ID!]!): [User]
-                        }
-                        type User {
-                            id: ID!
-                            name: String!
-                        }
-                        extend type JiraIssue {
-                            type: $conditionFieldType
-                            collaborators: [User] @hydrated(
-                                service: "users"
-                                field: "users"
-                                arguments: [
-                                    {name: "id", value: "$source.collaboratorIds"}
-                                ]
-                                when: {
-                                    result: {
-                                        sourceField: "type"
-                                        predicate: { $predicate }
-                                    }
+                    type Query {
+                        users(id: [ID!]!): [User]
+                    }
+                    type User {
+                        id: ID!
+                        name: String!
+                    }
+                    extend type JiraIssue {
+                        type: $conditionFieldType
+                        collaborators: [User] @hydrated(
+                            service: "users"
+                            field: "users"
+                            arguments: [
+                                {name: "id", value: "$source.collaboratorIds"}
+                            ]
+                            when: {
+                                result: {
+                                    sourceField: "type"
+                                    predicate: { $predicate }
                                 }
-                            )
-                        }
-                    """.trimIndent(),
+                            }
+                        )
+                    }
+                """.trimIndent(),
             ),
             underlyingSchema = mapOf(
                 "issues" to """
-                        type Query {
-                            issue: Issue
-                        }
-                        enum IssueType {
-                            BUG
-                            STORY
-                        }
-                        type Issue {
-                            id: ID!
-                            collaboratorIds: [ID!]
-                            type: $underlyingConditionFieldType
-                        }
-                    """.trimIndent(),
+                    type Query {
+                        issue: Issue
+                    }
+                    enum IssueType {
+                        BUG
+                        STORY
+                    }
+                    type Issue {
+                        id: ID!
+                        collaboratorIds: [ID!]
+                        type: $underlyingConditionFieldType
+                    }
+                """.trimIndent(),
                 "users" to """
-                        type Query {
-                            users(id: [ID!]!): [User]
-                        }
-                        type User {
-                            id: ID!
-                            name: String!
-                        }
-                    """.trimIndent(),
+                    type Query {
+                        users(id: [ID!]!): [User]
+                    }
+                    type User {
+                        id: ID!
+                        name: String!
+                    }
+                """.trimIndent(),
             ),
         )
     }
 
     @Test
     fun `boolean condition field is acceptable for true equals predicate`() {
-        val fixture = booleanConditionFixture()
+        val fixture = booleanConditionFixture(
+            conditionFieldType = "Boolean",
+            underlyingConditionFieldType = "Boolean!",
+            predicate = "equals: true",
+        )
 
         // When
         val errors = validate(fixture)
@@ -160,7 +164,11 @@ class NadelHydrationWhenConditionValidationTest {
 
     @Test
     fun `boolean condition field is acceptable for false equals predicate`() {
-        val fixture = booleanConditionFixture(predicate = "equals: false")
+        val fixture = booleanConditionFixture(
+            conditionFieldType = "Boolean",
+            underlyingConditionFieldType = "Boolean!",
+            predicate = "equals: false",
+        )
 
         // When
         val errors = validate(fixture)
@@ -171,7 +179,11 @@ class NadelHydrationWhenConditionValidationTest {
 
     @Test
     fun `non null boolean condition field is acceptable for equals predicate`() {
-        val fixture = booleanConditionFixture(conditionFieldType = "Boolean!")
+        val fixture = booleanConditionFixture(
+            conditionFieldType = "Boolean!",
+            underlyingConditionFieldType = "Boolean!",
+            predicate = "equals: true",
+        )
 
         // When
         val errors = validate(fixture)
@@ -185,6 +197,7 @@ class NadelHydrationWhenConditionValidationTest {
         val fixture = booleanConditionFixture(
             conditionFieldType = "[Boolean]",
             underlyingConditionFieldType = "[Boolean]",
+            predicate = "equals: true",
         )
 
         // When
@@ -196,7 +209,11 @@ class NadelHydrationWhenConditionValidationTest {
 
     @Test
     fun `boolean condition field rejects string equals value`() {
-        val fixture = booleanConditionFixture(predicate = "equals: \"true\"")
+        val fixture = booleanConditionFixture(
+            conditionFieldType = "Boolean",
+            underlyingConditionFieldType = "Boolean!",
+            predicate = "equals: \"true\"",
+        )
 
         // When
         val errors = validate(fixture)
@@ -207,7 +224,11 @@ class NadelHydrationWhenConditionValidationTest {
 
     @Test
     fun `boolean condition field rejects matches predicate`() {
-        val fixture = booleanConditionFixture(predicate = "matches: \"true\"")
+        val fixture = booleanConditionFixture(
+            conditionFieldType = "Boolean",
+            underlyingConditionFieldType = "Boolean!",
+            predicate = "matches: \"true\"",
+        )
 
         // When
         val errors = validate(fixture)
@@ -218,7 +239,11 @@ class NadelHydrationWhenConditionValidationTest {
 
     @Test
     fun `boolean condition field rejects startsWith predicate`() {
-        val fixture = booleanConditionFixture(predicate = "startsWith: \"tr\"")
+        val fixture = booleanConditionFixture(
+            conditionFieldType = "Boolean",
+            underlyingConditionFieldType = "Boolean!",
+            predicate = "startsWith: \"tr\"",
+        )
 
         // When
         val errors = validate(fixture)
@@ -297,7 +322,11 @@ class NadelHydrationWhenConditionValidationTest {
 
     @Test
     fun `enum condition field is acceptable for equals predicate`() {
-        val fixture = enumConditionFixture()
+        val fixture = enumConditionFixture(
+            conditionFieldType = "IssueType",
+            underlyingConditionFieldType = "IssueType!",
+            predicate = "equals: \"BUG\"",
+        )
 
         // When
         val errors = validate(fixture)
@@ -308,7 +337,11 @@ class NadelHydrationWhenConditionValidationTest {
 
     @Test
     fun `non null enum condition field is acceptable for equals predicate`() {
-        val fixture = enumConditionFixture(conditionFieldType = "IssueType!")
+        val fixture = enumConditionFixture(
+            conditionFieldType = "IssueType!",
+            underlyingConditionFieldType = "IssueType!",
+            predicate = "equals: \"BUG\"",
+        )
 
         // When
         val errors = validate(fixture)
@@ -322,6 +355,7 @@ class NadelHydrationWhenConditionValidationTest {
         val fixture = enumConditionFixture(
             conditionFieldType = "[IssueType]",
             underlyingConditionFieldType = "[IssueType]",
+            predicate = "equals: \"BUG\"",
         )
 
         // When
@@ -333,7 +367,11 @@ class NadelHydrationWhenConditionValidationTest {
 
     @Test
     fun `enum condition field rejects invalid equals value`() {
-        val fixture = enumConditionFixture(predicate = "equals: \"TASK\"")
+        val fixture = enumConditionFixture(
+            conditionFieldType = "IssueType",
+            underlyingConditionFieldType = "IssueType!",
+            predicate = "equals: \"TASK\"",
+        )
 
         // When
         val errors = validate(fixture)
@@ -345,7 +383,11 @@ class NadelHydrationWhenConditionValidationTest {
 
     @Test
     fun `enum condition field equals comparison is case sensitive`() {
-        val fixture = enumConditionFixture(predicate = "equals: \"bug\"")
+        val fixture = enumConditionFixture(
+            conditionFieldType = "IssueType",
+            underlyingConditionFieldType = "IssueType!",
+            predicate = "equals: \"bug\"",
+        )
 
         // When
         val errors = validate(fixture)
@@ -357,7 +399,11 @@ class NadelHydrationWhenConditionValidationTest {
 
     @Test
     fun `enum condition field rejects empty string equals value`() {
-        val fixture = enumConditionFixture(predicate = "equals: \"\"")
+        val fixture = enumConditionFixture(
+            conditionFieldType = "IssueType",
+            underlyingConditionFieldType = "IssueType!",
+            predicate = "equals: \"\"",
+        )
 
         // When
         val errors = validate(fixture)
@@ -369,7 +415,11 @@ class NadelHydrationWhenConditionValidationTest {
 
     @Test
     fun `enum condition field rejects matches predicate`() {
-        val fixture = enumConditionFixture(predicate = "matches: \"BUG\"")
+        val fixture = enumConditionFixture(
+            conditionFieldType = "IssueType",
+            underlyingConditionFieldType = "IssueType!",
+            predicate = "matches: \"BUG\"",
+        )
 
         // When
         val errors = validate(fixture)
@@ -380,7 +430,11 @@ class NadelHydrationWhenConditionValidationTest {
 
     @Test
     fun `enum condition field rejects startsWith predicate`() {
-        val fixture = enumConditionFixture(predicate = "startsWith: \"BU\"")
+        val fixture = enumConditionFixture(
+            conditionFieldType = "IssueType",
+            underlyingConditionFieldType = "IssueType!",
+            predicate = "startsWith: \"BU\"",
+        )
 
         // When
         val errors = validate(fixture)

--- a/lib/src/test/kotlin/graphql/nadel/validation/NadelHydrationWhenConditionValidationTest.kt
+++ b/lib/src/test/kotlin/graphql/nadel/validation/NadelHydrationWhenConditionValidationTest.kt
@@ -9,6 +9,71 @@ private const val source = "$" + "source"
 private const val argument = "$" + "argument"
 
 class NadelHydrationWhenConditionValidationTest {
+    private fun booleanConditionFixture(
+        conditionFieldType: String = "Boolean",
+        underlyingConditionFieldType: String = "Boolean!",
+        predicate: String = "equals: true",
+    ): NadelValidationTestFixture {
+        return NadelValidationTestFixture(
+            overallSchema = mapOf(
+                "issues" to """
+                        type Query {
+                            issue: JiraIssue
+                        }
+                        type JiraIssue @renamed(from: "Issue") {
+                            id: ID!
+                        }
+                    """.trimIndent(),
+                "users" to """
+                        type Query {
+                            users(id: [ID!]!): [User]
+                        }
+                        type User {
+                            id: ID!
+                            name: String!
+                        }
+                        extend type JiraIssue {
+                            shouldHydrate: $conditionFieldType
+                            collaborators: [User] @hydrated(
+                                service: "users"
+                                field: "users"
+                                arguments: [
+                                    {name: "id", value: "$source.collaboratorIds"}
+                                ]
+                                when: {
+                                    result: {
+                                        sourceField: "shouldHydrate"
+                                        predicate: { $predicate }
+                                    }
+                                }
+                            )
+                        }
+                    """.trimIndent(),
+            ),
+            underlyingSchema = mapOf(
+                "issues" to """
+                        type Query {
+                            issue: Issue
+                        }
+                        type Issue {
+                            id: ID!
+                            collaboratorIds: [ID!]
+                            shouldHydrate: $underlyingConditionFieldType
+                        }
+                    """.trimIndent(),
+                "users" to """
+                        type Query {
+                            users(id: [ID!]!): [User]
+                        }
+                        type User {
+                            id: ID!
+                            name: String!
+                        }
+                    """.trimIndent(),
+            ),
+        )
+    }
+
     private fun enumConditionFixture(
         conditionFieldType: String = "IssueType",
         underlyingConditionFieldType: String = "IssueType!",
@@ -80,6 +145,86 @@ class NadelHydrationWhenConditionValidationTest {
                     """.trimIndent(),
             ),
         )
+    }
+
+    @Test
+    fun `boolean condition field is acceptable for true equals predicate`() {
+        val fixture = booleanConditionFixture()
+
+        // When
+        val errors = validate(fixture)
+
+        // Then
+        assertTrue(errors.map { it.message }.isEmpty())
+    }
+
+    @Test
+    fun `boolean condition field is acceptable for false equals predicate`() {
+        val fixture = booleanConditionFixture(predicate = "equals: false")
+
+        // When
+        val errors = validate(fixture)
+
+        // Then
+        assertTrue(errors.map { it.message }.isEmpty())
+    }
+
+    @Test
+    fun `non null boolean condition field is acceptable for equals predicate`() {
+        val fixture = booleanConditionFixture(conditionFieldType = "Boolean!")
+
+        // When
+        val errors = validate(fixture)
+
+        // Then
+        assertTrue(errors.map { it.message }.isEmpty())
+    }
+
+    @Test
+    fun `list boolean condition field is not acceptable for equals predicate`() {
+        val fixture = booleanConditionFixture(
+            conditionFieldType = "[Boolean]",
+            underlyingConditionFieldType = "[Boolean]",
+        )
+
+        // When
+        val errors = validate(fixture)
+
+        // Then
+        errors.assertSingleOfType<NadelHydrationResultConditionUnsupportedFieldTypeError>()
+    }
+
+    @Test
+    fun `boolean condition field rejects string equals value`() {
+        val fixture = booleanConditionFixture(predicate = "equals: \"true\"")
+
+        // When
+        val errors = validate(fixture)
+
+        // Then
+        errors.assertSingleOfType<NadelHydrationConditionIncompatibleValueError>()
+    }
+
+    @Test
+    fun `boolean condition field rejects matches predicate`() {
+        val fixture = booleanConditionFixture(predicate = "matches: \"true\"")
+
+        // When
+        val errors = validate(fixture)
+
+        // Then
+        errors.assertSingleOfType<NadelHydrationConditionMatchesPredicateRequiresStringFieldError>()
+    }
+
+    @Test
+    fun `boolean condition field rejects startsWith predicate`() {
+        val fixture = booleanConditionFixture(predicate = "startsWith: \"tr\"")
+
+        // When
+        val errors = validate(fixture)
+
+        // Then
+        errors.assertSingleOfType<NadelHydrationConditionStartsWithPredicateRequiresStringFieldError>()
     }
 
     @Test

--- a/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/hydration/conditional/HydrationConditionalBooleanConditionTest.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/hydration/conditional/HydrationConditionalBooleanConditionTest.kt
@@ -1,0 +1,99 @@
+package graphql.nadel.tests.next.fixtures.hydration.conditional
+
+import graphql.nadel.tests.next.NadelIntegrationTest
+
+class HydrationConditionalBooleanConditionTest : NadelIntegrationTest(
+    query = """
+        query {
+          foo {
+            matchingBar {
+              name
+            }
+            nonMatchingBar {
+              name
+            }
+          }
+        }
+    """.trimIndent(),
+    variables = mapOf(),
+    services = listOf(
+        Service(
+            name = "service1",
+            overallSchema = """
+                type Query {
+                  foo: Foo
+                }
+                type Foo {
+                  id: ID
+                  shouldHydrate: Boolean
+                  matchingBarId: ID @hidden
+                  nonMatchingBarId: ID @hidden
+                  matchingBar: Bar
+                    @hydrated(
+                      service: "service2"
+                      field: "barById"
+                      arguments: [{name: "id", value: "$source.matchingBarId"}]
+                      when: { result: { sourceField: "shouldHydrate", predicate: { equals: true } } }
+                    )
+                  nonMatchingBar: Bar
+                    @hydrated(
+                      service: "service2"
+                      field: "barById"
+                      arguments: [{name: "id", value: "$source.nonMatchingBarId"}]
+                      when: { result: { sourceField: "shouldHydrate", predicate: { equals: false } } }
+                    )
+                }
+            """.trimIndent(),
+            runtimeWiring = { wiring ->
+                data class Foo(
+                    val id: String,
+                    val shouldHydrate: Boolean,
+                    val matchingBarId: String,
+                    val nonMatchingBarId: String,
+                )
+
+                val foo = Foo(
+                    id = "foo-id",
+                    shouldHydrate = true,
+                    matchingBarId = "matching-bar-id",
+                    nonMatchingBarId = "non-matching-bar-id",
+                )
+
+                wiring
+                    .type("Query") { type ->
+                        type.dataFetcher("foo") { foo }
+                    }
+            },
+        ),
+        Service(
+            name = "service2",
+            overallSchema = """
+                type Query {
+                  barById(id: ID): Bar
+                }
+                type Bar {
+                  id: ID
+                  name: String
+                }
+            """.trimIndent(),
+            runtimeWiring = { wiring ->
+                data class Bar(
+                    val id: String,
+                    val name: String,
+                )
+
+                val barsById = listOf(
+                    Bar(id = "matching-bar-id", name = "Matching Bar"),
+                    Bar(id = "non-matching-bar-id", name = "Non Matching Bar"),
+                ).associateBy { it.id }
+
+                wiring
+                    .type("Query") { type ->
+                        type.dataFetcher("barById") {
+                            barsById[it.getArgument<String>("id")!!]
+                        }
+                    }
+            },
+        ),
+    ),
+)

--- a/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/hydration/conditional/HydrationConditionalBooleanConditionTestSnapshot.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/hydration/conditional/HydrationConditionalBooleanConditionTestSnapshot.kt
@@ -1,0 +1,132 @@
+// @formatter:off
+package graphql.nadel.tests.next.fixtures.hydration.conditional
+
+import graphql.nadel.tests.next.ExpectedNadelResult
+import graphql.nadel.tests.next.ExpectedServiceCall
+import graphql.nadel.tests.next.TestSnapshot
+import graphql.nadel.tests.next.listOfJsonStrings
+import kotlin.Suppress
+import kotlin.collections.List
+import kotlin.collections.listOf
+
+private suspend fun main() {
+    graphql.nadel.tests.next.update<HydrationConditionalBooleanConditionTest>()
+}
+
+/**
+ * This class is generated. Do NOT modify.
+ *
+ * Refer to [graphql.nadel.tests.next.UpdateTestSnapshots]
+ */
+@Suppress("unused")
+public class HydrationConditionalBooleanConditionTestSnapshot : TestSnapshot() {
+    /**
+     * Query
+     *
+     * ```graphql
+     * query {
+     *   foo {
+     *     matchingBar {
+     *       name
+     *     }
+     *     nonMatchingBar {
+     *       name
+     *     }
+     *   }
+     * }
+     * ```
+     *
+     * Variables
+     *
+     * ```json
+     * {}
+     * ```
+     */
+    override val calls: List<ExpectedServiceCall> = listOf(
+            ExpectedServiceCall(
+                service = "service1",
+                query = """
+                | {
+                |   foo {
+                |     __typename__hydration__matchingBar: __typename
+                |     __typename__hydration__nonMatchingBar: __typename
+                |     hydration__matchingBar__matchingBarId: matchingBarId
+                |     hydration__nonMatchingBar__nonMatchingBarId: nonMatchingBarId
+                |     hydration__matchingBar__shouldHydrate: shouldHydrate
+                |     hydration__nonMatchingBar__shouldHydrate: shouldHydrate
+                |   }
+                | }
+                """.trimMargin(),
+                variables = "{}",
+                result = """
+                | {
+                |   "data": {
+                |     "foo": {
+                |       "hydration__matchingBar__matchingBarId": "matching-bar-id",
+                |       "hydration__matchingBar__shouldHydrate": true,
+                |       "__typename__hydration__matchingBar": "Foo",
+                |       "hydration__nonMatchingBar__nonMatchingBarId": "non-matching-bar-id",
+                |       "hydration__nonMatchingBar__shouldHydrate": true,
+                |       "__typename__hydration__nonMatchingBar": "Foo"
+                |     }
+                |   }
+                | }
+                """.trimMargin(),
+                delayedResults = listOfJsonStrings(
+                ),
+            ),
+            ExpectedServiceCall(
+                service = "service2",
+                query = """
+                | {
+                |   barById(id: "matching-bar-id") {
+                |     name
+                |   }
+                | }
+                """.trimMargin(),
+                variables = "{}",
+                result = """
+                | {
+                |   "data": {
+                |     "barById": {
+                |       "name": "Matching Bar"
+                |     }
+                |   }
+                | }
+                """.trimMargin(),
+                delayedResults = listOfJsonStrings(
+                ),
+            ),
+        )
+
+    /**
+     * ```json
+     * {
+     *   "data": {
+     *     "foo": {
+     *       "nonMatchingBar": null,
+     *       "matchingBar": {
+     *         "name": "Matching Bar"
+     *       }
+     *     }
+     *   }
+     * }
+     * ```
+     */
+    override val result: ExpectedNadelResult = ExpectedNadelResult(
+            result = """
+            | {
+            |   "data": {
+            |     "foo": {
+            |       "nonMatchingBar": null,
+            |       "matchingBar": {
+            |         "name": "Matching Bar"
+            |       }
+            |     }
+            |   }
+            | }
+            """.trimMargin(),
+            delayedResults = listOfJsonStrings(
+            ),
+        )
+}


### PR DESCRIPTION
## Summary

Nadel now accepts Boolean source fields for conditional hydration.

The `equals` predicate accepts `true` and `false`. The `startsWith` and `matches` predicates still require a String or ID field.

Nadel reports a validation error when the equals value is not a Boolean.

## Tests

Validation tests cover nullable and non-null Boolean fields. They also cover list fields, invalid values, and unsupported predicates.

An integration test confirms that Nadel runs the matching hydration and skips the other hydration.