### PR TITLE
fix omitting roots fields in service execution parameters

### DIFF
--- a/lib/src/main/java/graphql/nadel/NextgenEngine.kt
+++ b/lib/src/main/java/graphql/nadel/NextgenEngine.kt
@@ -403,13 +403,7 @@ internal class NextgenEngine(
             operationDefinition = compileResult.document.definitions.singleOfType(),
             serviceExecutionContext = serviceExecutionContext,
             hydrationDetails = executionHydrationDetails,
-            // Prefer non __typename field first, otherwise we just get first
-            executableNormalizedField = topLevelFields
-                .asSequence()
-                .filterNot {
-                    it.fieldName == TypeNameMetaFieldDef.name
-                }
-                .firstOrNull() ?: topLevelFields.first(),
+            executableNormalizedFields = topLevelFields,
         )
 
         val serviceExecution = getServiceExecution(service, topLevelFields)

--- a/lib/src/main/java/graphql/nadel/ServiceExecutionParameters.kt
+++ b/lib/src/main/java/graphql/nadel/ServiceExecutionParameters.kt
@@ -19,7 +19,10 @@ class ServiceExecutionParameters internal constructor(
      * @return details abut this service hydration or null if it's not a hydration call
      */
     val hydrationDetails: ServiceExecutionHydrationDetails?,
-    val executableNormalizedField: ExecutableNormalizedField,
+    /**
+     * All transformed underlying-schema root fields represented by [query], including artificial fields.
+     */
+    val executableNormalizedFields: List<ExecutableNormalizedField>,
 ) {
     val isHydrationCall: Boolean
         get() = hydrationDetails != null

--- a/test/src/test/kotlin/graphql/nadel/tests/legacy/renames/string field rename.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/legacy/renames/string field rename.kt
@@ -1,6 +1,8 @@
 package graphql.nadel.tests.legacy.renames
 
+import graphql.nadel.ServiceExecution
 import graphql.nadel.tests.legacy.NadelLegacyIntegrationTest
+import kotlin.test.assertEquals
 
 class `string field rename` : NadelLegacyIntegrationTest(
     query = """
@@ -115,6 +117,16 @@ class `string field rename` : NadelLegacyIntegrationTest(
         ),
     ),
 ) {
+    override fun makeServiceExecution(service: Service): ServiceExecution {
+        val serviceExecution = super.makeServiceExecution(service)
+        return ServiceExecution { parameters ->
+            val field = parameters.executableNormalizedFields.single()
+            assertEquals("renameStringUnderlying", field.name)
+            assertEquals("rename__renameString__renameStringUnderlying", field.resultKey)
+            serviceExecution.execute(parameters)
+        }
+    }
+
     private enum class MyService_EnumUnderlying {
         X,
         Y,

--- a/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/batching/BatchRootFieldsByShardTest.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/batching/BatchRootFieldsByShardTest.kt
@@ -2,10 +2,12 @@ package graphql.nadel.tests.next.fixtures.batching
 
 import graphql.nadel.Nadel
 import graphql.nadel.NadelExecutionHints
+import graphql.nadel.ServiceExecution
 import graphql.nadel.engine.NadelExecutionContext
 import graphql.nadel.hooks.NadelExecutionHooks
 import graphql.nadel.tests.next.NadelIntegrationTest
 import graphql.normalized.ExecutableNormalizedField
+import kotlin.test.assertEquals
 
 /**
  * Root fields owned by the same service but routed to different shards must NOT be batched together.
@@ -48,6 +50,22 @@ class BatchRootFieldsByShardTest : NadelIntegrationTest(
         ),
     ),
 ) {
+    override fun makeServiceExecution(service: Service): ServiceExecution {
+        val serviceExecution = super.makeServiceExecution(service)
+        return ServiceExecution { parameters ->
+            val fields = parameters.executableNormalizedFields
+            val shard = fields.map { it.resolvedArguments["cloudId"] }.distinct().single()
+            val expectedAliases = when (shard) {
+                "site-1" -> listOf("a", "b")
+                "site-2" -> listOf("c")
+                else -> error("Unexpected shard: $shard")
+            }
+            assertEquals(expectedAliases, fields.map { it.resultKey })
+            assertEquals(List(expectedAliases.size) { "issueById" }, fields.map { it.name })
+            serviceExecution.execute(parameters)
+        }
+    }
+
     override fun makeExecutionHints(): NadelExecutionHints.Builder {
         return super.makeExecutionHints()
             .batchRootFields { true }

--- a/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/batching/BatchRootFieldsPerServiceTest.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/batching/BatchRootFieldsPerServiceTest.kt
@@ -1,8 +1,11 @@
 package graphql.nadel.tests.next.fixtures.batching
 
 import graphql.nadel.NadelExecutionHints
+import graphql.nadel.ServiceExecution
 import graphql.nadel.hints.NadelBatchRootFieldsHint
 import graphql.nadel.tests.next.NadelIntegrationTest
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 /**
  * Root-field batching is opt-in per service. Here it is enabled for "batched" but not "unbatched".
@@ -57,6 +60,19 @@ class BatchRootFieldsPerServiceTest : NadelIntegrationTest(
         ),
     ),
 ) {
+    override fun makeServiceExecution(service: Service): ServiceExecution {
+        val serviceExecution = super.makeServiceExecution(service)
+        return ServiceExecution { parameters ->
+            val fields = parameters.executableNormalizedFields.map { it.name }
+            when (service.name) {
+                "batched" -> assertEquals(listOf("batchedFoo", "batchedBar"), fields)
+                "unbatched" -> assertTrue(fields.single() in setOf("unbatchedFoo", "unbatchedBar"))
+                else -> error("Unexpected service: ${service.name}")
+            }
+            serviceExecution.execute(parameters)
+        }
+    }
+
     override fun makeExecutionHints(): NadelExecutionHints.Builder {
         return super.makeExecutionHints()
             .batchRootFields(object : NadelBatchRootFieldsHint {

--- a/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/batching/BatchedRootFieldsTest.kt
+++ b/test/src/test/kotlin/graphql/nadel/tests/next/fixtures/batching/BatchedRootFieldsTest.kt
@@ -1,7 +1,9 @@
 package graphql.nadel.tests.next.fixtures.batching
 
 import graphql.nadel.NadelExecutionHints
+import graphql.nadel.ServiceExecution
 import graphql.nadel.tests.next.NadelIntegrationTest
+import kotlin.test.assertEquals
 
 /**
  * Multiple sibling root fields destined for the same service are combined into a single service
@@ -39,6 +41,17 @@ class BatchedRootFieldsTest : NadelIntegrationTest(
         ),
     ),
 ) {
+    override fun makeServiceExecution(service: Service): ServiceExecution {
+        val serviceExecution = super.makeServiceExecution(service)
+        return ServiceExecution { parameters ->
+            assertEquals(
+                listOf("foo", "bar", "baz"),
+                parameters.executableNormalizedFields.map { it.name },
+            )
+            serviceExecution.execute(parameters)
+        }
+    }
+
     override fun makeExecutionHints(): NadelExecutionHints.Builder {
         return super.makeExecutionHints()
             .batchRootFields { true }


### PR DESCRIPTION
Description:
- As part of the batching root change a regression was introduced that resulted in the omitting of fields

Fix: 
- Make sure we include all fields inside of service execution parameters