### PR TITLE
Expose all root fields for a service execution

### DIFF
--- a/lib/src/main/java/graphql/nadel/NextgenEngine.kt
+++ b/lib/src/main/java/graphql/nadel/NextgenEngine.kt
@@ -317,6 +317,7 @@ internal class NextgenEngine(
         val result: ServiceExecutionResult = timer.time(step = RootStep.ServiceExecution.child(service.name)) {
             executeService(
                 service = service,
+                overallTopLevelFields = topLevelFields,
                 topLevelFields = queryTransform.result,
                 executionContext = executionContext,
                 serviceExecutionContext = serviceExecutionContext,
@@ -370,6 +371,7 @@ internal class NextgenEngine(
 
     private suspend fun executeService(
         service: Service,
+        overallTopLevelFields: List<ExecutableNormalizedField>,
         topLevelFields: List<ExecutableNormalizedField>,
         executionContext: NadelExecutionContext,
         serviceExecutionContext: NadelServiceExecutionContext,
@@ -403,6 +405,7 @@ internal class NextgenEngine(
             operationDefinition = compileResult.document.definitions.singleOfType(),
             serviceExecutionContext = serviceExecutionContext,
             hydrationDetails = executionHydrationDetails,
+            overallExecutableNormalizedFields = overallTopLevelFields.toList(),
             // Prefer non __typename field first, otherwise we just get first
             executableNormalizedField = topLevelFields
                 .asSequence()

--- a/lib/src/main/java/graphql/nadel/ServiceExecutionParameters.kt
+++ b/lib/src/main/java/graphql/nadel/ServiceExecutionParameters.kt
@@ -19,6 +19,18 @@ class ServiceExecutionParameters internal constructor(
      * @return details abut this service hydration or null if it's not a hydration call
      */
     val hydrationDetails: ServiceExecutionHydrationDetails?,
+    /**
+     * The overall-schema top-level fields grouped into this service execution.
+     *
+     * All fields in this list are assigned to the same service and sharding target.
+     */
+    val overallExecutableNormalizedFields: List<ExecutableNormalizedField>,
+    /**
+     * A representative top-level field after query transformation.
+     *
+     * Use [overallExecutableNormalizedFields] when every overall-schema field in this service
+     * execution is required.
+     */
     val executableNormalizedField: ExecutableNormalizedField,
 ) {
     val isHydrationCall: Boolean

--- a/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/batching/BatchRootFieldsByShardTest.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/batching/BatchRootFieldsByShardTest.kt
@@ -2,10 +2,12 @@ package graphql.nadel.tests.next.fixtures.batching
 
 import graphql.nadel.Nadel
 import graphql.nadel.NadelExecutionHints
+import graphql.nadel.ServiceExecution
 import graphql.nadel.engine.NadelExecutionContext
 import graphql.nadel.hooks.NadelExecutionHooks
 import graphql.nadel.tests.next.NadelIntegrationTest
 import graphql.normalized.ExecutableNormalizedField
+import kotlin.test.assertEquals
 
 /**
  * Root fields owned by the same service but routed to different shards must NOT be batched together.
@@ -48,6 +50,21 @@ class BatchRootFieldsByShardTest : NadelIntegrationTest(
         ),
     ),
 ) {
+    override fun makeServiceExecution(service: Service): ServiceExecution {
+        val delegate = super.makeServiceExecution(service)
+        return ServiceExecution { parameters ->
+            val fields = parameters.overallExecutableNormalizedFields
+            val shardingTargets = fields.map { it.resolvedArguments["cloudId"] }.toSet()
+            assertEquals(1, shardingTargets.size)
+            when (shardingTargets.single()) {
+                "site-1" -> assertEquals(2, fields.size)
+                "site-2" -> assertEquals(1, fields.size)
+                else -> error("Unexpected sharding target: ${shardingTargets.single()}")
+            }
+            delegate.execute(parameters)
+        }
+    }
+
     override fun makeExecutionHints(): NadelExecutionHints.Builder {
         return super.makeExecutionHints()
             .batchRootFields { true }

--- a/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/batching/BatchRootFieldsPerServiceTest.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/batching/BatchRootFieldsPerServiceTest.kt
@@ -1,8 +1,11 @@
 package graphql.nadel.tests.next.fixtures.batching
 
 import graphql.nadel.NadelExecutionHints
+import graphql.nadel.ServiceExecution
 import graphql.nadel.hints.NadelBatchRootFieldsHint
 import graphql.nadel.tests.next.NadelIntegrationTest
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 /**
  * Root-field batching is opt-in per service. Here it is enabled for "batched" but not "unbatched".
@@ -57,6 +60,22 @@ class BatchRootFieldsPerServiceTest : NadelIntegrationTest(
         ),
     ),
 ) {
+    override fun makeServiceExecution(service: Service): ServiceExecution {
+        val delegate = super.makeServiceExecution(service)
+        return ServiceExecution { parameters ->
+            val fieldNames = parameters.overallExecutableNormalizedFields.map { it.fieldName }
+            when (service.name) {
+                "batched" -> assertEquals(listOf("batchedFoo", "batchedBar"), fieldNames)
+                "unbatched" -> {
+                    assertEquals(1, fieldNames.size)
+                    assertTrue(fieldNames.single() in setOf("unbatchedFoo", "unbatchedBar"))
+                }
+                else -> error("Unexpected service: ${service.name}")
+            }
+            delegate.execute(parameters)
+        }
+    }
+
     override fun makeExecutionHints(): NadelExecutionHints.Builder {
         return super.makeExecutionHints()
             .batchRootFields(object : NadelBatchRootFieldsHint {

--- a/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/batching/BatchedRootFieldsTest.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/batching/BatchedRootFieldsTest.kt
@@ -1,7 +1,9 @@
 package graphql.nadel.tests.next.fixtures.batching
 
 import graphql.nadel.NadelExecutionHints
+import graphql.nadel.ServiceExecution
 import graphql.nadel.tests.next.NadelIntegrationTest
+import kotlin.test.assertEquals
 
 /**
  * Multiple sibling root fields destined for the same service are combined into a single service
@@ -12,6 +14,7 @@ import graphql.nadel.tests.next.NadelIntegrationTest
 class BatchedRootFieldsTest : NadelIntegrationTest(
     query = """
         query {
+          __typename
           foo
           bar
           baz
@@ -23,7 +26,14 @@ class BatchedRootFieldsTest : NadelIntegrationTest(
             overallSchema = """
                 type Query {
                   foo: String
-                  bar: String
+                  bar: String @renamed(from: "underlyingBar")
+                  baz: String
+                }
+            """.trimIndent(),
+            underlyingSchema = """
+                type Query {
+                  foo: String
+                  underlyingBar: String
                   baz: String
                 }
             """.trimIndent(),
@@ -32,13 +42,24 @@ class BatchedRootFieldsTest : NadelIntegrationTest(
                     .type("Query") { type ->
                         type
                             .dataFetcher("foo") { "foo-value" }
-                            .dataFetcher("bar") { "bar-value" }
+                            .dataFetcher("underlyingBar") { "bar-value" }
                             .dataFetcher("baz") { "baz-value" }
                     }
             },
         ),
     ),
 ) {
+    override fun makeServiceExecution(service: Service): ServiceExecution {
+        val delegate = super.makeServiceExecution(service)
+        return ServiceExecution { parameters ->
+            assertEquals(
+                listOf("foo", "bar", "baz"),
+                parameters.overallExecutableNormalizedFields.map { it.fieldName },
+            )
+            delegate.execute(parameters)
+        }
+    }
+
     override fun makeExecutionHints(): NadelExecutionHints.Builder {
         return super.makeExecutionHints()
             .batchRootFields { true }

--- a/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/batching/BatchedRootFieldsTestSnapshot.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/batching/BatchedRootFieldsTestSnapshot.kt
@@ -20,14 +20,32 @@ private suspend fun main() {
  */
 @Suppress("unused")
 public class BatchedRootFieldsTestSnapshot : TestSnapshot() {
+    /**
+     * Query
+     *
+     * ```graphql
+     * query {
+     *   __typename
+     *   foo
+     *   bar
+     *   baz
+     * }
+     * ```
+     *
+     * Variables
+     *
+     * ```json
+     * {}
+     * ```
+     */
     override val calls: List<ExpectedServiceCall> = listOf(
             ExpectedServiceCall(
                 service = "monolith",
                 query = """
                 | {
-                |   bar
                 |   baz
                 |   foo
+                |   rename__bar__underlyingBar: underlyingBar
                 | }
                 """.trimMargin(),
                 variables = "{}",
@@ -35,7 +53,7 @@ public class BatchedRootFieldsTestSnapshot : TestSnapshot() {
                 | {
                 |   "data": {
                 |     "foo": "foo-value",
-                |     "bar": "bar-value",
+                |     "rename__bar__underlyingBar": "bar-value",
                 |     "baz": "baz-value"
                 |   }
                 | }
@@ -49,9 +67,10 @@ public class BatchedRootFieldsTestSnapshot : TestSnapshot() {
      * ```json
      * {
      *   "data": {
+     *     "__typename": "Query",
      *     "foo": "foo-value",
-     *     "bar": "bar-value",
-     *     "baz": "baz-value"
+     *     "baz": "baz-value",
+     *     "bar": "bar-value"
      *   }
      * }
      * ```
@@ -60,9 +79,10 @@ public class BatchedRootFieldsTestSnapshot : TestSnapshot() {
             result = """
             | {
             |   "data": {
+            |     "__typename": "Query",
             |     "foo": "foo-value",
-            |     "bar": "bar-value",
-            |     "baz": "baz-value"
+            |     "baz": "baz-value",
+            |     "bar": "bar-value"
             |   }
             | }
             """.trimMargin(),


### PR DESCRIPTION
## Summary

- Expose the overall-schema root fields grouped into each service execution.
- Capture the fields before query transformation while preserving the existing transformed representative field.
- Keep fields isolated by service and sharding target.

## Compatibility

This is an additive metadata API. It does not change field grouping, query transformation, downstream execution, or result merging. Existing consumers of the singular `executableNormalizedField` remain unchanged.

## Testing

- Added coverage for batched and non-batched services.
- Added coverage for separate sharding targets.
- Added a renamed root field and `__typename` coverage.
- Ran `./gradlew assemble check --info` successfully.