### PR TITLE
bugfix: don't widen the type conditions in the NadelServiceTypeFilter…

### DIFF
--- a/lib/src/main/java/graphql/nadel/engine/transform/NadelServiceTypeFilterTransform.kt
+++ b/lib/src/main/java/graphql/nadel/engine/transform/NadelServiceTypeFilterTransform.kt
@@ -4,7 +4,6 @@ import graphql.introspection.Introspection
 import graphql.nadel.Service
 import graphql.nadel.ServiceExecutionHydrationDetails
 import graphql.nadel.ServiceExecutionResult
-import graphql.nadel.definition.hydration.NadelHydrationConditionDefinition.Keyword.result
 import graphql.nadel.engine.NadelExecutionContext
 import graphql.nadel.engine.NadelServiceExecutionContext
 import graphql.nadel.engine.blueprint.IntrospectionService
@@ -176,8 +175,14 @@ class NadelServiceTypeFilterTransform : NadelTransform<State> {
         state: State,
         transformServiceExecutionContext: NadelTransformServiceExecutionContext?,
     ): NadelTransformFieldResult {
+        // A transform on a parent may have narrowed this field after planning. Intersect with the current types
+        // so service filtering can never reintroduce a type removed by an earlier transform.
+        val currentFieldObjectTypeNamesOwnedByService = field.objectTypeNames.filter {
+            it in state.fieldObjectTypeNamesOwnedByService
+        }
+
         // Nothing to query if there are no fields, we need to add selection
-        if (state.fieldObjectTypeNamesOwnedByService.isEmpty()) {
+        if (currentFieldObjectTypeNamesOwnedByService.isEmpty()) {
             val objectTypeNames = state.overallField.parent.getFieldDefinitions(executionBlueprint.engineSchema)
                 .asSequence()
                 .flatMap { fieldDef ->
@@ -218,7 +223,7 @@ class NadelServiceTypeFilterTransform : NadelTransform<State> {
             newField = field
                 .toBuilder()
                 .clearObjectTypesNames()
-                .objectTypeNames(state.fieldObjectTypeNamesOwnedByService)
+                .objectTypeNames(currentFieldObjectTypeNamesOwnedByService)
                 .build(),
         )
     }

--- a/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/execution/servicetypefilter/ServiceTypeFilterDoesNotRestoreRemovedOwnedTypeTestSnapshot.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/execution/servicetypefilter/ServiceTypeFilterDoesNotRestoreRemovedOwnedTypeTestSnapshot.kt
@@ -1,0 +1,100 @@
+// @formatter:off
+package graphql.nadel.tests.next.fixtures.execution.servicetypefilter
+
+import graphql.nadel.tests.next.ExpectedNadelResult
+import graphql.nadel.tests.next.ExpectedServiceCall
+import graphql.nadel.tests.next.TestSnapshot
+import graphql.nadel.tests.next.listOfJsonStrings
+import kotlin.Suppress
+import kotlin.collections.List
+import kotlin.collections.listOf
+
+private suspend fun main() {
+    graphql.nadel.tests.next.update<ServiceTypeFilterDoesNotRestoreRemovedOwnedTypeTest>()
+}
+
+/**
+ * This class is generated. Do NOT modify.
+ *
+ * Refer to [graphql.nadel.tests.next.UpdateTestSnapshots]
+ */
+@Suppress("unused")
+public class ServiceTypeFilterDoesNotRestoreRemovedOwnedTypeTestSnapshot : TestSnapshot() {
+    /**
+     * Query
+     *
+     * ```graphql
+     * query {
+     *   crossServiceItems {
+     *     value
+     *   }
+     * }
+     * ```
+     *
+     * Variables
+     *
+     * ```json
+     * {}
+     * ```
+     */
+    override val calls: List<ExpectedServiceCall> = listOf(
+            ExpectedServiceCall(
+                service = "issues",
+                query = """
+                | {
+                |   crossServiceItems {
+                |     ... on AllowedIssuesItem {
+                |       value
+                |     }
+                |   }
+                | }
+                """.trimMargin(),
+                variables = "{}",
+                result = """
+                | {
+                |   "data": {
+                |     "crossServiceItems": [
+                |       {
+                |         "value": "allowed issues data"
+                |       },
+                |       {}
+                |     ]
+                |   }
+                | }
+                """.trimMargin(),
+                delayedResults = listOfJsonStrings(
+                ),
+            ),
+        )
+
+    /**
+     * ```json
+     * {
+     *   "data": {
+     *     "crossServiceItems": [
+     *       {
+     *         "value": "allowed issues data"
+     *       },
+     *       {}
+     *     ]
+     *   }
+     * }
+     * ```
+     */
+    override val result: ExpectedNadelResult = ExpectedNadelResult(
+            result = """
+            | {
+            |   "data": {
+            |     "crossServiceItems": [
+            |       {
+            |         "value": "allowed issues data"
+            |       },
+            |       {}
+            |     ]
+            |   }
+            | }
+            """.trimMargin(),
+            delayedResults = listOfJsonStrings(
+            ),
+        )
+}

--- a/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/execution/servicetypefilter/ServiceTypeFilterDoesNotWidenNarrowedSelectionTest.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/execution/servicetypefilter/ServiceTypeFilterDoesNotWidenNarrowedSelectionTest.kt
@@ -1,0 +1,178 @@
+package graphql.nadel.tests.next.fixtures.execution.servicetypefilter
+
+import graphql.nadel.Nadel
+import graphql.nadel.Service
+import graphql.nadel.ServiceExecutionHydrationDetails
+import graphql.nadel.engine.NadelExecutionContext
+import graphql.nadel.engine.NadelServiceExecutionContext
+import graphql.nadel.engine.blueprint.NadelOverallExecutionBlueprint
+import graphql.nadel.engine.transform.NadelTransformFieldResult
+import graphql.nadel.engine.transform.NadelTransformServiceExecutionContext
+import graphql.nadel.engine.transform.query.NadelQueryTransformer
+import graphql.nadel.tests.next.NadelIntegrationTest
+import graphql.nadel.tests.util.NadelTransformAdapter
+import graphql.normalized.ExecutableNormalizedField
+
+/**
+ * Verifies that service type filtering composes monotonically with a transform on an abstract parent field.
+ *
+ * Nadel plans every field's transform state before query transformations start. A parent transform can subsequently
+ * narrow its child fields' [ExecutableNormalizedField.objectTypeNames] before Nadel recursively executes those
+ * children's already-planned service type filters. The service filter must therefore intersect its planned
+ * service-owned types with each child's current types. Replacing the current types with the planned set would
+ * resurrect implementations deliberately removed by the parent and could expose their fields.
+ *
+ * The concrete tests cover both outcomes of that intersection: no service-owned types remain, so Nadel substitutes an
+ * artificial `__typename`, or one service-owned type remains and must not be widened to its removed sibling.
+ */
+abstract class ServiceTypeFilterNarrowedSelectionTest(
+    private val narrowedTypeNames: List<String>,
+) : NadelIntegrationTest(
+    query = """
+        query {
+          crossServiceItems {
+            value
+          }
+        }
+    """.trimIndent(),
+    services = listOf(
+        Service(
+            name = "shared",
+            overallSchema = """
+                interface CrossServiceItem {
+                  value: String
+                }
+            """.trimIndent(),
+            underlyingSchema = """
+                type Query {
+                  echo: String
+                }
+            """.trimIndent(),
+            runtimeWiring = {},
+        ),
+        Service(
+            name = "comments",
+            overallSchema = """
+                type CommentsItem implements CrossServiceItem {
+                  value: String
+                }
+            """.trimIndent(),
+            underlyingSchema = """
+                type Query {
+                  echo: String
+                }
+                interface CrossServiceItem {
+                  value: String
+                }
+                type CommentsItem implements CrossServiceItem {
+                  value: String
+                }
+            """.trimIndent(),
+            runtimeWiring = { wiring ->
+                wiring.type("CrossServiceItem") { type ->
+                    type.typeResolver { env ->
+                        env.schema.getObjectType("CommentsItem")
+                    }
+                }
+            },
+        ),
+        Service(
+            name = "issues",
+            overallSchema = """
+                type Query {
+                  crossServiceItems: [CrossServiceItem]
+                }
+                type AllowedIssuesItem implements CrossServiceItem {
+                  value: String
+                }
+                type DeniedIssuesItem implements CrossServiceItem {
+                  value: String
+                }
+            """.trimIndent(),
+            underlyingSchema = """
+                type Query {
+                  crossServiceItems: [CrossServiceItem]
+                }
+                interface CrossServiceItem {
+                  value: String
+                }
+                type AllowedIssuesItem implements CrossServiceItem {
+                  value: String
+                }
+                type DeniedIssuesItem implements CrossServiceItem {
+                  value: String
+                }
+            """.trimIndent(),
+            runtimeWiring = { wiring ->
+                data class AllowedIssuesItem(val value: String)
+                data class DeniedIssuesItem(val value: String)
+
+                wiring
+                    .type("CrossServiceItem") { type ->
+                        type.typeResolver { env ->
+                            env.schema.getObjectType(env.getObject<Any>().javaClass.simpleName)
+                        }
+                    }
+                    .type("Query") { type ->
+                        type.dataFetcher("crossServiceItems") {
+                            listOf(
+                                AllowedIssuesItem(value = "allowed issues data"),
+                                DeniedIssuesItem(value = "denied issues data"),
+                            )
+                        }
+                    }
+            },
+        ),
+    ),
+) {
+    override fun makeNadel(): Nadel.Builder {
+        return super.makeNadel()
+            .transforms(listOf(NarrowChildSelectionsTransform(narrowedTypeNames)))
+    }
+}
+
+class ServiceTypeFilterDoesNotWidenNarrowedSelectionTest : ServiceTypeFilterNarrowedSelectionTest(
+    narrowedTypeNames = listOf("CommentsItem"),
+)
+
+class ServiceTypeFilterDoesNotRestoreRemovedOwnedTypeTest : ServiceTypeFilterNarrowedSelectionTest(
+    narrowedTypeNames = listOf("AllowedIssuesItem", "CommentsItem"),
+)
+
+/** Simulates a parent transform, such as AGG scope narrowing, restricting its child selections. */
+private class NarrowChildSelectionsTransform(
+    private val narrowedTypeNames: List<String>,
+) : NadelTransformAdapter {
+    override suspend fun isApplicable(
+        executionContext: NadelExecutionContext,
+        serviceExecutionContext: NadelServiceExecutionContext,
+        executionBlueprint: NadelOverallExecutionBlueprint,
+        services: Map<String, Service>,
+        service: Service,
+        overallField: ExecutableNormalizedField,
+        transformServiceExecutionContext: NadelTransformServiceExecutionContext?,
+        hydrationDetails: ServiceExecutionHydrationDetails?,
+    ): Unit? {
+        return Unit.takeIf { overallField.name == "crossServiceItems" }
+    }
+
+    override suspend fun transformField(
+        executionContext: NadelExecutionContext,
+        serviceExecutionContext: NadelServiceExecutionContext,
+        transformer: NadelQueryTransformer,
+        executionBlueprint: NadelOverallExecutionBlueprint,
+        service: Service,
+        field: ExecutableNormalizedField,
+        state: Unit,
+        transformServiceExecutionContext: NadelTransformServiceExecutionContext?,
+    ): NadelTransformFieldResult {
+        field.children.forEach { child ->
+            check(
+                child.objectTypeNames.toSet() ==
+                    setOf("AllowedIssuesItem", "CommentsItem", "DeniedIssuesItem")
+            )
+            child.setObjectTypeNames(narrowedTypeNames)
+        }
+        return NadelTransformFieldResult.unmodified(field)
+    }
+}

--- a/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/execution/servicetypefilter/ServiceTypeFilterDoesNotWidenNarrowedSelectionTestSnapshot.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/execution/servicetypefilter/ServiceTypeFilterDoesNotWidenNarrowedSelectionTestSnapshot.kt
@@ -1,0 +1,96 @@
+// @formatter:off
+package graphql.nadel.tests.next.fixtures.execution.servicetypefilter
+
+import graphql.nadel.tests.next.ExpectedNadelResult
+import graphql.nadel.tests.next.ExpectedServiceCall
+import graphql.nadel.tests.next.TestSnapshot
+import graphql.nadel.tests.next.listOfJsonStrings
+import kotlin.Suppress
+import kotlin.collections.List
+import kotlin.collections.listOf
+
+private suspend fun main() {
+    graphql.nadel.tests.next.update<ServiceTypeFilterDoesNotWidenNarrowedSelectionTest>()
+}
+
+/**
+ * This class is generated. Do NOT modify.
+ *
+ * Refer to [graphql.nadel.tests.next.UpdateTestSnapshots]
+ */
+@Suppress("unused")
+public class ServiceTypeFilterDoesNotWidenNarrowedSelectionTestSnapshot : TestSnapshot() {
+    /**
+     * Query
+     *
+     * ```graphql
+     * query {
+     *   crossServiceItems {
+     *     value
+     *   }
+     * }
+     * ```
+     *
+     * Variables
+     *
+     * ```json
+     * {}
+     * ```
+     */
+    override val calls: List<ExpectedServiceCall> = listOf(
+            ExpectedServiceCall(
+                service = "issues",
+                query = """
+                | {
+                |   crossServiceItems {
+                |     __typename__type_filter__value: __typename
+                |   }
+                | }
+                """.trimMargin(),
+                variables = "{}",
+                result = """
+                | {
+                |   "data": {
+                |     "crossServiceItems": [
+                |       {
+                |         "__typename__type_filter__value": "AllowedIssuesItem"
+                |       },
+                |       {
+                |         "__typename__type_filter__value": "DeniedIssuesItem"
+                |       }
+                |     ]
+                |   }
+                | }
+                """.trimMargin(),
+                delayedResults = listOfJsonStrings(
+                ),
+            ),
+        )
+
+    /**
+     * ```json
+     * {
+     *   "data": {
+     *     "crossServiceItems": [
+     *       {},
+     *       {}
+     *     ]
+     *   }
+     * }
+     * ```
+     */
+    override val result: ExpectedNadelResult = ExpectedNadelResult(
+            result = """
+            | {
+            |   "data": {
+            |     "crossServiceItems": [
+            |       {},
+            |       {}
+            |     ]
+            |   }
+            | }
+            """.trimMargin(),
+            delayedResults = listOfJsonStrings(
+            ),
+        )
+}


### PR DESCRIPTION
…Transform

Please make sure you consider the following:

- [ ] Add tests that use __typename in queries
- [ ] Does this change work with all nadel transformations (rename, type rename, hydration, etc)? Add tests for this.
- [ ] Is it worth using hints for this change in order to be able to enable a percentage rollout?
- [ ] Do we need to add integration tests for this change in the graphql gateway?
- [ ] Do we need a pollinator check for this?
