### PR TITLE
Remove hydration filter object types hint

### DIFF
--- a/lib/src/main/java/graphql/nadel/NadelExecutionHints.kt
+++ b/lib/src/main/java/graphql/nadel/NadelExecutionHints.kt
@@ -7,7 +7,6 @@ import graphql.nadel.hints.NadelDeferSupportHint
 import graphql.nadel.hints.NadelDisableSharedTypesHint
 import graphql.nadel.hints.NadelExecuteOnEngineSchemaHint
 import graphql.nadel.hints.NadelHydrationExecutableSourceFields
-import graphql.nadel.hints.NadelHydrationFilterObjectTypesHint
 import graphql.nadel.hints.NadelNoInterfaceToObjectFragmentExpansionHint
 import graphql.nadel.hints.NadelReachableUnderlyingServiceTypesHint
 import graphql.nadel.hints.NadelShadowUnderlyingTypeNameInvestigation
@@ -25,7 +24,6 @@ data class NadelExecutionHints(
     val shortCircuitEmptyQuery: NadelShortCircuitEmptyQueryHint,
     val virtualTypeSupport: NadelVirtualTypeSupportHint,
     val executeOnEngineSchema: NadelExecuteOnEngineSchemaHint,
-    val hydrationFilterObjectTypes: NadelHydrationFilterObjectTypesHint,
     val hydrationExecutableSourceFields: NadelHydrationExecutableSourceFields,
     val shadowUnderlyingTypeNameInvestigation: NadelShadowUnderlyingTypeNameInvestigation,
     val disableSharedTypes: NadelDisableSharedTypesHint,
@@ -52,7 +50,6 @@ data class NadelExecutionHints(
         private var sharedTypeRenames = NadelSharedTypeRenamesHint { false }
         private var virtualTypeSupport = NadelVirtualTypeSupportHint { false }
         private var executeOnEngineSchema = NadelExecuteOnEngineSchemaHint { false }
-        private var hydrationFilterObjectTypes = NadelHydrationFilterObjectTypesHint { false }
         private var hydrationExecutableSourceFields = NadelHydrationExecutableSourceFields { false }
         private var shadowUnderlyingTypeNameInvestigation = NadelShadowUnderlyingTypeNameInvestigation { false }
         private var disableSharedTypes = NadelDisableSharedTypesHint { false }
@@ -71,7 +68,6 @@ data class NadelExecutionHints(
             sharedTypeRenames = nadelExecutionHints.sharedTypeRenames
             virtualTypeSupport = nadelExecutionHints.virtualTypeSupport
             executeOnEngineSchema = nadelExecutionHints.executeOnEngineSchema
-            hydrationFilterObjectTypes = nadelExecutionHints.hydrationFilterObjectTypes
             hydrationExecutableSourceFields = nadelExecutionHints.hydrationExecutableSourceFields
             shadowUnderlyingTypeNameInvestigation = nadelExecutionHints.shadowUnderlyingTypeNameInvestigation
             disableSharedTypes = nadelExecutionHints.disableSharedTypes
@@ -120,11 +116,6 @@ data class NadelExecutionHints(
             return this
         }
 
-        fun hydrationFilterObjectTypes(flag: NadelHydrationFilterObjectTypesHint): Builder {
-            hydrationFilterObjectTypes = flag
-            return this
-        }
-
         fun hydrationExecutableSourceFields(flag: NadelHydrationExecutableSourceFields): Builder {
             hydrationExecutableSourceFields = flag
             return this
@@ -165,7 +156,6 @@ data class NadelExecutionHints(
                 shortCircuitEmptyQuery,
                 virtualTypeSupport,
                 executeOnEngineSchema,
-                hydrationFilterObjectTypes,
                 hydrationExecutableSourceFields,
                 shadowUnderlyingTypeNameInvestigation,
                 disableSharedTypes,

--- a/lib/src/main/java/graphql/nadel/engine/transform/hydration/NadelHydrationFieldsBuilder.kt
+++ b/lib/src/main/java/graphql/nadel/engine/transform/hydration/NadelHydrationFieldsBuilder.kt
@@ -14,9 +14,7 @@ import graphql.nadel.engine.transform.hydration.batch.NadelBatchHydrationObjectI
 import graphql.nadel.engine.transform.query.NFUtil
 import graphql.nadel.engine.transform.result.json.JsonNode
 import graphql.nadel.engine.util.deepClone
-import graphql.nadel.engine.util.resolveObjectTypes
 import graphql.nadel.engine.util.toBuilder
-import graphql.nadel.engine.util.unwrapAll
 import graphql.normalized.ExecutableNormalizedField
 import graphql.normalized.NormalizedInputValue
 
@@ -41,13 +39,7 @@ internal object NadelHydrationFieldsBuilder {
                 makeBackingQueries(
                     instruction = instruction,
                     fieldArguments = args,
-                    fieldChildren = deepClone(
-                        if (executionContext.hints.hydrationFilterObjectTypes()) {
-                            filterChildren(instruction, virtualField.children)
-                        } else {
-                            virtualField.children
-                        }
-                    ),
+                    fieldChildren = deepClone(filterChildren(instruction, virtualField.children)),
                     executionBlueprint = executionBlueprint,
                 )
             }
@@ -63,37 +55,14 @@ internal object NadelHydrationFieldsBuilder {
     }
 
     fun makeBatchBackingQueries(
-        executionHints: NadelExecutionHints,
         executionBlueprint: NadelOverallExecutionBlueprint,
         instruction: NadelBatchHydrationFieldInstruction,
         aliasHelper: NadelAliasHelper,
         virtualField: ExecutableNormalizedField,
         argBatches: List<Map<NadelHydrationArgument, NormalizedInputValue>>,
     ): List<ExecutableNormalizedField> {
-        val fieldChildren = if (executionHints.hydrationFilterObjectTypes()) {
-            deepClone(fields = filterChildren(instruction, virtualField.children)) +
-                makeObjectIdFields(executionBlueprint, aliasHelper, instruction)
-        } else {
-            val backingFieldOverallObjectTypeNames =
-                getBackingFieldOverallObjectTypenames(instruction, executionBlueprint)
-            deepClone(fields = virtualField.children)
-                .mapNotNull { childField ->
-                    val objectTypesAreNotReturnedByBackingField =
-                        backingFieldOverallObjectTypeNames.none { it in childField.objectTypeNames }
-
-                    if (objectTypesAreNotReturnedByBackingField) {
-                        null
-                    } else {
-                        childField.toBuilder()
-                            .clearObjectTypesNames()
-                            .objectTypeNames(childField.objectTypeNames.filter { it in backingFieldOverallObjectTypeNames })
-                            .build()
-                    }
-                }
-                .let { children ->
-                    children + makeObjectIdFields(executionBlueprint, aliasHelper, instruction)
-                }
-        }
+        val fieldChildren = deepClone(fields = filterChildren(instruction, virtualField.children)) +
+            makeObjectIdFields(executionBlueprint, aliasHelper, instruction)
 
         return argBatches.map { argBatch ->
             makeBackingQueries(
@@ -125,26 +94,6 @@ internal object NadelHydrationFieldsBuilder {
                         .build()
                 }
             }
-    }
-
-    @Deprecated("Will be removed once NadelHydrationFilterObjectTypesHint is rolled out")
-    private fun getBackingFieldOverallObjectTypenames(
-        instruction: NadelBatchHydrationFieldInstruction,
-        executionBlueprint: NadelOverallExecutionBlueprint,
-    ): Set<String> {
-        val overallTypeName = instruction.backingFieldDef.type.unwrapAll().name
-
-        val overallType = executionBlueprint.engineSchema.getType(overallTypeName)
-            ?: error("Unable to find overall type $overallTypeName")
-
-        val backingFieldOverallObjectTypes = resolveObjectTypes(executionBlueprint.engineSchema, overallType) { type ->
-            error("Unable to resolve to object type: $type")
-        }
-
-        return backingFieldOverallObjectTypes
-            .asSequence()
-            .map { it.name }
-            .toSet()
     }
 
     fun makeRequiredSourceFields(

--- a/lib/src/main/java/graphql/nadel/engine/transform/hydration/batch/NadelNewBatchHydrator.kt
+++ b/lib/src/main/java/graphql/nadel/engine/transform/hydration/batch/NadelNewBatchHydrator.kt
@@ -443,7 +443,6 @@ internal class NadelNewBatchHydrator(
 
         val queries = NadelHydrationFieldsBuilder
             .makeBatchBackingQueries(
-                executionHints = executionContext.hints,
                 executionBlueprint = executionBlueprint,
                 instruction = instruction,
                 aliasHelper = aliasHelper,

--- a/lib/src/main/java/graphql/nadel/hints/NadelHydrationFilterObjectTypesHint.kt
+++ b/lib/src/main/java/graphql/nadel/hints/NadelHydrationFilterObjectTypesHint.kt
@@ -1,5 +1,0 @@
-package graphql.nadel.hints
-
-fun interface NadelHydrationFilterObjectTypesHint {
-    operator fun invoke(): Boolean
-}

--- a/test/src/test/kotlin/graphql/nadel/tests/next/NadelIntegrationTest.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/next/NadelIntegrationTest.kt
@@ -188,7 +188,6 @@ abstract class NadelIntegrationTest(
 
     open fun makeExecutionHints(): NadelExecutionHints.Builder {
         return NadelExecutionHints.Builder()
-            .hydrationFilterObjectTypes { true }
             .hydrationExecutableSourceFields { true }
     }
 

--- a/test/src/test/resources/fixtures/new hydration/multiple-conditional-hydrations-with-different-source-fields.yml
+++ b/test/src/test/resources/fixtures/new hydration/multiple-conditional-hydrations-with-different-source-fields.yml
@@ -117,25 +117,6 @@ serviceCalls:
     request:
       query: |
         query {
-          barById(id: "BAR_A") {
-            name
-          }
-        }
-      variables: { }
-    # language=JSON
-    response: |-
-      {
-        "data": {
-          "barById": {
-            "name": "Bar A"
-          }
-        },
-        "extensions": {}
-      }
-  - serviceName: "service2"
-    request:
-      query: |
-        query {
           barById(id: "BAR_B") {
             name
           }

--- a/test/src/test/resources/fixtures/new hydration/polymorphic hydrations/solitary-polymorphic-hydration-when-hook-returns-null.yml
+++ b/test/src/test/resources/fixtures/new hydration/polymorphic hydrations/solitary-polymorphic-hydration-when-hook-returns-null.yml
@@ -139,8 +139,6 @@ serviceCalls:
         query {
           humanById(id: "HUMAN-0") {
             __typename
-            __typename__type_filter__id: __typename
-            __typename__type_filter__breed: __typename
             id
             name
           }
@@ -152,8 +150,6 @@ serviceCalls:
         "data": {
           "humanById": {
             "__typename": "Human",
-            "__typename__type_filter__id": "Human",
-            "__typename__type_filter__breed": "Human",
             "id": "HUMAN-0",
             "name": "Fanny Longbottom"
           }

--- a/test/src/test/resources/fixtures/new hydration/polymorphic hydrations/solitary-polymorphic-hydration.yml
+++ b/test/src/test/resources/fixtures/new hydration/polymorphic hydrations/solitary-polymorphic-hydration.yml
@@ -139,8 +139,6 @@ serviceCalls:
         query {
           petById(id: "PET-0") {
             __typename
-            __typename__type_filter__id: __typename
-            __typename__type_filter__name: __typename
             breed
             id
           }
@@ -152,8 +150,6 @@ serviceCalls:
         "data": {
           "petById": {
             "__typename": "Pet",
-            "__typename__type_filter__id": "Pet",
-            "__typename__type_filter__name": "Pet",
             "id": "PET-0",
             "breed": "Akita"
           }
@@ -167,8 +163,6 @@ serviceCalls:
         query {
           humanById(id: "HUMAN-0") {
             __typename
-            __typename__type_filter__id: __typename
-            __typename__type_filter__breed: __typename
             id
             name
           }
@@ -180,8 +174,6 @@ serviceCalls:
         "data": {
           "humanById": {
             "__typename": "Human",
-            "__typename__type_filter__id": "Human",
-            "__typename__type_filter__breed": "Human",
             "id": "HUMAN-0",
             "name": "Fanny Longbottom"
           }


### PR DESCRIPTION
Please make sure you consider the following:

- [ ] Add tests that use __typename in queries
- [ ] Does this change work with all nadel transformations (rename, type rename, hydration, etc)? Add tests for this.
- [ ] Is it worth using hints for this change in order to be able to enable a percentage rollout?
- [ ] Do we need to add integration tests for this change in the graphql gateway?
- [ ] Do we need a pollinator check for this?
